### PR TITLE
Check RSS feed before attempting to update a provider metadata file

### DIFF
--- a/src/go.mod
+++ b/src/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/mmcdole/gofeed v1.2.1
 	github.com/shurcooL/githubv4 v0.0.0-20230704064427-599ae7bbf278
+	github.com/stretchr/testify v1.8.4
 	golang.org/x/mod v0.14.0
 	golang.org/x/oauth2 v0.14.0
 )
@@ -13,16 +14,18 @@ require (
 require (
 	github.com/PuerkitoBio/goquery v1.8.0 // indirect
 	github.com/andybalholm/cascadia v1.3.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mmcdole/goxpp v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/shurcooL/graphql v0.0.0-20230722043721-ed46e5a46466 // indirect
-	github.com/stretchr/testify v1.8.4 // indirect
 	golang.org/x/net v0.18.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/src/go.sum
+++ b/src/go.sum
@@ -67,5 +67,7 @@ google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp0
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/src/internal/github/rss.go
+++ b/src/internal/github/rss.go
@@ -10,6 +10,8 @@ import (
 	httpInternal "registry-stable/internal/http"
 )
 
+// GetTagsFromRss gets all tags found in the RSS feed of a GitHub releases page
+// Tags are sorted by descending creation date
 func GetTagsFromRss(releasesRssUrl string) ([]string, error) {
 	feed, err := getReleaseRssFeed(releasesRssUrl)
 	if err != nil {

--- a/src/internal/repository-metadata-files/provider/update.go
+++ b/src/internal/repository-metadata-files/provider/update.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"encoding/json"
+	"fmt"
+	"golang.org/x/mod/semver"
+	"log"
+	"os"
+	"registry-stable/internal/github"
+	"registry-stable/internal/provider"
+)
+
+func UpdateMetadataFile(p provider.Provider) error {
+	if shouldUpdate, err := shouldUpdateMetadataFile(p); err != nil || !shouldUpdate {
+		return err
+	}
+
+	return CreateMetadataFile(p)
+}
+
+func shouldUpdateMetadataFile(p provider.Provider) (bool, error) {
+	lastSemverTag, err := getLastSemverTag(p)
+	if err != nil {
+		return false, err
+	}
+
+	pathToFile := getFilePath(p)
+	fileContent, err := getProviderFileContent(pathToFile)
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range fileContent.Versions {
+		versionWithPrefix := fmt.Sprintf("v%s", v.Version)
+		if versionWithPrefix == lastSemverTag {
+			log.Printf("Found latest tag %s in the repository file %s, nothing to update...", lastSemverTag, pathToFile)
+			return false, nil
+		}
+	}
+
+	log.Printf("Could not find latest tag %s in the repository file %s, updating the file...", lastSemverTag, pathToFile)
+	return true, nil
+
+}
+
+func getProviderFileContent(path string) (provider.MetadataFile, error) {
+	res, _ := os.ReadFile(path)
+
+	var fileData provider.MetadataFile
+
+	err := json.Unmarshal(res, &fileData)
+
+	if err != nil {
+		return provider.MetadataFile{}, err
+	}
+
+	return fileData, nil
+}
+
+func getSemverTags(p provider.Provider) ([]string, error) {
+	releasesRssUrl := getRssUrl(p)
+	tags, err := github.GetTagsFromRss(releasesRssUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	var semverTags []string
+	for _, tag := range tags {
+		if semver.IsValid(tag) {
+			semverTags = append(semverTags, tag)
+		}
+	}
+
+	return semverTags, nil
+}
+
+func getLastSemverTag(p provider.Provider) (string, error) {
+	semverTags, err := getSemverTags(p)
+	if err != nil {
+		return "", err
+	}
+
+	if len(semverTags) < 1 {
+		return "", fmt.Errorf("no semver tags found in repository for provider %s/%s", p.Namespace, p.ProviderName)
+	}
+
+	// Tags should be sorted by descending creation date. So, return the first tag
+	return semverTags[0], nil
+}
+
+func getRssUrl(p provider.Provider) string {
+	repositoryUrl := p.RepositoryURL()
+	return fmt.Sprintf("%s/releases.atom", repositoryUrl)
+}


### PR DESCRIPTION
This was missing from https://github.com/opentofu/registry-stable/pull/4

Create `UpdateMetadataFile` for providers, checking GitHub Releases RSS feed's last semver tag to see if it exists in the metadata file. If not - Recreate the metadata file