### PR TITLE
Faster version bumping

### DIFF
--- a/src/internal/github/assets.go
+++ b/src/internal/github/assets.go
@@ -16,8 +16,8 @@ type Platform struct {
 }
 
 func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
-	token := c.assetThrottle.Wait()
-	defer token.Done()
+	done := c.assetThrottle()
+	defer done()
 
 	c.log.Info("Downloading asset", slog.String("url", downloadURL))
 	resp, err := c.httpClient.Get(downloadURL)

--- a/src/internal/github/assets.go
+++ b/src/internal/github/assets.go
@@ -16,6 +16,9 @@ type Platform struct {
 }
 
 func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
+	token := c.assetThrottle.Wait()
+	defer token.Done()
+
 	c.log.Info("Downloading asset", slog.String("url", downloadURL))
 	resp, err := c.httpClient.Get(downloadURL)
 	if err != nil {

--- a/src/internal/github/git.go
+++ b/src/internal/github/git.go
@@ -39,8 +39,8 @@ func parseTagsFromStdout(lines []string) ([]string, error) {
 
 // GetTags lists the tags of the remote repository and returns the refs/tags/ found
 func (c Client) GetTags(repositoryUrl string) ([]string, error) {
-	token := c.cliThrottle.Wait()
-	defer token.Done()
+	done := c.cliThrottle()
+	defer done()
 
 	log.Printf("Getting tags for repository %s", repositoryUrl)
 

--- a/src/internal/github/git.go
+++ b/src/internal/github/git.go
@@ -38,11 +38,9 @@ func parseTagsFromStdout(lines []string) ([]string, error) {
 }
 
 // GetTags lists the tags of the remote repository and returns the refs/tags/ found
-func (client Client) GetTags(repositoryUrl string) ([]string, error) {
-	err := client.cliLimiter.Wait(client.ctx)
-	if err != nil {
-		return nil, err
-	}
+func (c Client) GetTags(repositoryUrl string) ([]string, error) {
+	token := c.cliThrottle.Wait()
+	defer token.Done()
 
 	log.Printf("Getting tags for repository %s", repositoryUrl)
 

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -15,6 +15,8 @@ func (c Client) FetchPublishedReleases(owner string, repoName string) (releases 
 		"perPage":   githubv4.Int(100),
 		"endCursor": (*githubv4.String)(nil),
 	}
+	token := c.apiThrottle.Wait()
+	defer token.Done()
 
 	for {
 		var query GHRepository

--- a/src/internal/github/github.go
+++ b/src/internal/github/github.go
@@ -15,8 +15,8 @@ func (c Client) FetchPublishedReleases(owner string, repoName string) (releases 
 		"perPage":   githubv4.Int(100),
 		"endCursor": (*githubv4.String)(nil),
 	}
-	token := c.apiThrottle.Wait()
-	defer token.Done()
+	done := c.apiThrottle()
+	defer done()
 
 	for {
 		var query GHRepository

--- a/src/internal/github/throttle.go
+++ b/src/internal/github/throttle.go
@@ -7,36 +7,21 @@ import (
 	"golang.org/x/time/rate"
 )
 
-type Throttle struct {
-	ctx      context.Context
-	limiter  *rate.Limiter
-	checkout chan int
-}
+type Throttle func() ThrottleToken
 
-type ThrottleToken struct {
-	manager Throttle
-	id      int
-}
+type ThrottleToken func()
 
 func NewThrottle(ctx context.Context, every time.Duration, concurrent int) Throttle {
-	r := Throttle{
-		ctx:      ctx,
-		limiter:  rate.NewLimiter(rate.Every(every), 1),
-		checkout: make(chan int, concurrent),
-	}
+	limiter := rate.NewLimiter(rate.Every(every), 1)
+	checkout := make(chan int, concurrent)
+
 	for i := 0; i < concurrent; i++ {
-		r.checkout <- i
+		checkout <- i
 	}
-	return r
-}
-
-func (m Throttle) Wait() ThrottleToken {
-	id := <-m.checkout
-	// TODO We might want to handle the returned error from Wait here
-	m.limiter.Wait(m.ctx)
-	return ThrottleToken{m, id}
-}
-
-func (t ThrottleToken) Done() {
-	t.manager.checkout <- t.id
+	return func() ThrottleToken {
+		id := <-checkout
+		// TODO We might want to handle the returned error from Wait here
+		limiter.Wait(ctx)
+		return func() { checkout <- id }
+	}
 }

--- a/src/internal/github/throttle.go
+++ b/src/internal/github/throttle.go
@@ -1,0 +1,42 @@
+package github
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+type Throttle struct {
+	ctx      context.Context
+	limiter  *rate.Limiter
+	checkout chan int
+}
+
+type ThrottleToken struct {
+	manager Throttle
+	id      int
+}
+
+func NewThrottle(ctx context.Context, every time.Duration, concurrent int) Throttle {
+	r := Throttle{
+		ctx:      ctx,
+		limiter:  rate.NewLimiter(rate.Every(every), 1),
+		checkout: make(chan int, concurrent),
+	}
+	for i := 0; i < concurrent; i++ {
+		r.checkout <- i
+	}
+	return r
+}
+
+func (m Throttle) Wait() ThrottleToken {
+	id := <-m.checkout
+	// TODO We might want to handle the returned error from Wait here
+	m.limiter.Wait(m.ctx)
+	return ThrottleToken{m, id}
+}
+
+func (t ThrottleToken) Done() {
+	t.manager.checkout <- t.id
+}


### PR DESCRIPTION
This allows for throttling requests to github both by requests started/second and active requests.

Previously, requests would just pile up (at the given rate) and github would balk.  This now limits the number of "active" requests at any given time to prevent the pileup.