### PR TITLE
Use alternative version detection proposed by Dmitry

### DIFF
--- a/src/internal/github/assets.go
+++ b/src/internal/github/assets.go
@@ -20,12 +20,18 @@ func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
 	defer done()
 
 	c.log.Info("Downloading asset", slog.String("url", downloadURL))
+
 	resp, err := c.httpClient.Get(downloadURL)
 	if err != nil {
 		return nil, fmt.Errorf("error downloading asset %s: %w", downloadURL, err)
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		c.log.Info("Asset not found", slog.String("url", downloadURL))
+		return nil, nil
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("unexpected status code when downloading asset %s: %d", downloadURL, resp.StatusCode)

--- a/src/internal/github/client.go
+++ b/src/internal/github/client.go
@@ -40,7 +40,7 @@ func NewClient(ctx context.Context, log *slog.Logger, token string) Client {
 
 		cliThrottle:   NewThrottle(ctx, time.Second/30, 30),
 		apiThrottle:   NewThrottle(ctx, time.Second, 3),
-		assetThrottle: NewThrottle(ctx, time.Second/30, 30),
+		assetThrottle: NewThrottle(ctx, time.Second/60, 30),
 	}
 	/* TODO
 	retryClient := retryablehttp.NewClient()

--- a/src/internal/provider/protocols.go
+++ b/src/internal/provider/protocols.go
@@ -17,6 +17,9 @@ func (p Provider) GetProtocols(manifestDownloadUrl string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if contents == nil {
+		return nil, nil
+	}
 
 	manifest, err := parseManifestContents(contents)
 	if err != nil {

--- a/src/internal/provider/shasum.go
+++ b/src/internal/provider/shasum.go
@@ -10,6 +10,9 @@ func (p Provider) GetShaSums(shaFileDownloadUrl string) (map[string]string, erro
 	if assetErr != nil {
 		return nil, fmt.Errorf("failed to download asset contents: %w", assetErr)
 	}
+	if contents == nil {
+		return nil, nil
+	}
 
 	return shaFileToMap(contents), nil
 }

--- a/src/internal/provider/update.go
+++ b/src/internal/provider/update.go
@@ -52,7 +52,7 @@ func (p Provider) shouldUpdateMetadataFile() (bool, error) {
 
 }
 
-func (p Provider) getSemverTags() ([]string, error) {
+func (p Provider) getRssSemverTags() ([]string, error) {
 	releasesRssUrl := p.getRssUrl()
 	tags, err := p.Github.GetTagsFromRss(releasesRssUrl)
 	if err != nil {
@@ -70,7 +70,7 @@ func (p Provider) getSemverTags() ([]string, error) {
 }
 
 func (p Provider) getLastSemverTag() (string, error) {
-	semverTags, err := p.getSemverTags()
+	semverTags, err := p.getRssSemverTags()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
As the github graphql api has some pretty strict req/second limits, it is actually faster to list the tags and detect versions from there.

~The only concern I have is exposing tags that were never actually tied to releases on github.  We could potentially use the rest api via https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#get-a-release-by-tag-name, though I'm not sure it's worth the overhead.~  This is incorrect, we still use the release assets url building.