### PR TITLE
Common json file output w/ tests

### DIFF
--- a/src/internal/files/files.go
+++ b/src/internal/files/files.go
@@ -7,7 +7,7 @@ import (
 	"path"
 )
 
-func WriteToJsonFile(filePath string, data interface{}) error {
+func SafeWriteObjectToJsonFile(filePath string, data interface{}) error {
 	marshalledJson, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal for %s: %w", filePath, err)

--- a/src/internal/files/files_test.go
+++ b/src/internal/files/files_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFiles_WriteToJsonFile_Success(t *testing.T) {
+func TestFiles_SafeWriteObjectToJsonFile_Success(t *testing.T) {
 	dir := t.TempDir()
 
 	data := map[string]interface{}{
@@ -19,7 +19,7 @@ func TestFiles_WriteToJsonFile_Success(t *testing.T) {
 
 	path := filepath.Join(dir, "subdir", "file.json")
 
-	err := WriteToJsonFile(path, data)
+	err := SafeWriteObjectToJsonFile(path, data)
 
 	if err != nil {
 		t.Error(err)
@@ -39,12 +39,12 @@ func TestFiles_WriteToJsonFile_Success(t *testing.T) {
 	assert.Equal(t, data, read)
 }
 
-func TestFiles_WriteToJsonFile_InvalidMarshall(t *testing.T) {
+func TestFiles_SafeWriteObjectToJsonFile_InvalidMarshall(t *testing.T) {
 	dir := t.TempDir()
 
 	path := filepath.Join(dir, "subdir", "file.json")
 
-	err := WriteToJsonFile(path, make(chan int))
+	err := SafeWriteObjectToJsonFile(path, make(chan int))
 
 	if err == nil {
 		t.Fatal("Expected marshal error, got <nil>")
@@ -52,11 +52,11 @@ func TestFiles_WriteToJsonFile_InvalidMarshall(t *testing.T) {
 	assert.Contains(t, err.Error(), "json: unsupported type: chan int")
 }
 
-func TestFiles_WriteToJsonFile_InvalidPath(t *testing.T) {
+func TestFiles_SafeWriteObjectToJsonFile_InvalidPath(t *testing.T) {
 	// TODO this might not be valid for non-posix systems
 	path := "/dev/null/foo"
 
-	err := WriteToJsonFile(path, nil)
+	err := SafeWriteObjectToJsonFile(path, nil)
 
 	if err == nil {
 		t.Fatal("Expected directory error, got <nil>")
@@ -64,10 +64,10 @@ func TestFiles_WriteToJsonFile_InvalidPath(t *testing.T) {
 	assert.Equal(t, "failed to create directory for /dev/null/foo: mkdir /dev/null: not a directory", err.Error())
 }
 
-func TestFiles_WriteToJsonFile_InvalidPath2(t *testing.T) {
+func TestFiles_SafeWriteObjectToJsonFile_InvalidPath2(t *testing.T) {
 	dir := t.TempDir()
 
-	err := WriteToJsonFile(dir, nil)
+	err := SafeWriteObjectToJsonFile(dir, nil)
 
 	if err == nil {
 		t.Fatal("Expected file error, got <nil>")

--- a/src/internal/repository-metadata-files/module/create.go
+++ b/src/internal/repository-metadata-files/module/create.go
@@ -15,7 +15,7 @@ func CreateMetadataFile(m module.Module, moduleDataDir string) error {
 	}
 
 	filePath := getFilePath(m, moduleDataDir)
-	return files.WriteToJsonFile(filePath, repositoryFileData)
+	return files.SafeWriteObjectToJsonFile(filePath, repositoryFileData)
 }
 
 func getFilePath(m module.Module, moduleDataDir string) string {

--- a/src/internal/repository-metadata-files/provider/create.go
+++ b/src/internal/repository-metadata-files/provider/create.go
@@ -15,7 +15,7 @@ func CreateMetadataFile(p provider.Provider, providerDataDir string) error {
 	}
 
 	filePath := getFilePath(p, providerDataDir)
-	return files.WriteToJsonFile(filePath, repositoryFileData)
+	return files.SafeWriteObjectToJsonFile(filePath, repositoryFileData)
 }
 
 func getFilePath(p provider.Provider, providerDataDir string) string {

--- a/src/internal/v1api/modules.go
+++ b/src/internal/v1api/modules.go
@@ -75,7 +75,7 @@ func (g Generator) readModuleMetadata(path string, logger *slog.Logger) (*module
 // This data  is to be consumed when an end user requests /v1/modules/{namespace}/{name}/{targetSystem}/versions
 func (g Generator) writeModuleVersionListing(namespace string, name string, targetSystem string, versions []ModuleVersionResponseItem) error {
 	path := filepath.Join(g.DestinationDir, "v1", "modules", namespace, name, targetSystem, "versions")
-	return files.WriteToJsonFile(path, ModuleVersionListingResponse{Modules: []ModuleVersionListingResponseItem{{Versions: versions}}})
+	return files.SafeWriteObjectToJsonFile(path, ModuleVersionListingResponse{Modules: []ModuleVersionListingResponseItem{{Versions: versions}}})
 }
 
 // writeModuleVersionDownload writes the file containing the download link for the module version.
@@ -87,5 +87,5 @@ func (g Generator) writeModuleVersionDownload(namespace string, name string, sys
 	response := ModuleVersionDownloadResponse{Location: location}
 
 	path := filepath.Join(g.DestinationDir, "v1", "modules", namespace, name, system, internal.TrimTagPrefix(version), "download")
-	return files.WriteToJsonFile(path, response)
+	return files.SafeWriteObjectToJsonFile(path, response)
 }

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -95,10 +95,10 @@ func (g Generator) readProviderMetadata(path string, logger *slog.Logger) (*prov
 
 func (g Generator) writeProviderVersionDownload(namespace string, name string, version string, versionMetadata ProviderVersionDetails) error {
 	path := filepath.Join(g.DestinationDir, "v1", "providers", namespace, name, version, "download", versionMetadata.OS, versionMetadata.Arch)
-	return files.WriteToJsonFile(path, versionMetadata)
+	return files.SafeWriteObjectToJsonFile(path, versionMetadata)
 }
 
 func (g Generator) writeProviderVersionListing(namespace string, name string, versions []ProviderVersionResponseItem) error {
 	path := filepath.Join(g.DestinationDir, "v1", "providers", namespace, name, "versions")
-	return files.WriteToJsonFile(path, ProviderVersionListingResponse{Versions: versions})
+	return files.SafeWriteObjectToJsonFile(path, ProviderVersionListingResponse{Versions: versions})
 }


### PR DESCRIPTION
I noticed a lot of copy pasta around writing to json files.  This changes @Yantrio's code to use @RLRabinowitz's files package, which has been enhanced with better error messages and tests.