### PR TITLE
Use repository tags to skip git ls-remote

### DIFF
--- a/src/internal/github/client.go
+++ b/src/internal/github/client.go
@@ -47,7 +47,7 @@ func NewClient(ctx context.Context, log *slog.Logger, token string) Client {
 		cliThrottle:   NewThrottle(ctx, time.Second/30, 30),
 		apiThrottle:   NewThrottle(ctx, time.Second, 3),
 		assetThrottle: NewThrottle(ctx, time.Second/60, 30),
-		rssThrottle:   NewThrottle(ctx, time.Second/10, 10),
+		rssThrottle:   NewThrottle(ctx, time.Second/30, 30),
 	}
 	/* TODO
 	retryClient := retryablehttp.NewClient()

--- a/src/internal/github/client.go
+++ b/src/internal/github/client.go
@@ -44,7 +44,7 @@ func NewClient(ctx context.Context, log *slog.Logger, token string) Client {
 		httpClient: httpClient,
 		ghClient:   githubv4.NewClient(httpClient),
 
-		cliThrottle:   NewThrottle(ctx, time.Second/30, 30),
+		cliThrottle:   NewThrottle(ctx, time.Second/60, 60),
 		apiThrottle:   NewThrottle(ctx, time.Second, 3),
 		assetThrottle: NewThrottle(ctx, time.Second/60, 30),
 		rssThrottle:   NewThrottle(ctx, time.Second/30, 30),

--- a/src/internal/module/build.go
+++ b/src/internal/module/build.go
@@ -13,6 +13,16 @@ import (
 func (m Module) UpdateMetadataFile() error {
 	m.Logger.Info("Beginning version bump process for module", slog.String("module", m.Namespace+"/"+m.Name+"/"+m.TargetSystem))
 
+	shouldUpdate, err := m.shouldUpdateMetadataFile()
+	if err != nil {
+		m.Logger.Error("Failed to determine update status", slog.Any("err", err))
+		return err
+	}
+	if !shouldUpdate {
+		m.Logger.Info("No version bump required")
+		return nil
+	}
+
 	meta, err := m.BuildMetadata()
 	if err != nil {
 		return err

--- a/src/internal/module/module.go
+++ b/src/internal/module/module.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/opentofu/registry-stable/internal/files"
 	"github.com/opentofu/registry-stable/internal/github"
@@ -52,7 +53,7 @@ func (m Module) VersionDownloadURL(version Version) string {
 
 // MetadataPath returns the path to the metadata file for the module.
 func (m Module) MetadataPath() string {
-	return filepath.Join(m.Directory, m.Namespace[0:1], m.Namespace, m.Name, m.TargetSystem+".json")
+	return filepath.Join(m.Directory, strings.ToLower(m.Namespace[0:1]), m.Namespace, m.Name, m.TargetSystem+".json")
 }
 
 // ReadMetadata reads the metadata file for the module.

--- a/src/internal/module/module.go
+++ b/src/internal/module/module.go
@@ -37,6 +37,12 @@ func (m Module) RepositoryURL() string {
 	return fmt.Sprintf("https://github.com/%s/terraform-%s-%s", m.Namespace, m.TargetSystem, m.Name)
 }
 
+// RSSURL returns the URL of the RSS feed for the repository's tags.
+func (m Module) RSSURL() string {
+	repositoryUrl := m.RepositoryURL()
+	return fmt.Sprintf("%s/tags.atom", repositoryUrl)
+}
+
 // VersionDownloadURL returns the location to download the module from.
 // the file should just contain a link to GitHub to download the tarball, ie:
 // git::https://github.com/terraform-aws-modules/terraform-aws-iam?ref=v5.30.0

--- a/src/internal/module/update.go
+++ b/src/internal/module/update.go
@@ -1,0 +1,65 @@
+package module
+
+import (
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/mod/semver"
+)
+
+func (p Module) shouldUpdateMetadataFile() (bool, error) {
+	semVerTag, err := p.getLastSemVerTag()
+	if err != nil {
+		return false, err
+	}
+
+	fileContent, err := p.ReadMetadata()
+	if err != nil {
+		return false, err
+	}
+
+	for _, v := range fileContent.Versions {
+		if v.Version == semVerTag {
+			p.Logger.Info("Found latest tag, nothing to update...", slog.String("tag", semVerTag))
+			return false, nil
+		}
+	}
+
+	p.Logger.Info("Could not find latest tag, updating...", slog.String("tag", semVerTag))
+	return true, nil
+}
+
+// getSemVerTagsFromRSS returns a list of semver tags from the RSS feed
+// ignoring all non-valid semver tags
+func (p Module) getSemVerTagsFromRSS() ([]string, error) {
+	releasesRssUrl := p.RSSURL()
+	tags, err := p.Github.GetTagsFromRSS(releasesRssUrl)
+	if err != nil {
+		return nil, err
+	}
+
+	var semverTags []string
+	for _, tag := range tags {
+		if semver.IsValid(tag) || semver.IsValid("v"+tag) {
+			semverTags = append(semverTags, tag)
+		}
+	}
+
+	return semverTags, nil
+}
+
+// getLastSemVerTag returns the most recently created semver tag from the RSS feed
+// by sorting the tags by descending creation date
+func (p Module) getLastSemVerTag() (string, error) {
+	semverTags, err := p.getSemVerTagsFromRSS()
+	if err != nil {
+		return "", err
+	}
+
+	if len(semverTags) < 1 {
+		return "", fmt.Errorf("no semver tags found in repository %s", p.RepositoryURL())
+	}
+
+	// Tags should be sorted by descending creation date. So, return the first tag
+	return semverTags[0], nil
+}


### PR DESCRIPTION
I've been testing with a few 10s of thousands of modules and realized that with multiple runs, it's faster (orders of magnitude) to use the tags.atom feed the same way we do with providers.

Fixes #49 