### PR TITLE
Providers build should work even if the manifest file is broken

### DIFF
--- a/providers/a/andrey-olishchuk/dmprovider.json
+++ b/providers/a/andrey-olishchuk/dmprovider.json
@@ -1,0 +1,328 @@
+{
+  "versions": [
+    {
+      "version": "0.0.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.5_darwin_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_darwin_amd64.zip",
+          "shasum": "fc40a7104166947e14c69a0f40bf8561b60d2820c1f62d77f9f6c5e6b57396bc"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.5_darwin_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_darwin_arm64.zip",
+          "shasum": "3a099c5f9f71a78ee41698b54ca2c4922b52cdd399c5ff71f8200946e633aa68"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.5_freebsd_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_freebsd_386.zip",
+          "shasum": "2f8243a118ec1c62815cdbad73240e52995a82013028dda65f0089298c400faa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_freebsd_amd64.zip",
+          "shasum": "c3846924beb9baafb7c2e2181823d22322693e356729f945a5e069e397117b5c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.5_freebsd_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_freebsd_arm.zip",
+          "shasum": "00cfa4375fd98e50883142ed3190e9e8e31df09d1d5a6977f744345d0945b283"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_freebsd_arm64.zip",
+          "shasum": "693b0c9d1d2d59e36b01ccea0493948ce33b6379b2da73fcfe66ba49f7264e4c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.5_linux_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_linux_386.zip",
+          "shasum": "5908e09d10c716ba0a7cf053a982635201cf8f2fec1b537369b65bfd7e940662"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.5_linux_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_linux_amd64.zip",
+          "shasum": "06316ae4e3bc0f51a3c6268ef7e0b52d74881f7be1f83bc7752dcc6325e31941"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.5_linux_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_linux_arm.zip",
+          "shasum": "c625ebd2ebbdf8ab1596856ead700d1fcb0e183b21cb7574653195c84ce88aa8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.5_linux_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_linux_arm64.zip",
+          "shasum": "0696ddd80de0e10a1c5f4da1fe4607ef134f4233a494f71be9e3b39038d0b63e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.5_windows_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_windows_386.zip",
+          "shasum": "b12ac0a1cd04d1d65e726c550f1d923aeb0c0e39e05bc1fd89e56073714664a9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.5_windows_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_windows_amd64.zip",
+          "shasum": "9863fe957613a75df73e7cea1c910650d17247458884e49cb21de239507963d0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.5_windows_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_windows_arm.zip",
+          "shasum": "f16b2cff2902911127270ce5bb7dc295aaba04154895291948777e05d0498a7e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.5_windows_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.5/terraform-provider-dmprovider_0.0.5_windows_arm64.zip",
+          "shasum": "20f5f9aeeecfe932001b547a874deabf37cb2e7f383846ff23f47552a75e07fc"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_darwin_amd64.zip",
+          "shasum": "701de57e6140d85c07d6eba8f033745c4472aacaf5dc0f4cbdd13ba52b5fbf0c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.4_darwin_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_darwin_arm64.zip",
+          "shasum": "4a3860dd769951e38efda90e6c7a5c17c5f0bb18754678e570b2e73bdab3554b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_freebsd_386.zip",
+          "shasum": "c03a1ee771415a8e7645431353b64d7c4796ea3ab12438e022f8a0b02283b610"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_freebsd_amd64.zip",
+          "shasum": "fb6f52d8c1f7ac519f2fa5ad0684230c91268d2f70f64cf3a74511e163414a91"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_freebsd_arm.zip",
+          "shasum": "d60ab1d041f1acad031a1a060e4797ca8f97f89bcb38d889280c4a73368a053e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_freebsd_arm64.zip",
+          "shasum": "6e9c5565d4f173b3eaa6d79701d7a20c10f17fcab257465e3ccb16a52dfb3ada"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.4_linux_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_linux_386.zip",
+          "shasum": "9da07281ef9a39b3b96d991ef65f308e15892e3ed6b818107a6ade898bb51228"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_linux_amd64.zip",
+          "shasum": "43c48ed5642b31af07ff0bda767dc60ed8de6fdb9dee7ff35890947d91eaf6cd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.4_linux_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_linux_arm.zip",
+          "shasum": "dbbd5520d824fc6f8506066b04b28eddca6f1334a3beb092943b588a386822b9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_linux_arm64.zip",
+          "shasum": "42e8eca61ed49d68bbf449062276a7e31da673b58af5c52fac4079f7033389ce"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.4_windows_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_windows_386.zip",
+          "shasum": "1d357c26a39176e4ba263592f7c43cbf668c517d9a880dc2c16ba37b165bbf22"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_windows_amd64.zip",
+          "shasum": "22fb1d03ebf270b1ffa6326e8d0ab1887882d91ea07a2f3bfe9037b3dc6b1b47"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.4_windows_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_windows_arm.zip",
+          "shasum": "e1e9a3cd5e15f1b45f1ab3d5d6f4c59fa4caa3b8c95f89e0a5224c599a4ccdda"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.4_windows_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.4/terraform-provider-dmprovider_0.0.4_windows_arm64.zip",
+          "shasum": "8a03dc548dc3c0b96c1d963d500fd09c5ec3dd3ae7cb168ffc70ea54e78232e6"
+        }
+      ]
+    },
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_darwin_amd64.zip",
+          "shasum": "53d83fd96c589ce773b54aeecd50f0c1abfb4c54c5edf34107c1b56c233650b8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.3_darwin_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_darwin_arm64.zip",
+          "shasum": "229e8866ffde07585813aa2d2a17a80c744ecfe3cc16303bceefa958e416180b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.3_freebsd_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_freebsd_386.zip",
+          "shasum": "48cbebfc95e241f19ff8b48094a00049828da3c916105a78cbb3647f7e3ec530"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_freebsd_amd64.zip",
+          "shasum": "a4d022ea90b84e3b0a90d94a8aaeeb0f7432dc1e0223591b651c3db192780cc1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.3_freebsd_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_freebsd_arm.zip",
+          "shasum": "e18e46894ef6101e96bba438cd554c4810f381e67ed444182adeb69236091d68"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_freebsd_arm64.zip",
+          "shasum": "91f7ebc68618f92899e902178ec610dd666ca51ff3f92b4cf5cae9b2fad607b9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.3_linux_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_linux_386.zip",
+          "shasum": "b7f5136113bf69cae8c6391af5a16b0072c07a26f5b224ed548f6e8dc377675d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_linux_amd64.zip",
+          "shasum": "c0efca9027579bb500a595433f43ce95c123c2c060e79e658b38d267dbdb6f19"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.3_linux_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_linux_arm.zip",
+          "shasum": "71be94d63e00df8417b5c82ee1ee4287e65501e6cdacf5328216c387b204e6e3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_linux_arm64.zip",
+          "shasum": "7116b1bc3512e9d7b6202dc0f868fd0cbc91d5c89cb9a93b1e3300d454f2869b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dmprovider_0.0.3_windows_386.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_windows_386.zip",
+          "shasum": "d3c057e2972ff9fb74e28335a3d28452ae8d3e3fbf7958d03c0d0ab855dae518"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dmprovider_0.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_windows_amd64.zip",
+          "shasum": "d75383d8c981ee0083142c6158d9245922f26a28e969345835c192173709ccbc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-dmprovider_0.0.3_windows_arm.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_windows_arm.zip",
+          "shasum": "cb4e63c91404b39f66820bc52983df42ab3f8b49c367cfc9c8f3058861b95d2d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-dmprovider_0.0.3_windows_arm64.zip",
+          "download_url": "https://github.com/andrey-olishchuk/terraform-provider-dmprovider/releases/download/v0.0.3/terraform-provider-dmprovider_0.0.3_windows_arm64.zip",
+          "shasum": "7e743a9342dc24ecb71fe7f72f747c9485feac50b4dc207a1c7aa4b3f2c8ec15"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/a/ariga/atlas.json
+++ b/providers/a/ariga/atlas.json
@@ -1,0 +1,3649 @@
+{
+  "versions": [
+    {
+      "version": "0.6.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.6.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_darwin_amd64.zip",
+          "shasum": "cb938de3d2e9b447154489b57dfa7c8cce97de629181b4546bcf4e573e247a17"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.6.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_darwin_arm64.zip",
+          "shasum": "a4ed9ccae9406dbcab51b05d3b552932c4d6cf57fb913942433c86be18cb3c1c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.6.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_linux_amd64.zip",
+          "shasum": "2dc5fc72b57da470739cb55a5be23a47d58f01f198d795d4fe4a36a7606487f5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.6.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_linux_arm64.zip",
+          "shasum": "e64750a5e6a7960db31a69f4b1fecc15dd2c1c7f3d919c81a741434b6f276994"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.6.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.6.0/terraform-provider-atlas_0.6.0_windows_amd64.zip",
+          "shasum": "5f2268e397c982327bfbd621ee98e381efb455faf977a2d0c2904ca4a8053a2a"
+        }
+      ]
+    },
+    {
+      "version": "0.5.9",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.9_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_darwin_amd64.zip",
+          "shasum": "5133b509e29c090d6f0876ea4c2c9eeb4980af0651e0a6775529888e6bdebe02"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.9_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_darwin_arm64.zip",
+          "shasum": "12ac265f80c980fb1226319cdb315b5101b59b0eee760409e8a104b00e5a3969"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.9_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_linux_amd64.zip",
+          "shasum": "862a77c5adcdba712d66017f054cfef9b6fe31903f6ffc3bce096553ed89e184"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.9_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_linux_arm64.zip",
+          "shasum": "387aca6c9624e8e632aa855e96638222cf2cd7d8ca45d07a6cb861a53dbf723c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.9_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.9/terraform-provider-atlas_0.5.9_windows_amd64.zip",
+          "shasum": "e335981245a9fef7b09ed4a9bfc6c6396e11ca69704618a09664c39b5e2f5536"
+        }
+      ]
+    },
+    {
+      "version": "0.5.8",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.8_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_darwin_amd64.zip",
+          "shasum": "dec22799875c4cacb552cd0fdb66538694e6b11536519d878d123c45cbfc69f3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.8_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_darwin_arm64.zip",
+          "shasum": "9e3b0b7de2d68d2c04c1871f29cb0d9450191892b75761a416112fc99978b424"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.8_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_linux_amd64.zip",
+          "shasum": "8110796a1ca5a333da618d949ac6f495ae916ff99b3e8e95b3d95fe85e9be75f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.8_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_linux_arm64.zip",
+          "shasum": "9de4d8a2c2525688d52b01819d4b30ec34cd1b91dd9f40fd73734e26fedbc98b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.8_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.8/terraform-provider-atlas_0.5.8_windows_amd64.zip",
+          "shasum": "4aebd83c3023c328cd3eebc5ee24566fe3c8386a5916cb7febcd2da7d617549d"
+        }
+      ]
+    },
+    {
+      "version": "0.5.7",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.7_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_darwin_amd64.zip",
+          "shasum": "bd335eda63bc8a6985a99e173a9f94bb3c6d0abe5db52b2241c8b6ba727bb61c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.7_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_darwin_arm64.zip",
+          "shasum": "02fc4fad3ecaca359aaba332a4b0649c8aa9b8ef65df0f6251c55fb49998ca55"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.7_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_linux_amd64.zip",
+          "shasum": "e4626607c22448e7cb505c207e9ce0332e14b8cc0d635274991982de2b51f618"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.7_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_linux_arm64.zip",
+          "shasum": "41469412faf3e5a609f392ee73171f663d8537fb2d0be3f781b44fa2ecd42a08"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.7_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.7/terraform-provider-atlas_0.5.7_windows_amd64.zip",
+          "shasum": "adfc89f5aa8d5e5ecadb0de6e336756af5a8382ac5a172f1ee48ae57ea467f7f"
+        }
+      ]
+    },
+    {
+      "version": "0.5.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.6_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_darwin_amd64.zip",
+          "shasum": "501f23bb6760788d9e8664382baa458e0eca80e5871a7465ebedba3453e349b9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.6_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_darwin_arm64.zip",
+          "shasum": "25be4a1830391c76bea8e2d57cb569780b9af22a128e34210cee985c7d7824ce"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.6_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_linux_amd64.zip",
+          "shasum": "a7b83335aa1f42a0831ffe1492be8ec3f22a9a52595868de5669a20a556ff0bd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.6_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_linux_arm64.zip",
+          "shasum": "a91b6b6028617e97a2339a1da6d7c0a6ac2b9227dbe7551a97a21c3c6a0d159e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.6_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.6/terraform-provider-atlas_0.5.6_windows_amd64.zip",
+          "shasum": "85cacc4305028ada8494059c44b141627fff273320f930dfd24311093c2dadce"
+        }
+      ]
+    },
+    {
+      "version": "0.5.5",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.5_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_darwin_amd64.zip",
+          "shasum": "f6b65e07f1225cd50cd15ae57a9c1c2de7dfdad3d54ef469057d94378adda983"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.5_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_darwin_arm64.zip",
+          "shasum": "87c68f19438a6ad6f2ea3562052479f8eb7d8beac5c637497db5a976788eed95"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.5_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_linux_amd64.zip",
+          "shasum": "97f0c70788e1c56dbbfe0548d4c516bcf4302cde0b46ea4b19df3aa44ba40f4f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.5_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_linux_arm64.zip",
+          "shasum": "5de72328f071bb70e52d4015826d9e014b0eadcf8315e66894c2f8d882b20c08"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.5_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.5/terraform-provider-atlas_0.5.5_windows_amd64.zip",
+          "shasum": "9686ca01ff0c55b4a2bda7e205808fff7a80ed221ac26182504c4bcde3115e9d"
+        }
+      ]
+    },
+    {
+      "version": "0.5.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_darwin_amd64.zip",
+          "shasum": "f2603d1e99d25834965700a8a98e84c0ffa0c710fe7ecabac02d7c19f37ec6bf"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_darwin_arm64.zip",
+          "shasum": "651725f7f35432a0f7a9d2178553f6ec941885eb90821be48cd519fe21d4e695"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.4_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_linux_amd64.zip",
+          "shasum": "f5f5d2ff4b224e1a53794255f0902d7942b852f855c1764337ce73aa313952d0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.4_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_linux_arm64.zip",
+          "shasum": "620a54a1886ba262616406f1d1176872c4a0c159ef5e9518d47cacf737367a4b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.4_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4/terraform-provider-atlas_0.5.4_windows_amd64.zip",
+          "shasum": "12a8ffe4e346ffd945374c54e865d64ba484a7202f27e27edc7f010a2056c52e"
+        }
+      ]
+    },
+    {
+      "version": "0.5.4-pre.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.4-pre.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_darwin_amd64.zip",
+          "shasum": "e6f9c50dd55f67cb5e57a1a0857ff728f1f2e57b8d12cf298c23b67097318170"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.4-pre.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_darwin_arm64.zip",
+          "shasum": "e7d204bdd2f9ad654aa52780c4b0536155c9783670c9ad836099bb6c9e7b4a4d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.4-pre.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_linux_amd64.zip",
+          "shasum": "b25a50c1df9755b56afae303f9c71c5b680d333c7a723f7e4056a2eb8baeacbc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.4-pre.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_linux_arm64.zip",
+          "shasum": "087568722ab99d17d0cb286b7730f315e512d4e26f759cfbd875cd0e2706d126"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.4-pre.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.4-pre.0/terraform-provider-atlas_0.5.4-pre.0_windows_amd64.zip",
+          "shasum": "971f093ef7aa46f30194268e6c7ed62c600f327985e96475a3f4e1beec8e0277"
+        }
+      ]
+    },
+    {
+      "version": "0.5.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.3_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_darwin_amd64.zip",
+          "shasum": "053b89c5c7f4a13f77a2872530075cb0c12c25102e3647eb9f06547c9bdb1e03"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.3_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_darwin_arm64.zip",
+          "shasum": "8b2650cf576f7c84b92468cf50d7949f5c21905b214b19b59f1d531e18ea0477"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.3_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_linux_amd64.zip",
+          "shasum": "2a8357da6e94a4dcc6ec7aad5f589640b9a71cea70ef6501cb5454dea34a5757"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.3_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_linux_arm64.zip",
+          "shasum": "d0fdf3b54e54a298ac4513aab145433e2e4de36d09fb20de91f655223cc32d98"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.3_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3/terraform-provider-atlas_0.5.3_windows_amd64.zip",
+          "shasum": "df89d15ee3786dc70803af92c8e73f86ee59ac9512ee7886f6efabacf34d472f"
+        }
+      ]
+    },
+    {
+      "version": "0.5.3-pre.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.3-pre.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_darwin_amd64.zip",
+          "shasum": "28934deac408a0cb140ce0fb11728b1f50334a84f609905291f58179179334da"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.3-pre.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_darwin_arm64.zip",
+          "shasum": "210556af63a0a6e1c052f9b84be969348cfd15958afa1a376b50d6cc562d7ea2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.3-pre.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_linux_amd64.zip",
+          "shasum": "982a696ec4cff25d3652f7cca068e091b8eb3b5c84f37ddae6a00a90ffc14635"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.3-pre.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_linux_arm64.zip",
+          "shasum": "4f62bbd321e97b46f2c0464bd91388b832f646ba1d73a172ad732cf97fa0e8a5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.3-pre.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.3-pre.0/terraform-provider-atlas_0.5.3-pre.0_windows_amd64.zip",
+          "shasum": "e2c3552e74c62eb6a7d85ebdda5c15e6d725306c5a27e8fe8de6b3d2a687054c"
+        }
+      ]
+    },
+    {
+      "version": "0.5.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.2_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_darwin_amd64.zip",
+          "shasum": "b956d4821b52d554fad69d853bf75ca25b35ba57c3b280153f32ef1f110b428e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.2_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_darwin_arm64.zip",
+          "shasum": "d61577188e7c0f8e311e57930dd42f0d10a4ade9e5c7d8ab68db85bcd285f5d5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.2_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_linux_amd64.zip",
+          "shasum": "ea084d1473c587e68c7c74052a983a93ba3377d1b2eb97735d4a8135449dfa61"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.2_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_linux_arm64.zip",
+          "shasum": "93afa2b960edd48c751aab0c7a882520f99641057e15e1726bc6e5f8eda5a864"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.2_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.2/terraform-provider-atlas_0.5.2_windows_amd64.zip",
+          "shasum": "a59d046c6b1b5f4d6da39a96392b2af0b430cf1bbbc6adeece3d80fe0e5dfbae"
+        }
+      ]
+    },
+    {
+      "version": "0.5.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_darwin_amd64.zip",
+          "shasum": "1847a6169e68f0af9b3fd71360c1c38da596216127dd58f6a7ab26c1894ea958"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_darwin_arm64.zip",
+          "shasum": "28662a31f84784a253bbf07844a207342a6dfa1c2bc75b72b908f6994ec1e9ac"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_linux_amd64.zip",
+          "shasum": "48e2fef317d1ddc28de4f70aff9c4b6d94ae1d53ec92770618b8d912a3152faa"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_linux_arm64.zip",
+          "shasum": "5877fb72cf418058b8cb89a64fe288d8f5949841e8f3685d3a38ddc0253c48c1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.1/terraform-provider-atlas_0.5.1_windows_amd64.zip",
+          "shasum": "ccff9cf55d581e6420d04b8b02d97f3f1cceec992cfe3d35837a0da8a1523096"
+        }
+      ]
+    },
+    {
+      "version": "0.5.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_darwin_amd64.zip",
+          "shasum": "8c976c4448e721a8212fe048b4e66a86e497223a5e01ec12e9ae1319bb749d49"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_darwin_arm64.zip",
+          "shasum": "8821e80f28fe861f26ceb6afd3212d15ca027048330230f6970bf42544c415b0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_linux_amd64.zip",
+          "shasum": "fda31f13122f7795e3f37ad23b617a829dfda2771a52c4ec6c976cd7bf266004"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.5.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_linux_arm64.zip",
+          "shasum": "1c5cf2da0c898b8c44da62f955bb8043988a6812e252a441993e5ba8073e3fab"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.5.0/terraform-provider-atlas_0.5.0_windows_amd64.zip",
+          "shasum": "a22140b9350905ff02e9f6d160a42c30e21be641be532460805727bcf2104093"
+        }
+      ]
+    },
+    {
+      "version": "0.4.7",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.7_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_darwin_amd64.zip",
+          "shasum": "219419dff9e2404aebebc36c72699971ea3147dc839461eae5e19fb19cc0bcd5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.7_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_darwin_arm64.zip",
+          "shasum": "9d9ab8b7580d57fcc9c11877b3622b0572e2a10032e538674d44afbb1ca26df1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.7_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_linux_amd64.zip",
+          "shasum": "e42868511e54fb2deb8cfa00342f1815c8bee3e39b8b51d54fdcaf159e6d9ca6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.7_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_linux_arm64.zip",
+          "shasum": "10865462dec67a51d4293c2913a1fe453f809aca6ab6e0f10dab7538263979f3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.7_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.7/terraform-provider-atlas_0.4.7_windows_amd64.zip",
+          "shasum": "8f785713f0c9a48e623f0c0f600dd52e3c017b4d9daddb667258f520ab0ae66c"
+        }
+      ]
+    },
+    {
+      "version": "0.4.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_darwin_amd64.zip",
+          "shasum": "c55df55dc419c4ecd57c50ed2a8c0fe760a3b19a4e6ffcf6cb2262b78cccc683"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_darwin_arm64.zip",
+          "shasum": "b66c6ff72f3b0a06ee135c7d0e54b38fb7140241c38d69894f755ec2251a0723"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_linux_amd64.zip",
+          "shasum": "98074aabb099ad8c9475f8a2a3eefa407c81e6d772969e25c94e8646ee935c22"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_linux_arm64.zip",
+          "shasum": "3f7478905a96c15538905245f4d58d67a0ccde48863b6157269e221cd85844d9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6/terraform-provider-atlas_0.4.6_windows_amd64.zip",
+          "shasum": "9b5f9270b3ffeaa040ad78c442f3033bee86cf423e67217d2b9bb0b983f96b0b"
+        }
+      ]
+    },
+    {
+      "version": "0.4.6-pre.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.2_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_darwin_amd64.zip",
+          "shasum": "f19ee8871a8336c66aef227982922c262a0f29f63cf96be510516ddb95268e80"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.2_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_darwin_arm64.zip",
+          "shasum": "2386245bc2079188b24dddbf9b68cfb3f996b9582dc80eeab72b4a10011b4560"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.2_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_linux_amd64.zip",
+          "shasum": "b2f9c99020f3a51351941f765461f1b7004980998a01711605b04dc1214c2301"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.2_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_linux_arm64.zip",
+          "shasum": "e4347761e0ace07aec977411a21034febc274e33f103f302915985871990133b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.2_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.2/terraform-provider-atlas_0.4.6-pre.2_windows_amd64.zip",
+          "shasum": "ea3370a5c3c1506b1e2078113104c6af5da9d08dae8c09461323c17d7073d40b"
+        }
+      ]
+    },
+    {
+      "version": "0.4.6-pre.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_darwin_amd64.zip",
+          "shasum": "46fb40b27d44a6a0e2e3a2c1280373cee724c66caad2abe70957f6edf3bce52f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_darwin_arm64.zip",
+          "shasum": "cc23f8e7eff4a945167d1b5b5415822583ec282523715d7d20a5b1f3e196a69d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_linux_amd64.zip",
+          "shasum": "0b3689dcf745c6c38578b066b0e10b1d854c5c45e93d8f695521a6fece6386af"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_linux_arm64.zip",
+          "shasum": "75c7d3e9d2d83388aa74ca3793d83f651355acccd2ef96dacb0c11829fc8d8bb"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.1/terraform-provider-atlas_0.4.6-pre.1_windows_amd64.zip",
+          "shasum": "3a97f5471917d8c3f6cec5ceb221a8cca32e26f7c4065d0cc2a40cff57c3c991"
+        }
+      ]
+    },
+    {
+      "version": "0.4.6-pre.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_darwin_amd64.zip",
+          "shasum": "c6589f3c9f49d5432e87ba6a180b0363a4ad8d8dd45d0c0d07010b555132a0d4"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_darwin_arm64.zip",
+          "shasum": "317bfc11ab11409266a7a5c4c4e5201342de93f1ae151f0de94007216617f36e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_linux_amd64.zip",
+          "shasum": "097599a6d28bbd66229e28b31d2f2f98a083af7e5394b2c961a60fdca52ba705"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_linux_arm64.zip",
+          "shasum": "fc921cb8829b3bb0354ba178298552314ee6006d5dafae4fdcafc70caceace22"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.6-pre.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.6-pre.0/terraform-provider-atlas_0.4.6-pre.0_windows_amd64.zip",
+          "shasum": "4356069cae30c54c9014c03c59f1f06e957365ea17f778796dfba82e0f611307"
+        }
+      ]
+    },
+    {
+      "version": "0.4.5",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.5_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_darwin_amd64.zip",
+          "shasum": "58d39d0d7558dddb5f53107df84d384cca2b2115792874d719fe5712f75480c9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.5_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_darwin_arm64.zip",
+          "shasum": "2f91f1ba32267e7c193ae1d2deaa79cad4c81475daa56008c2fbbdca9e76a372"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.5_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_linux_amd64.zip",
+          "shasum": "bbda7d7fdd6fd42ef400393113ace8b5171845810e0369fbf7548d76067cbcee"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.5_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_linux_arm64.zip",
+          "shasum": "82cf680c089eabe60ae7fed21bb769a26477b36bd2ca43df3253562918137956"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.5_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.5/terraform-provider-atlas_0.4.5_windows_amd64.zip",
+          "shasum": "708260a5e8081f5e4c303e2e643ba18314783c0c5a7dccbd8c9fbcfc6c2cbc48"
+        }
+      ]
+    },
+    {
+      "version": "0.4.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_darwin_amd64.zip",
+          "shasum": "891747a6b7a188c193ccc655803a2e530a5a719c7579a29ea64dbf087697af4d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_darwin_arm64.zip",
+          "shasum": "63bb1fee1aee3fc3d383ef0b9bf620eaea4d660b35471c70475c99b5669c19f9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.4_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_linux_amd64.zip",
+          "shasum": "bc494c61519311edbf882a60de3ee4c6f95a0929dca6199338872f1b019ae784"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.4_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_linux_arm64.zip",
+          "shasum": "395ccab619d40403068cea5321b09c89922477d8d3a00ea96633a3f448525fdd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.4_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.4/terraform-provider-atlas_0.4.4_windows_amd64.zip",
+          "shasum": "66d73f0536e502c1626839027a6b619acebe8326e32907190542356bb6e734d5"
+        }
+      ]
+    },
+    {
+      "version": "0.4.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.3_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_darwin_amd64.zip",
+          "shasum": "0826a669e2097a1d642d806b70f5425b2334db0fc77ca80e0cbfe76f6926e533"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.3_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_darwin_arm64.zip",
+          "shasum": "dd83cab34af7b6cc3e8d74e9f571b20a37d6b292a0e8bb2630e6e79c59a349ab"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.3_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_linux_amd64.zip",
+          "shasum": "8d15438ea073d2e9ed08b6de7590d1b3ed8a133ef5085807dd3307126006dde8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.3_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_linux_arm64.zip",
+          "shasum": "50c019f512d724567613990a04bdbb3f167814f3fd61f9b18585fa17e81d1ddd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.3_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.3/terraform-provider-atlas_0.4.3_windows_amd64.zip",
+          "shasum": "3b7274c17570c91506fb814fbaf3cfc364d4571ecb59171e2d365538b314fb53"
+        }
+      ]
+    },
+    {
+      "version": "0.4.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.2_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_darwin_amd64.zip",
+          "shasum": "b54beefce7fc4b21c75a784c4107e0574ce00c9d20f24858f31bfddc144d9efa"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.2_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_darwin_arm64.zip",
+          "shasum": "d7a67b3d4f5adc50f12ff676c60894a7e44ca072e4c69679ddda8686922bf243"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.2_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_linux_amd64.zip",
+          "shasum": "7f708a95890245c94c7bad07f0724679f2f40d3d3d0a629a098b7b45c00fe910"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.2_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_linux_arm64.zip",
+          "shasum": "fa58a084cfbb8726e6382aa32521350efcc31c5cb324900a09f4b679c9e98bb5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.2_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.2/terraform-provider-atlas_0.4.2_windows_amd64.zip",
+          "shasum": "b0438f82814a34c0c4a9486da085a61f9e583784cf875d882a14c16727267625"
+        }
+      ]
+    },
+    {
+      "version": "0.4.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_darwin_amd64.zip",
+          "shasum": "39e5550899fab2379515e1945fb3e83e068e6aad524ed93d8067e9b6a5e19cec"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_darwin_arm64.zip",
+          "shasum": "691b46b170cfa30174df5ec6a5e5749922c9d3d48634aafedb4c42e955d8e17d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_linux_amd64.zip",
+          "shasum": "82ecd9c0f4ba5908112a4a2546104d71535c712e304381ef70a70ae14477fe7a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_linux_arm64.zip",
+          "shasum": "f07bfa0b529008c881f17d1f117e9aa410666d8bb929e2ce18e25d22af1bea7f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.1/terraform-provider-atlas_0.4.1_windows_amd64.zip",
+          "shasum": "304bfe1b355208d5f979aa2afb8a0cba880f6abef37460ef5406a60e5c687183"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_darwin_amd64.zip",
+          "shasum": "6bd37424d6c4cfa76488cda27512c485cbe311b57c20a651a413529a1caf1f06"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_darwin_arm64.zip",
+          "shasum": "9056ed0183b9e912505df14f3cf8064054ee17c0a89a32b641a6ebe981e17eac"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_linux_amd64.zip",
+          "shasum": "7b3cfcef7f00873ac5da8aa7c945a7f473750da9a77b759bc4e19005328411b3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_linux_arm64.zip",
+          "shasum": "cdc35af8ba120804cdfa2d4b03435c41fe23bbb5600d8c5e18bf7dff097069fe"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0/terraform-provider-atlas_0.4.0_windows_amd64.zip",
+          "shasum": "c8c4c9a40597422c542ab99d3c4a402e34a3c10343014f673cf2d4b9e90826e8"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.6_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_darwin_amd64.zip",
+          "shasum": "d180350f0f57795b05bb177e78f7c610387132c191b6ff7c2e4c2139aeb70943"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.6_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_darwin_arm64.zip",
+          "shasum": "5dcaa8fc22a58f4088634bdd5966d44bb04d04ef24914080c9f0ac054bb7a59c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.6_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_linux_amd64.zip",
+          "shasum": "622fe61fd51106b4f85de829d3b2d712475f1b9bda7b3ba310b1c35082439c35"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.6_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_linux_arm64.zip",
+          "shasum": "f7b0274deebc211572c19ca90bc6e4fc2d1308fabd7c764607910789c8424beb"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.6_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.6/terraform-provider-atlas_0.4.0-pre.6_windows_amd64.zip",
+          "shasum": "16500a31c26aa344b74aa764a4165af9a29a561809190e548c96069ac9522905"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.5",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.5_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_darwin_amd64.zip",
+          "shasum": "29f70844cfa6a9c408bd53db270d996f4361acd9557f4a896a2bf61737c23288"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.5_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_darwin_arm64.zip",
+          "shasum": "69ec6cb57540d5dde246470d4c610c59649f0f629cfb3c978db85817772801be"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.5_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_linux_amd64.zip",
+          "shasum": "a2c202b77826606fe4f3ba0d083cb5f02d40ea580b8687e16c83109bb3f6ef9b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.5_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_linux_arm64.zip",
+          "shasum": "396d0df148bdd33bb50ca144d85fff7b0e54ad2c93ac535e436862bdbc52bd59"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.5_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.5/terraform-provider-atlas_0.4.0-pre.5_windows_amd64.zip",
+          "shasum": "2fd424ed6cc9cc1eddefc01ba74e15b1c6637108ee5fb2b7483e65bf5d5568a2"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_darwin_amd64.zip",
+          "shasum": "2ca21f37a618f0fad76e9ba6930a7cfcc3227d65f47bc81fd2ad2269b52a17a0"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_darwin_arm64.zip",
+          "shasum": "afff13331f747b9e287eec42b33110b7994d22b51b0d4d8ba72a987bbc02de38"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.4_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_linux_amd64.zip",
+          "shasum": "95d2f35c83abbf7bac4a9e587fcc0a8ab26e20cdaf8569d5483b805924395bc3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.4_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_linux_arm64.zip",
+          "shasum": "6c6ee8e1f63a233f37f165e1d2a4e7667ac3bb3c2ac447b3ea90c4b9426536f6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.4_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.4/terraform-provider-atlas_0.4.0-pre.4_windows_amd64.zip",
+          "shasum": "c08573f9414831a29ec408c9580185c489d1a9e58d37f22c9327d2568da748dd"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.3_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_darwin_amd64.zip",
+          "shasum": "c976f216e9e9010adcc89d560951b8fe64c56e385309b58e36b4aae926f7f582"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.3_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_darwin_arm64.zip",
+          "shasum": "2aabe0329cb73cdfaca681c4fedf778cf096bbf987d28a6c514ebb1c48643dc0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.3_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_linux_amd64.zip",
+          "shasum": "521537e272ccbf3f3777f280849e03d963f3b1ed761eb9c3572cc92d9269acb5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.3_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_linux_arm64.zip",
+          "shasum": "a076b3df47daad2d692aabc81205c58eefc75670a3eeee4ab4eca8d8c7e00279"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.3_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.3/terraform-provider-atlas_0.4.0-pre.3_windows_amd64.zip",
+          "shasum": "3877922a8e15dc6b704c691b75bd18f2e15245a7f28627fe0da5aa3c16ee82dc"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.2_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_darwin_amd64.zip",
+          "shasum": "ab3d70219b4612d55ba6477d2a35372b32faa78a74520b4cb01ac5550dc74f5b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.2_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_darwin_arm64.zip",
+          "shasum": "0fe84f37ea45c74ccea76989334cb55d4fdfbceb7cef09742a7086c0eead262f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.2_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_linux_amd64.zip",
+          "shasum": "1437bac227796e68ab7c3312fae3da709de3f1e2c5283ddb6dd261ca0943844e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.2_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_linux_arm64.zip",
+          "shasum": "c30f08454946aa63ea83c8d19b5e5e50eb1f48c36d8f3767c900e6be7afcf29e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.2_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.2/terraform-provider-atlas_0.4.0-pre.2_windows_amd64.zip",
+          "shasum": "6ace5c4639536057ce825ba93838a362f68ee0d8093a0a84dfe70d1a8924c1a6"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_darwin_amd64.zip",
+          "shasum": "3675da3c4232b74c3d64389e5c18609d0eca958c844a752fec07cc2d9a046a2b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_darwin_arm64.zip",
+          "shasum": "7001b319ad21f5b05b63f817caae10688e2b63455b146910ba7da07a2f9dcb41"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_linux_amd64.zip",
+          "shasum": "88d90d2f4766dc76f1a583347f2d123b1842b3bfc4f3d628d5db3dd2891265cd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_linux_arm64.zip",
+          "shasum": "a7b364532d34f584dafcf593b0ae52cac2a063274bb24fb87a868936445f41cf"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.1/terraform-provider-atlas_0.4.0-pre.1_windows_amd64.zip",
+          "shasum": "5806e65316d39c8a98ec994839990f7349d5476cbbb3f4e6a5753a7df39fb317"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0-pre.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_darwin_amd64.zip",
+          "shasum": "dddcdcb17d58ba9fe92ca1c70810b8b829a62c41e754778b2fa96773c59fc3aa"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_darwin_arm64.zip",
+          "shasum": "02f540e85c02a2abfdc45ca8215fec39979462ed0ef31d758922899d4892e956"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_linux_amd64.zip",
+          "shasum": "2d960cfc62a321c50041c9f1d7a6a63e4ad3392b1749fe8bddad0ba4c87af420"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_linux_arm64.zip",
+          "shasum": "5b4216760768a18f05c25578b1ebace345d3a13206570e58aa3c547de7486a97"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.4.0-pre.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.4.0-pre.0/terraform-provider-atlas_0.4.0-pre.0_windows_amd64.zip",
+          "shasum": "07e0b76acadcbdd3f55cc19bc6ebdd3ed042e4a56bec9f08d010cfee2a8bd2c9"
+        }
+      ]
+    },
+    {
+      "version": "0.3.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_darwin_amd64.zip",
+          "shasum": "1736f9420fffe5b0312bd7ccfa3ab60fec6ddf7854052f71f516006a16086fb3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_darwin_arm64.zip",
+          "shasum": "54fb3d9c240453e00b8308a0bd8847fcd4c5817b6c9fc0f750208c26c818ff85"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_linux_amd64.zip",
+          "shasum": "35ba5025e977b83403ce79a3cde2c7b9ebedf9bfa2c215bc1a4985f645d9ccfb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_linux_arm64.zip",
+          "shasum": "f0b402fd6a2a776601f99af14f8248223552b242ae4cbdd1b2a457a135b4a158"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1/terraform-provider-atlas_0.3.1_windows_amd64.zip",
+          "shasum": "0759734166be8a228bc1a2663ac128a0e6b6d0b2b8d78a14c7b3de837f299cdb"
+        }
+      ]
+    },
+    {
+      "version": "0.3.1-pre.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.1-pre.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_darwin_amd64.zip",
+          "shasum": "e2257ca50fa8ffe8ccd41e67784b641739b6da37faf311ad140cb52601e273a6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.1-pre.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_darwin_arm64.zip",
+          "shasum": "59747038825594c94cf245b0f4e5fb282e65a7a6d75d94bd8a192d6e2a1dfccc"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.1-pre.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_linux_amd64.zip",
+          "shasum": "22c5e4a1ddd4b7213e0d79a63ceeb3b8a73a4008c84532adc79f48d82f614564"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.1-pre.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_linux_arm64.zip",
+          "shasum": "0eb4a7288b54bf515d0017ba5c73825b43efbfb2f30e02039f7a7cf21e95b011"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.1-pre.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.1-pre.0/terraform-provider-atlas_0.3.1-pre.0_windows_amd64.zip",
+          "shasum": "68db56948c5d1d9f7afa1be5e6db48e179146b050b948f23e87918e9330f1854"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_darwin_amd64.zip",
+          "shasum": "a0b0bd944543f7fb38b83e5cf2ce378b1ae2cbb128a51c18217a2977a6fc835e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_darwin_arm64.zip",
+          "shasum": "309dab8a4340f7efd469aabac3040c7b3e4eb03399efcb5edee6580c73705321"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_freebsd_386.zip",
+          "shasum": "657d2d5f161ef9812f02badc45431c91066dd177aa4dfaa70a4f3d0a4a3e3ee9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_freebsd_amd64.zip",
+          "shasum": "5a33f010c29b77d020750719271fad59884a4a53e48fbaa0f81dab0d5d0cb741"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_freebsd_arm.zip",
+          "shasum": "d0ffce850c8176c37ac6510eceebb3f4322ff050b094704348bc8f7dc906a937"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_freebsd_arm64.zip",
+          "shasum": "ea5a6d433ec3552f7848d63f23430fdda5ad036509d23c37c16f3fe7fcecedfb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_linux_386.zip",
+          "shasum": "cf534a0e983d8e77332558914a2c02daae6edb7cc507aed1ff2f87ff77d4ff72"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_linux_amd64.zip",
+          "shasum": "c149c6009066ce42729b479d488ade97e8303ba3e9f15a5245709999bbdf0d5a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_linux_arm.zip",
+          "shasum": "3b14e9d4f8ceb71fa853d19aaccf2bd685a8df249419602216f20312cf239ee2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_linux_arm64.zip",
+          "shasum": "baa9bcf2cf6242f8551a51d06b1a53d02791b9079b59bf604bf40936a5cb6b9e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_windows_386.zip",
+          "shasum": "ed1d2a23ff83a489c00725bf93e5bbef082d5f6afbd14c8c7253fca4328a3798"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_windows_amd64.zip",
+          "shasum": "5f3fe13d51772b470a22248001b0e7d7c31bae32b0f24859dbad795b3faee557"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_windows_arm.zip",
+          "shasum": "f35a65467c99ae0b3a4fe59e60669e8ac8c1ead5a96b7b66cc4406f2773f4f2e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0/terraform-provider-atlas_0.3.0_windows_arm64.zip",
+          "shasum": "7a67a255c20023599288bc192af3f9545176cf64da017a19c9eaa2a7246e782d"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0-pre.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_darwin_amd64.zip",
+          "shasum": "8436e8f231c1e74ca90eb822e7148058b34713a020afd244272637131a03135e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_darwin_arm64.zip",
+          "shasum": "12de8c5d32d9fbee23ccf487b8e72ad71255551dc0edab3f9d18d67980477ba1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_freebsd_386.zip",
+          "shasum": "9df5b9b12df4e8cd334bc1e5e77048b41e15e96c4ea9db8d885345f5a7e415b5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_freebsd_amd64.zip",
+          "shasum": "9a4eafed44c6cb6e75160656e78f5b15269c94b12dac4de229865d7bb99420ff"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_freebsd_arm.zip",
+          "shasum": "b1e36a4811154a811b0120a665ed39011c23b69014fe3de44ff8aae28394565b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_freebsd_arm64.zip",
+          "shasum": "4af9c80df148ef03144a94c1e6733acd285fd0b046b1225ebb85dc3de50511ec"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_linux_386.zip",
+          "shasum": "04ef360198abfd7b99818397bf81b4b0630b5ae30dd4f251a2fd8158cb0e3083"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_linux_amd64.zip",
+          "shasum": "965d7eb7ac03ca591bff997cd3e3f3ea5b2504bdde15cf06ac1d2ec22df27d71"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_linux_arm.zip",
+          "shasum": "007959d265b7c91a10761635d88df54df252270c3c304d8d5bfaebbe457b1e57"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_linux_arm64.zip",
+          "shasum": "4dda59d47351211b3c206bee13334a9ba7cc2cb23e1e3c5a6ee6f7587be10518"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_windows_386.zip",
+          "shasum": "6fb6e7eda1c54b34c2bf1221c8682511bc74b05389c2d428270537237106cb9a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_windows_amd64.zip",
+          "shasum": "ee6e1b2fbeaf2913f63c5c01284f828914d361f603458ecfc9c200f35540c290"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_windows_arm.zip",
+          "shasum": "6325c58ffe5356f54133ef786c7d307955cb756ba40c9823e9461297853305fd"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.1_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.1/terraform-provider-atlas_0.3.0-pre.1_windows_arm64.zip",
+          "shasum": "56eb7c28bac5949135ac543440004079521c90d075e8edeed136bd8eab8fc564"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0-pre.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_darwin_amd64.zip",
+          "shasum": "7e61facfafda9e661f310bbce133d4929b6da062dd17e4d80d601b1bf97482f6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_darwin_arm64.zip",
+          "shasum": "5d84a155db3851bd5bb341e11d9f7d2778d1fedcab92b0c0ae6a82a952c03596"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_freebsd_386.zip",
+          "shasum": "65ebd58225dd98e1c518afa54625062c1131569b51ca19e54405d173295b1e96"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_freebsd_amd64.zip",
+          "shasum": "abf52603df9c7424bd4d1b50267989c1d9994c8f98fd9bd235ffa3f36594f443"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_freebsd_arm.zip",
+          "shasum": "b47d2cd35cd8679768afb26a38cbd3c1d09d2326187122cf6a9cd5009668d858"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_freebsd_arm64.zip",
+          "shasum": "8aa31c771b8a552ed4b787fdf95869d3f4e9bcfa74fa2dd312abbf4c37087c95"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_linux_386.zip",
+          "shasum": "ec9569843f64bb894aaa6877cc708dce78322613b09ffb438387be9ccdf32136"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_linux_amd64.zip",
+          "shasum": "b76f2603ed1e15ce5a0513701cf6da4800a4f94dfbf4d707edf467a32bc5390b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_linux_arm.zip",
+          "shasum": "05d0ae86fa291d454deaa0180437dc893d1364534a6f3393bf51aaae689d2d1e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_linux_arm64.zip",
+          "shasum": "c8f79cf312ebb6d97a6c852f7fc212598bbeffd7e180fc2ff41a74cd832edcd3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_windows_386.zip",
+          "shasum": "f1d6e884ef82fb07a4ab195562a377a09942e10bdfd0e6113d0d4100cb130bf9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_windows_amd64.zip",
+          "shasum": "6a123abd56d3ad9e0525925dea8d3ad8f140fd965aca4b30086c76fa32a216d9"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_windows_arm.zip",
+          "shasum": "c069597976c89a731800fb720d385bd8ff4a39407a2a294e828ca1ebc922cee2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-pre.0_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-pre.0/terraform-provider-atlas_0.3.0-pre.0_windows_arm64.zip",
+          "shasum": "87f9fd55eb5c8dabb4e85de29c71fb8dbc07eb1f70dc1aa6aef72742eab8c79e"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0-alpha.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_darwin_amd64.zip",
+          "shasum": "b5a0f908a5c42a11c3edae30942be231ece3d1ff42733477f93493191a324436"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_darwin_arm64.zip",
+          "shasum": "aa95745432bd23d3489b37c624f3844b66db8951606f5d6ea651f8536873f4a5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_freebsd_386.zip",
+          "shasum": "2dc4268d9196bb03c87244a97a82cdd22d1e7f3b29cefc493cd7945217226275"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_freebsd_amd64.zip",
+          "shasum": "62e0242d5b5fb17277c76057acef33f6c49099a09cf789f160b8ba235950dd56"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_freebsd_arm.zip",
+          "shasum": "b0fba349fdd22d4b116172282d282d67e13120336aca90cd5e30798f55036f84"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_freebsd_arm64.zip",
+          "shasum": "56532f042906531d5f43495a0c688905627d3dbf695dbbf0eb59801f9ed8d279"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_linux_386.zip",
+          "shasum": "45ff8737cb1aa3b114cf4d1ae8e2906ca26fd5677bfcc0e3e51a177a0343d065"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_linux_amd64.zip",
+          "shasum": "7940d21282e6e06baf160aaf550f28b5dd19151dc95b3d94c57d9844475c4448"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_linux_arm.zip",
+          "shasum": "c0971b1fde1f5abea82057f449b08f6a7205ebe4c05d8001579195b76e47b707"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_linux_arm64.zip",
+          "shasum": "0934bf75a7c597e7e91b6da9f7ae40359adb7aa0510016e61a9e8ff419febd49"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_windows_386.zip",
+          "shasum": "313f82d3947c738ef2a9893f47149e69ebb329de3bb94fa817ae34a3b7f1e575"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_windows_amd64.zip",
+          "shasum": "20e18764c88b5a345f4c5ee4eb65e6c0b1cf7d098a9e39a5195479c009c3e599"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_windows_arm.zip",
+          "shasum": "4f5b371af21053d7fd34cc903e13f9fd4cbb63321a53863edd5f7819e1eb501e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha.1_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha.1/terraform-provider-atlas_0.3.0-alpha.1_windows_arm64.zip",
+          "shasum": "56f2a49706dd4ec2826b666f02f0f0420d8026f7f8a6e21e650b2d727e23a097"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0-alpha",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_darwin_amd64.zip",
+          "shasum": "ea014050d3d419af884635568fe9d70919032286274363d40442d00fb322a823"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_darwin_arm64.zip",
+          "shasum": "1204946f41173714c6c907dfaea854863cd3c103bd34929322940721360e7562"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_freebsd_386.zip",
+          "shasum": "54f7bd03a9084d13774ed531074594612e06c23f5afea3f078dec4bb48b4644c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_freebsd_amd64.zip",
+          "shasum": "2a25a23d3150e32d3f136c405f67973fcf082845081dc71492cc1d2e7f2abfce"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_freebsd_arm.zip",
+          "shasum": "1c9d4966d450cf5d9f38e657ab2e128844152df53c7d2b9c199e3d9a0116b10a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_freebsd_arm64.zip",
+          "shasum": "5f67ae1c56e12a88d43a23479bacd90e9d20d96be95a4bedbef552ec8f940b4d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_linux_386.zip",
+          "shasum": "1ad41db56637d8a5eb1f0c815276c0057ec56ed3c8993a1265fcff2fc6528855"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_linux_amd64.zip",
+          "shasum": "8ffe9eb431ecef8a9ed60a1bf49c006c8b663c0c079c84c6fc5cc8844602afb8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_linux_arm.zip",
+          "shasum": "93a78b435ecf4e3fae0e89750927e0ac1f47670a019440a6aa8d576cc4688d35"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_linux_arm64.zip",
+          "shasum": "e973518634eaaf6a0680cabb0967f009fb80f3c1deb20c25049ef9b344dd89b2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_windows_386.zip",
+          "shasum": "1022545e17e9c1111b67c48d579d8413432a2eae97ca2b518584543e49eb1584"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_windows_amd64.zip",
+          "shasum": "ef4ae7ce57d1ff7d3b4e0fb68faa86532ab8e10f7e42d773bd80378fc1d65b76"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_windows_arm.zip",
+          "shasum": "04d92cad279f37160cfe40adddab09c2fe74433091f44ca603ec6804ff16a479"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.3.0-alpha_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.3.0-alpha/terraform-provider-atlas_0.3.0-alpha_windows_arm64.zip",
+          "shasum": "28b07ef54e31a70d9d24664453ca1d5a99236028242c9350ae0be694e7fad05d"
+        }
+      ]
+    },
+    {
+      "version": "0.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_darwin_amd64.zip",
+          "shasum": "4b73316d67c0a0e17738c9d7d7301a3d10b0e0a5cc493b259ee1d79cd326480a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_darwin_arm64.zip",
+          "shasum": "5809219ef9442229a64690ec443625190cf1958e28c4830a0a2f8b15d9525c22"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.2.1_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_freebsd_386.zip",
+          "shasum": "f7dbc6f0bd3153e27dba74a0837fb9b0e9f500be0f41820f1459602c98e92254"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_freebsd_amd64.zip",
+          "shasum": "307b1ad10c7a2ff617a5f7f0358d1bc55febfc91c525c22e9f0baa7141106dc1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.2.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_freebsd_arm.zip",
+          "shasum": "d8f990469e6ab0be3933bb0a22fe174e12bc2d91ad6260b7382fc0bebbd06fcc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_freebsd_arm64.zip",
+          "shasum": "e61fa04f59f94d07556dd2f38f054b6a0593f7c2036b3d4479a2b6faa92810a3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.2.1_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_linux_386.zip",
+          "shasum": "eb9f5b0e5832317758181b13cc065eefa5057c84ca3a05ac8a326095eda2ccee"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_linux_amd64.zip",
+          "shasum": "4a5280271d81d22b0cab12e1b7be31a0d70c7c310c9963a62961713d442c93fd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.2.1_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_linux_arm.zip",
+          "shasum": "e0dbbd6511d78b3eb170623f741cbadb7f2e375a81a035d22c92eadb042a004e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_linux_arm64.zip",
+          "shasum": "a2badb08043c0ac78b684ce75178eeba1978d19f8c61ee4bf4422b5ac3afbbbc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.2.1_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_windows_386.zip",
+          "shasum": "16a617d68a04e18910edce25d8d2d6f62cbfad58f39113abc3fb673f92312fdf"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_windows_amd64.zip",
+          "shasum": "7a09e0c3a81f6d9410ca849b2cdf60e4fadf31444799409e74c1d26a5097c05c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.2.1_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_windows_arm.zip",
+          "shasum": "3117860505489961a0069dbb922a70ff6db60fc98b50058ce752c8a89bd8164d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.1_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.1/terraform-provider-atlas_0.2.1_windows_arm64.zip",
+          "shasum": "326c2ce9120d1e31b5aa4e5a4943fe9e4c59682d00b31e3440ea4d1ec2f4668f"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_darwin_amd64.zip",
+          "shasum": "f44599d14494978502aae9150657a9c3ee6e80079ee925595ca8910adab85e06"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_darwin_arm64.zip",
+          "shasum": "6ed30cad07525e01eb56f62632dc470b1d68f281df54f453a5bead9a8ec88398"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_freebsd_386.zip",
+          "shasum": "4213764d14049ce6b2b3e899399735b4472b1bdb043248a72acb9100cd0b83c5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_freebsd_amd64.zip",
+          "shasum": "92a2eed9c13bf6a7cb4b8a13954548acb4f0a9664d543e04b9999744fcbf2211"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_freebsd_arm.zip",
+          "shasum": "3abe86c76a8be11d3128437b02aae329af680f710ca4f1b10c221250df22cddc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_freebsd_arm64.zip",
+          "shasum": "9101af6f64baa782e0acea5dd9c4efdaafb21bed5b7134d35d0e57372d392093"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_linux_386.zip",
+          "shasum": "d39bcf9401d589bb772be4e30ec860eaeae824876665ae60712bec7ddde2ea32"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_linux_amd64.zip",
+          "shasum": "1d53b6933568a833280c2fdf9ee930f9d9de2a124b97e6e0879fcfefe036582b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.2.0_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_linux_arm.zip",
+          "shasum": "462a3d51d74fcd53d1aeaa0f797c60271d191bb459f88b577ee0e182c9ffb181"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_linux_arm64.zip",
+          "shasum": "c98296fb567ac0ccf795d2004e02fff4c51d5e33c49bfcbd1c83f17dd9197f0e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_windows_386.zip",
+          "shasum": "8649072daa7404815021bdd2aed989c23691bb74accaaad706f8487e52d1c400"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_windows_amd64.zip",
+          "shasum": "e2c3b940eb33fa93b9e46315e5cdbd9cc40a56d5923947d56924e42f41546c68"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.2.0_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_windows_arm.zip",
+          "shasum": "4a4ec45c8b06ae2fc79ad20a5e97598239065416b71adb9d9268cbecf8ac5365"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.2.0_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.2.0/terraform-provider-atlas_0.2.0_windows_arm64.zip",
+          "shasum": "39cc3116eb1687f8ce620619697b86a5cce6b9495320dce9f30d66d79e9e8077"
+        }
+      ]
+    },
+    {
+      "version": "0.1.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_darwin_amd64.zip",
+          "shasum": "7f5d130883f1b69048d79eb8ed4a8b78c6c4344cf3783311ad254d487ee33813"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_darwin_arm64.zip",
+          "shasum": "33a13af9992b1ceb89aef9ee5c848baa9633c1c00a9fd7554bbcbb6d0bea479d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.8_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_freebsd_386.zip",
+          "shasum": "eb9e85a8d83d08bda293ae76ddc9b23f20a6df6e2a471280069eb7161e8dbe75"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_freebsd_amd64.zip",
+          "shasum": "5bf7925b3407474697e7b3d58aa9cbaf64d97810dc5cd5d38c851c64c7384318"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.8_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_freebsd_arm.zip",
+          "shasum": "0c35aba9dea0aef8d4f3f30723432e032830fb9792105d43777eddc5d250a8e3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_freebsd_arm64.zip",
+          "shasum": "7df4ea372f869551b0ec24326716f502015435ef484ae3a0ae718f239d047388"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.8_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_linux_386.zip",
+          "shasum": "08229aba1ac89e0944cd4137d49f77c8fd11c14ff36292d91dcf5cf0f3b2ebe5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_linux_amd64.zip",
+          "shasum": "a70f4e5227908a86bb975d7b6ad04b48c9261e64448d7bdc5df6fc475268dae3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.8_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_linux_arm.zip",
+          "shasum": "b6842c73ce59428eae2669cb40c681f35acd2f8a81cbc0cb27cfec7aafc89f47"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_linux_arm64.zip",
+          "shasum": "a1fa3b2076abe7c12f2a22e6164dbb32c8abc5956f061629e8ba50e3724b189a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.8_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_windows_386.zip",
+          "shasum": "82a37bc7943a0f789a9077bb4324b75cb769f8a9a9d2baaae77e15b426751da7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_windows_amd64.zip",
+          "shasum": "9bbccff8c96f54a8f53d1e5f3c603311426b61a54a456d1b3e0dee27196f9ca1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.8_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_windows_arm.zip",
+          "shasum": "e5cf0cc4e59e34a1ef0fdfb9709c9c503b846a7e62badc5620941b9b3e7f511f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8/terraform-provider-atlas_0.1.8_windows_arm64.zip",
+          "shasum": "189601c89f18c70ba3fe1ea23d96155eb1df2f20695a8f2a83b0c64c996f4c7e"
+        }
+      ]
+    },
+    {
+      "version": "0.1.8-alpha",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_darwin_amd64.zip",
+          "shasum": "a8cb1868aa8bcbd000e7c85875c09430b0f11d38bd712a83f866d9f6d5fa7ebf"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_darwin_arm64.zip",
+          "shasum": "f13d4abc496a784bb2d5af7dad8771b7a18d76d93b94540ce93888bbb204d224"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_freebsd_386.zip",
+          "shasum": "bf8aa12e2e8752997b1308ac6bdabfd18cf90337954bb084715fa7ffe492c878"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_freebsd_amd64.zip",
+          "shasum": "4da4322995a17e15aacb6a963786b2a8a82dcc96520b4f0e21fa2b2105f19d26"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_freebsd_arm.zip",
+          "shasum": "ee3b0f33d777915f4a8bb706dbed9a81a91ce21d6718b3c5e33580a3a2712bca"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_freebsd_arm64.zip",
+          "shasum": "f7b8e4e17dcc6685854f3769ceec8cd8e2d6e980dcb82664e5e4482a37675580"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_linux_386.zip",
+          "shasum": "1c268147604393aefc961ea399b55d65cffbcded02e7cf1f20f58fc3ded5dc2f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_linux_amd64.zip",
+          "shasum": "6d2c8b7b1d5fe40ab7dd007e1bc97871eb4262d40f5dfa26f8b879cba9bb7ed6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_linux_arm.zip",
+          "shasum": "7f632e6fc20c501b390d62ee9dddce66756cd8811fb79580a83ad74332e777dd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_linux_arm64.zip",
+          "shasum": "43c268be49ef8ce8f68a28e340af6a32aed7cc67260521638740fab7d6b07638"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_windows_386.zip",
+          "shasum": "7a9d129a79ddbe863fe0e0fc02b6acb9bed158081fbada6be7d9d4f507c51b8a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_windows_amd64.zip",
+          "shasum": "2b78334e1992d0216dfb954c828663acc868d97e21f73f81bb864320b1d85ed2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_windows_arm.zip",
+          "shasum": "ba6e3f11dcd8e6de02ebac63950b74372d85cbdb6b0f441b130a1c60ea462a52"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.8-alpha_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.8-alpha/terraform-provider-atlas_0.1.8-alpha_windows_arm64.zip",
+          "shasum": "39dfd40506e6f558f919dff505ff1fc2e6676bd76ac2baa9d122e81fbf7a4cdb"
+        }
+      ]
+    },
+    {
+      "version": "0.1.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.7_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_darwin_amd64.zip",
+          "shasum": "3193d28c3e5fa813ee330e58f716e823bf15def56891fca49685fed8b1ac6dc5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.7_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_darwin_arm64.zip",
+          "shasum": "528d89466a05e92f69ecf7bcbdfe53c188dd6a33f3345cf1ffd77fb9415e0a90"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.7_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_freebsd_386.zip",
+          "shasum": "2503c4f6c6a79fc49784d331019619254dbaa2b774d1e62bcae7b2ad32cd2826"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_freebsd_amd64.zip",
+          "shasum": "8a6c09c4271dee1371e971aa56368732512707e3448f74de680510529d7b3cda"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.7_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_freebsd_arm.zip",
+          "shasum": "70992cf69ee640cc60591d8ad48a06ebb3cadc3d220883c7b84363746b703e6e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.7_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_freebsd_arm64.zip",
+          "shasum": "7528868066da1300f875faae90a0ab419154e9e1d140227494532b28ab43515c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.7_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_linux_386.zip",
+          "shasum": "23a1fd51cd7490ca873d6f77a4a4757cc8616798ab02e6f34a71a410f2b89e2e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.7_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_linux_amd64.zip",
+          "shasum": "b8f27adb8981d4141b8f0454717e53f001142687d98cd122e7c7c5116f232624"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.7_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_linux_arm.zip",
+          "shasum": "00fd8f96f4a6f64de82ff831aee8325e1b2469dd4c29c16048f3f32376d0003a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.7_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_linux_arm64.zip",
+          "shasum": "92150ae7b0b19d74befb7aadd28eb0b9ebfdc2c478558eb513c718b32fac3776"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.7_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_windows_386.zip",
+          "shasum": "1c87172b87f315506084167df49094d554038f853c1ac24cfff1cf48e90c9595"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.7_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_windows_amd64.zip",
+          "shasum": "c9684a7fa33cd19514263811be74f6b4ff80084c53d4a8fffd22e30d7a3a3c55"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.7_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_windows_arm.zip",
+          "shasum": "81c710b4e410b531140c16c962b1b473f777d590fc5611eb54b730c70fa2a7bd"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.7_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.7/terraform-provider-atlas_0.1.7_windows_arm64.zip",
+          "shasum": "fc2d36e936c49434c8f7bc16fec3fe17e68eb547bf7735d0fc4406c3ce93393d"
+        }
+      ]
+    },
+    {
+      "version": "0.1.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.6_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_darwin_amd64.zip",
+          "shasum": "4e7686d2e768e72d4d42831724d72f5323a20ff72b3163d87263ffe684858021"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.6_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_darwin_arm64.zip",
+          "shasum": "42d82f7f45b05e15f93482a69e65d9f0880ebb9d745729da78443feb483a34b5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.6_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_freebsd_386.zip",
+          "shasum": "74714232834e54483e53d18150ec31331a577ff9f170af22f99f6a3b63b4e5ae"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_freebsd_amd64.zip",
+          "shasum": "72e3db9cb3e5bef5d07044f260904ec301197a47aa61438d5c79f1e8b5db1f50"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.6_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_freebsd_arm.zip",
+          "shasum": "ffa15e750a12389f08a76194a601b4047e0007108cf220de511d4db7f0ede91c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_freebsd_arm64.zip",
+          "shasum": "bcc32cf1ec2b75e9e91277e27cc37c8d323392b7ca8a04dc45d026214cc3e14a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.6_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_linux_386.zip",
+          "shasum": "c367c7f1b122b332dccc3608ffadae71d13a7e7334de4c2bc133d021d6cc5dd1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.6_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_linux_amd64.zip",
+          "shasum": "f36683743d9c7ad4f3a53dd78fa0597502731d669752344aa07b0e67bd021aac"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.6_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_linux_arm.zip",
+          "shasum": "c3952b78ffeac73c97ef60f1b84b6c3d04f159ffe1b50ecb4fffe8db2eabec32"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.6_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_linux_arm64.zip",
+          "shasum": "303dc03eaf01edc2a6e44f0a33ababc7a40ea1bc23da29b0e2bdfded959ed133"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.6_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_windows_386.zip",
+          "shasum": "47d5f916b9e4656e0a5751b3aa42e3532243b4d4ab1056d393a7a7a318a22266"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.6_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_windows_amd64.zip",
+          "shasum": "dcec2b00b7bf1c1fda04ec61afa6f0ab7e074df4a0fb117db9799ac2145b9430"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.6_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_windows_arm.zip",
+          "shasum": "b13604b5fa07501e08d7c5667c413fe3c24406492d5249f6619f67ef4b916e06"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.6_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.6/terraform-provider-atlas_0.1.6_windows_arm64.zip",
+          "shasum": "4e057986a317fb031433c05c3bbceadff425c1204086aa3884adfe0596d473b0"
+        }
+      ]
+    },
+    {
+      "version": "0.1.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_darwin_amd64.zip",
+          "shasum": "4cdad5c927d6747d27c9a7920abab16966fd11dd9ab10e2c6fc23bf77bf92233"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_darwin_arm64.zip",
+          "shasum": "8f452b002f1b2e1e75da21e4eebe421cddb835c9568104c79eb1f8347127bdb4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.4_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_freebsd_386.zip",
+          "shasum": "714c5e000b4741cf48e27c7d53536c06578aafde6f228d835fc3800d7c895d5d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_freebsd_amd64.zip",
+          "shasum": "471468f5091213daa4827a7583baf08c402dd6160362701b4d96257d438428c7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.4_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_freebsd_arm.zip",
+          "shasum": "4d8d43182c4c331f1ba87c0fa007b15d912a3aa3ee6eee63135be99b61c780b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_freebsd_arm64.zip",
+          "shasum": "dd7d30a1d6c7bb2f679eb1919c1fa15c34398612a969fb009c31e3292fdadf03"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.4_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_linux_386.zip",
+          "shasum": "9333d62f9ff7e36572cee997e1efb1832436da5f4136c32597b39978cb9a9a2e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.4_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_linux_amd64.zip",
+          "shasum": "93060f9788016b199e08e4162dc1874daa01bbe1da2243c74e4d2ff870c3d035"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.4_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_linux_arm.zip",
+          "shasum": "4f3093f099dd06c77e8f28f1bf79c0c3c32e211534a42391cef40b25150aa8c7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.4_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_linux_arm64.zip",
+          "shasum": "f9f7b0de0ef0bafabd5507257b120117d74ff8bd50e3366cff5379189e40c245"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.4_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_windows_386.zip",
+          "shasum": "cb43edf5beb386fcbf0740428fe475f2622604b92fd9949a017b5fc7ea4645b9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.4_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_windows_amd64.zip",
+          "shasum": "80d32142bc9ffcd53b9b1b34564f1e74b1e21182ce13d205bb99482ba0e6466b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.4_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_windows_arm.zip",
+          "shasum": "0dc1c0d0a254b72b7f602ead1277717cc6120dac328ebb5739d8fa29527f9026"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.4_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.4/terraform-provider-atlas_0.1.4_windows_arm64.zip",
+          "shasum": "2908683be4312c07c03de37d54b16aba406916859e342dfc152f6ad2baa38c12"
+        }
+      ]
+    },
+    {
+      "version": "0.1.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.3_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_darwin_amd64.zip",
+          "shasum": "67ee7d65c0e337123d675d7e31e071172a0ab37141dc8d6617d203f6a8dc924f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.3_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_darwin_arm64.zip",
+          "shasum": "8680dadf18f5f33ba34f242b8dc0b641016a02360d02a38259e2d137c05d9bee"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.3_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_freebsd_386.zip",
+          "shasum": "796daa9bfa97b895bdae53b188ccdb961bf4eeaeb4e9efa99e657f4b2210791b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_freebsd_amd64.zip",
+          "shasum": "2304b1b23cc31b6f0c628f89b1e066dbd0f7e7f8c288bac35b44dd67a952b9de"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.3_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_freebsd_arm.zip",
+          "shasum": "a8d99b98b3c9a7662b7f70864163a5d3f7544aa6c82f6748609a697bfb813d89"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_freebsd_arm64.zip",
+          "shasum": "8a05bc8b11181c3741e13a9c293016cfb1abfe8fe080641e064f7b0a8df43ff0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.3_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_linux_386.zip",
+          "shasum": "a3b7cb1783bd48bccc1f123148f082b7d2d8fd51a2aa9eb93203aae1046063b3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.3_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_linux_amd64.zip",
+          "shasum": "355a879a1f0df7628d97bb1242a3479b987c1ef32d995b94989a32f7e88726da"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.3_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_linux_arm.zip",
+          "shasum": "36f198115c89ec1bec4cf44a298e00938b89fe1727dbcf7a79396a9f87498ba0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.3_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_linux_arm64.zip",
+          "shasum": "e18f2c58312343166a3e5541a299f445ee4c755850e171bd14086ec327f08223"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.3_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_windows_386.zip",
+          "shasum": "0a6e5e945eb09fb9183ba3e41aa7876c6b238b72eb9ec2d0e643e1a6813d05ce"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.3_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_windows_amd64.zip",
+          "shasum": "a8e0afafd0019369a9add0040dabb53b31ec44c94f3285032e6f720ee5bcdeaa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.3_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_windows_arm.zip",
+          "shasum": "7372a605478b26b39d95fade16a050e6842d9e2f23949a942c8fec320727e197"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.3_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.3/terraform-provider-atlas_0.1.3_windows_arm64.zip",
+          "shasum": "3e9b6097cc3346d65691ec0a7b6bc1bfd6cee20960c1b8a4f5e112450ee48ea7"
+        }
+      ]
+    },
+    {
+      "version": "0.1.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.2_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_darwin_amd64.zip",
+          "shasum": "8a21469bf502b74e70addacff05ff33c16192c6eb6ffac4a977ae43571bd8c2e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.2_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_darwin_arm64.zip",
+          "shasum": "398be4ab74a89f27723fcb86074a393677c6621f860b0e8295d309f091d56815"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.2_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_freebsd_386.zip",
+          "shasum": "b6f58284593de8b446f9525cb0f23fd0c5c88556156d5927058fa5479e6d858a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_freebsd_amd64.zip",
+          "shasum": "7da2fa0537f31830b13812fedc47df143012592bbde8d56911e1a96d61175bc8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.2_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_freebsd_arm.zip",
+          "shasum": "d97aa3d0a79c4eec0dcdc6698dc1c8477569226cad952c4aa164fd4e54119567"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_freebsd_arm64.zip",
+          "shasum": "ff18dd39724c1cbb74fef99bf388ba246a6c10a60942622dde78a045ded318cf"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.2_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_linux_386.zip",
+          "shasum": "0dcf6897acb6773e6bbf9348a3b6b80ceb41df07a2526d40fd66b9e5cb507eac"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.2_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_linux_amd64.zip",
+          "shasum": "5c87e93e10f47e5d764bd9986b06cb55b5287dff535c239d940d3ce2ce163813"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.2_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_linux_arm.zip",
+          "shasum": "28a332bfc1b57d607e3958268b4c99c812897188d4233019af4b6d7e74a07d78"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.2_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_linux_arm64.zip",
+          "shasum": "ed565f3091f9aca9549453ba2d68ea2d8dd399c8e2c67a95c04053c1c2c955a3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.2_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_windows_386.zip",
+          "shasum": "b65e0f96d97c5ad1091a348ad58c44943ad91041970debf578f44611816de830"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.2_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_windows_amd64.zip",
+          "shasum": "2b66f7a1515bb3997dd0787b3797dd9a401e11b46bed33b045fbffe3513f56ff"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.2_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_windows_arm.zip",
+          "shasum": "a730cac3a6b5cb225ac0d188c98d3152d15a669e7d037d85a12745b262de039d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.2_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.2/terraform-provider-atlas_0.1.2_windows_arm64.zip",
+          "shasum": "b3c06deeaf6c9297e2b4f1c72d6fe1783578e875296d6f6fdbf81104b43c5074"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_darwin_amd64.zip",
+          "shasum": "a3acf985a825e493b90f03885e8c295ba87ca2538bcf0091e1a39f3815bf1143"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_darwin_arm64.zip",
+          "shasum": "db15e916a76cccf16ab1d1f2cad0ac3d117410fa45d0c3521e1bf88e590525a1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_freebsd_386.zip",
+          "shasum": "3be3b5e24e66f5cdc53d1ef09e6eac92e758177f0eefd72df417868436e084cf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_freebsd_amd64.zip",
+          "shasum": "4e4336e983785b57f5e085bea0a167fc935bd365ddb09408349bc8ddf2b29df0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_freebsd_arm.zip",
+          "shasum": "da6dcbb741f5fc49ba12bad4ad6bb6501efdf3297c44f4fda3ac8040d72da6bf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_freebsd_arm64.zip",
+          "shasum": "d88818c8a040c1c3d6e649bfe7fd326d508fad508def9fd5aee9875c69d253e0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_linux_386.zip",
+          "shasum": "2e4de019401977835233bd75a523c61b21166b2d850de35a6d6356e3e73cafd4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_linux_amd64.zip",
+          "shasum": "91d7ee490c967f60f880c4442fa21fae5f9389844bdf2d325cdd6b84be90c1b5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_linux_arm.zip",
+          "shasum": "d151ad590fd6acd7c1519bfd72b3875f03c2df24a939b8395a7644f3b367d765"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_linux_arm64.zip",
+          "shasum": "19dfa6dc112d1ab4d0b7fd7c2a9f168dd9ba21bed1984c489896b8adaccbbf08"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_windows_386.zip",
+          "shasum": "1c9c7fefe95ed2fa1b715c13adf0a835b5115de8771e22afda92d1219bae96ec"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_windows_amd64.zip",
+          "shasum": "2b794231045e8850ea9417f1e413aeb1405586df61e44e5ecd532ea66baacb02"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.1_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_windows_arm.zip",
+          "shasum": "528d231c80efa241b663486419d099295735764697e6132b6e208e7a491dac64"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.1_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.1/terraform-provider-atlas_0.1.1_windows_arm64.zip",
+          "shasum": "51281c295071aaec4feafb997af7d9d2e57f8a8b7a69e94bf7184acaf579ad03"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_darwin_amd64.zip",
+          "shasum": "5aa34cd019e3440701149e3fa5fa8b942eb8f6218f622accdd2c342d3b72d89b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_darwin_arm64.zip",
+          "shasum": "27ec3e9870d9acf6f3087607af960ec74d6aac2107f42313dc7c3fdeb17d58e4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_freebsd_386.zip",
+          "shasum": "e83fda803fcd9cfd022daae05d8a2e491656b15538195f6e53b56c4288f3672c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_freebsd_amd64.zip",
+          "shasum": "68b375ebfe3994fb14968c54d73c0fbf2d05db0f87a1602a561c21a0b71c72ec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_freebsd_arm.zip",
+          "shasum": "2d93e70c68a40d25136fb7d77d1e86effe95d85784e19bab26e01993b2d07b7e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_freebsd_arm64.zip",
+          "shasum": "cc4e72978c12e063b10810ae5b9f2fa118db277f97801d3a6e6fc135a0781082"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_linux_386.zip",
+          "shasum": "dfb373c3485aad228b89ceb29cfccc44007ab3d0d0f00c29a9ae66e15864f463"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_linux_amd64.zip",
+          "shasum": "8ee097a17d7129643700a605246cc705035e9cd84e2a700f3d9e0ec50ed14680"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_linux_arm.zip",
+          "shasum": "46809eb43743d98beafa045c7ff907bac232465e268def7a3c184415d8bcf252"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_linux_arm64.zip",
+          "shasum": "2d82595db7f489b2ce122630879fe16e4b478f6ea6f3e2bd99dc0d4c6f91ca51"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_windows_386.zip",
+          "shasum": "93b8e9653850b5e5c39d8cffadda971559daa28d0b48a6129158dde7cbac81d5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_windows_amd64.zip",
+          "shasum": "6c7eeab0f6f65f478ce48529a8e8592abb7d990ef48976f253b4bf103d88046d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.1.0_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_windows_arm.zip",
+          "shasum": "e5f787096094e8e8c1d46b35954c1586ed84b2be56ea32a04eaf0b1a36629e89"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.1.0_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.1.0/terraform-provider-atlas_0.1.0_windows_arm64.zip",
+          "shasum": "1739922b15291a6ab728eed4a661cf0659a478cffd4efecb94d13460d6d6c7d9"
+        }
+      ]
+    },
+    {
+      "version": "0.0.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.6_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_darwin_amd64.zip",
+          "shasum": "2772cfdb1aae2bb10ebe7514b520c92e6275f4cc3467a01918bf51cea5555498"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.6_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_darwin_arm64.zip",
+          "shasum": "4235e674ed9bdc9afe6fa6bdeabcc591f29fab381f1649cb41402019a42a0de3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.6_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_freebsd_386.zip",
+          "shasum": "c653034e78456d620c7542a562ea73200a47c8f4023a35d64ca21583260d6c08"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_freebsd_amd64.zip",
+          "shasum": "2e9cd21c2e46e5c8e4ca861dc92ce7c9b3636300070fc1dbca613e3c88de38f8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.6_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_freebsd_arm.zip",
+          "shasum": "beb98a453da5ec6f5e380a7bd4736144ff992e6c416ddc1d8ff61dc610783c82"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_freebsd_arm64.zip",
+          "shasum": "336aafdfca094b91e95f8b134f082dee10b480554a870e65422b8323db0f92c9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.6_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_linux_386.zip",
+          "shasum": "bd333bf51b527aec5d8d3c8021e3a3077e76b4b04bfa1149df18c0f8558107c8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.6_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_linux_amd64.zip",
+          "shasum": "9c176188c92ba8b342c092678eba9c1a3dbbb8f86b7a50c445ad713b4539cd81"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.6_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_linux_arm.zip",
+          "shasum": "31590e5d89db5ed1050abcb91cb8216f38c2cf370644e1f31d1051b95971a268"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.6_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_linux_arm64.zip",
+          "shasum": "3c08cf7bdd123f1784535370053058d6845c1cea7b5bef667a56f1db62a65ad2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.6_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_windows_386.zip",
+          "shasum": "c53ede449df15c061f3375b55810895fa44f8573010e99e620c98ffde2b2262b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.6_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_windows_amd64.zip",
+          "shasum": "5deedaf62e81b6f93e7c9600463b2f9fed9859fbefcaa523c4140505b6fd5373"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.6_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_windows_arm.zip",
+          "shasum": "24973105e886ae9dc26448c115ef78ca9112a65c348324ea794d1eadc2ba04d6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.6_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.6/terraform-provider-atlas_0.0.6_windows_arm64.zip",
+          "shasum": "b7bd7c2989a821756234e01e0c42188bb155427df72413b3c63cc7e7935623e2"
+        }
+      ]
+    },
+    {
+      "version": "0.0.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.5_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_darwin_amd64.zip",
+          "shasum": "fcdf131342edc847bc5a38e9451778b669316fbdcf4990fbf8ed8bef749372b4"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.5_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_darwin_arm64.zip",
+          "shasum": "ca441e870647f68624a0f018ae210a0ec8f818d1b57a057c85eba6f6a125be59"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.5_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_freebsd_386.zip",
+          "shasum": "4644bd51e9de2fb72a73575e07e3cc74987cef7c7bf021c20149743409f84a9b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_freebsd_amd64.zip",
+          "shasum": "74d6d953f2b3335e20e48547d2f4163918710e90bebe4f97ca28cbf06262ddf5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.5_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_freebsd_arm.zip",
+          "shasum": "2e0d26d8346e9d3bbfe56f83ee5d4da390ed37331cf6ec480ec1d671ee6b4680"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_freebsd_arm64.zip",
+          "shasum": "70a679c4d8c115cb1ed462626f94f22d124984a1635aee1ded37960651a3c7d5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.5_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_linux_386.zip",
+          "shasum": "3c0c82952d6347e12a45b046fcf99847a7ffa049000310dd59962a50a8ee1b8e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.5_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_linux_amd64.zip",
+          "shasum": "a71abff41f765868b7a2f2c9f2c7c6401f4f65492b95927429e9a579f95122d8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.5_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_linux_arm.zip",
+          "shasum": "9d93122299b2b2bea99c248663da9327415773908504e0dc6cad12ba47069d4c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.5_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_linux_arm64.zip",
+          "shasum": "87c33ff0873c17402ad19beee5bb5a84972140665d6fa187d570a099d1c1b746"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.5_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_windows_386.zip",
+          "shasum": "030e784aea20c8f9cfcf8ee9815a881f7216214fde397ed04dfd47dae6f3b047"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.5_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_windows_amd64.zip",
+          "shasum": "6e6ca2d2c06c5a058e13bf63eb3921eb33482b80b2b6ffc919654318a8ec139c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.5_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_windows_arm.zip",
+          "shasum": "0cabc5772d814029e41a6adaef2f5b73fbec4056650d3d8a1692a233f355bb46"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.5_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.5/terraform-provider-atlas_0.0.5_windows_arm64.zip",
+          "shasum": "22404bdbb528150c30456a5910a1cdcdeb14699150d621826046fdaacb59227d"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_darwin_amd64.zip",
+          "shasum": "ed0c4ce6516bf1255b0f18c9dafc995fba05a84ffd0c897c90e406bfd1012a6f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_darwin_arm64.zip",
+          "shasum": "c35c78396b3e9cd068ea40ca40988e362707dc661e5e62aef5bceaa307569853"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_freebsd_386.zip",
+          "shasum": "373657378f0d24de0e5c07f099876a676436b4dfb90ea31d1868d896a56c5e0a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_freebsd_amd64.zip",
+          "shasum": "46bca3e35e32bac2ddde776e3bae348b04c8d4eedb70ae99687367a973bb096f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_freebsd_arm.zip",
+          "shasum": "47187e2e322c51aabb85ce27e445d136d22bf5411f7d48f8d760df24bcd088fe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_freebsd_arm64.zip",
+          "shasum": "2059dd53b2dba3b627242fc961c21d3e7b874b87dd3e9110a4ac4abf555a3ade"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.4_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_linux_386.zip",
+          "shasum": "8276bef2ea60e7fa822006fe9b0cbf309672fb57fe00046f2d6c5cb61e41d003"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_linux_amd64.zip",
+          "shasum": "dbd5a9778c5e8f9563e0c31e523632c6658e77cd080ad1b9eb28feed8de25994"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.4_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_linux_arm.zip",
+          "shasum": "a538edf59c906a98ce8b844a9993ab4fbb00a167b1b4de77db415e16f361f55f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_linux_arm64.zip",
+          "shasum": "9443cb36a67f47e0e34162dc0b596b91d3b3074ad1608fcdd6afed8401c9ccb7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.4_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_windows_386.zip",
+          "shasum": "4db136bb4067d8e5053b09c5307b5665451b33a5ecca3afad6ad8a6e9c8abc78"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_windows_amd64.zip",
+          "shasum": "4e8d16f22d3bc73277c54da28b6f259e6a12b6977f63d0cc96a224963b9a36fc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.4_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_windows_arm.zip",
+          "shasum": "2b1fe1025dfedb7169dcf69c092065e293f0f096817cae3571b2cdf0f7b8ef98"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.4_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.4/terraform-provider-atlas_0.0.4_windows_arm64.zip",
+          "shasum": "469b57800a181252417bad5e169743286808cbec548272bb4c95ca107013b436"
+        }
+      ]
+    },
+    {
+      "version": "0.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_darwin_amd64.zip",
+          "shasum": "957674984b402b21e3ca70ea1c691a5c520ed4ba1faf2c2e73225208bc8b705c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_darwin_arm64.zip",
+          "shasum": "7566f296424f5188027190ec3d4166778ec3deac84ac607b62b3d3cb6d521ecf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.1_freebsd_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_freebsd_386.zip",
+          "shasum": "4e633f1948bc7d2e026c7d883986fc385301a5b72ec6c94cec61f5f567d26ca6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_freebsd_amd64.zip",
+          "shasum": "1132b139f634fcfdee08fa693e47456a37db7174bbaa70a565de09f0a80b3894"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_freebsd_arm.zip",
+          "shasum": "43602665993e6c112b7aab130d7344fd51a6971b860220167feb0f26496428a5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_freebsd_arm64.zip",
+          "shasum": "46bf3a07ed11f47807cd951731bcdfabe3309ec67974ae832ae3b56eaf739848"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.1_linux_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_linux_386.zip",
+          "shasum": "b2d7ce01f8b0a535ba2ad32196c2716fd9a1f1870cc96e7caf19988419a840e5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_linux_amd64.zip",
+          "shasum": "62f29a8004f10325ed17d9e484abc40a09f880af5a0017c615e91c77562b8288"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.1_linux_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_linux_arm.zip",
+          "shasum": "d19ffc3cb51c89145ac287a5fbcc82f90881ea17d88fea64b31f724f37c0547d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.1_linux_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_linux_arm64.zip",
+          "shasum": "8876334f9be67faeab7f832939c81ac9cf9b444a8e850da6f97bd0ad70967c65"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-atlas_0.0.1_windows_386.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_windows_386.zip",
+          "shasum": "5806a0d2c4c5d9f7fd886bac3df2997c89a55740f7e051ece6e3e92bbe3a8f02"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-atlas_0.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_windows_amd64.zip",
+          "shasum": "d1e3e8f208399980d5ed912f23786d5b789d2f159ce7caa3d414b29b428d5b03"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-atlas_0.0.1_windows_arm.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_windows_arm.zip",
+          "shasum": "1b95413980aba5acff9ca35efc4df5ee936775debd527aa53ac71b011397ac7a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-atlas_0.0.1_windows_arm64.zip",
+          "download_url": "https://github.com/ariga/terraform-provider-atlas/releases/download/v0.0.1/terraform-provider-atlas_0.0.1_windows_arm64.zip",
+          "shasum": "3f602e4d46db7b0734c91e44df527ab1cd66c516eb3133b452dabfeb8afccfc4"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/b/Burwood/burwoodportal.json
+++ b/providers/b/Burwood/burwoodportal.json
@@ -1,0 +1,652 @@
+{
+  "versions": [
+    {
+      "version": "0.1.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_darwin_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_darwin_amd64.zip",
+          "shasum": "8d6b49f646cf3c5e0ed141cdffe8c21e0b59c268e631a947b1a3bfb0daf05aa1"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_darwin_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_darwin_arm64.zip",
+          "shasum": "34eccb423806085b73352d151fddcd713c74c1e9914dec5a255b9f55a9544d9c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.6_freebsd_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_freebsd_386.zip",
+          "shasum": "37f0ace022d2a751fff1e3ee0f8dadd3cd1b601d93273f2c02e96f64b7b09b3b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_freebsd_amd64.zip",
+          "shasum": "4567cc2b2d092bc49e5a74ad5c68ee5669705d38f291b5119a3c28d592b349c8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.6_freebsd_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_freebsd_arm.zip",
+          "shasum": "79bcac4fc8ff83a7f37fbd1f852c2d792d1401a471886ddfa7e930650d144c95"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_freebsd_arm64.zip",
+          "shasum": "35e96c2de4b25821dfb138998edc2c0edea1079a7cfc7750960d993a6a7f9532"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.6_linux_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_linux_386.zip",
+          "shasum": "55e97329e564871e4c0f6817f71aaf7e305373f8e97ee59341fcfac9e8d365a9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_linux_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_linux_amd64.zip",
+          "shasum": "ee4f35845418ee13ef78f228d83e98c0c198f7080232350f4bb5023e693b20a2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.6_linux_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_linux_arm.zip",
+          "shasum": "fdf250f7b4691404241e4625d2d4b9df225cf0ce35d47e68de71341a45ccd282"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_linux_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_linux_arm64.zip",
+          "shasum": "facf8de37d198514ef983a2063078a1ca2553ed8bca5b75e1ebf6bb4e33a8760"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.6_windows_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_windows_386.zip",
+          "shasum": "a81f12c6cddb179fbfd0ad6b911986e8d65b00f60c23c3e314fc6cc87f8f4fdc"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_windows_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_windows_amd64.zip",
+          "shasum": "4f680f733e0443896540117ef55cdcc2d6650ca3112b34ee7ced07fa5c39b0a4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.6_windows_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_windows_arm.zip",
+          "shasum": "72c76900fc3323f689b90df7583c83850eaa3fbb712971a69ae195be02442a31"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.6_windows_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.6/terraform-provider-burwoodportal_0.1.6_windows_arm64.zip",
+          "shasum": "4c0bf1e44238e41078e41ae624aa35f000f09d60f549b906a513b45b4201a7af"
+        }
+      ]
+    },
+    {
+      "version": "0.1.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_darwin_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_darwin_amd64.zip",
+          "shasum": "c1c29788f7c920731c1cb93fa52bdfbd43275c722c2803261f7cc3249ec93ba6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_darwin_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_darwin_arm64.zip",
+          "shasum": "49ba02903887f8273de330088bc553c7a396fb2b64d4efdabbfd0f21f35ea58e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.5_freebsd_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_freebsd_386.zip",
+          "shasum": "72b5e40967aa6af4c5e352340c6827c3ddbb5cc0be2e5431a5b21175cd11bc34"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_freebsd_amd64.zip",
+          "shasum": "6f9d098c4153171936ed12b3398c8b52d625d89b2fa197bfb5bea0e3ac8cfab8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.5_freebsd_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_freebsd_arm.zip",
+          "shasum": "42751286bfe939b9a75772d1de850002057a6e1aa8c969e482f54ea894b13174"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_freebsd_arm64.zip",
+          "shasum": "2148df3a78a1780e368e8428451dbbe8e26c68f6b3f467415b7ce3d1ac771fe3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.5_linux_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_linux_386.zip",
+          "shasum": "d853e1faaf32e5c52c4d4c26ffcb16e0c6f92cd2d2a193b6705e4359d1aa5b4d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_linux_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_linux_amd64.zip",
+          "shasum": "54c5acff0a0ad227499c0565ee0c10ebf07b30465af7433d1b9126f6d625181e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.5_linux_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_linux_arm.zip",
+          "shasum": "f38df2798b24ebfed16bba749e9c24fe76091efb4ffb74815188a1c2886b7bca"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_linux_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_linux_arm64.zip",
+          "shasum": "be654e6a168e01321c71c8736a9ca485193cb5fa4e64a686989c11871c226081"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.5_windows_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_windows_386.zip",
+          "shasum": "80baa40639d3fe058382783e07fba224c3ede62bde6f2639aa488c0a94f2530c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_windows_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_windows_amd64.zip",
+          "shasum": "9cb34cdb003080ca991996b41dfe8a60718a7a7b69ae200d3eca9ffa07549861"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.5_windows_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_windows_arm.zip",
+          "shasum": "b9408684a96c5e81c00b2033cc73d5b60063cf344929f250fb143b46d421bc94"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.5_windows_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.5/terraform-provider-burwoodportal_0.1.5_windows_arm64.zip",
+          "shasum": "50b10cdd6d44d1a038b23d2ebe09f5240afee33806840998a5e2ecf387e98f4b"
+        }
+      ]
+    },
+    {
+      "version": "0.1.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_darwin_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_darwin_amd64.zip",
+          "shasum": "aa4dd2482f1338299fca729182f2e8df42bf7e8dce4adfa291230caa22d3fef3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_darwin_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_darwin_arm64.zip",
+          "shasum": "cdf2ba6b2052f87e798b20b78b2062d16ac88df4df0927e7cd4572f59e7b7406"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.4_freebsd_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_freebsd_386.zip",
+          "shasum": "16fd6e1891aa14ccaddfa4d2684d8a5beb143a0e5b76016b0b3181014ab9f935"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_freebsd_amd64.zip",
+          "shasum": "1d012c0dec7b43f0b6f9f60a99ef37677bee367a44f9bd81e89969d76e4989ca"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.4_freebsd_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_freebsd_arm.zip",
+          "shasum": "043adcfff99caa0802b4f3be89748fdc69603e66a2d99120c0992d3b32141b61"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_freebsd_arm64.zip",
+          "shasum": "81c960f72e24fa2edd3f6933ce966121c20a2c2844683fb0f30d79063438b912"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.4_linux_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_linux_386.zip",
+          "shasum": "58ed9bd3c128a1bb3773c2476f2dd15caee533ae52ca1105f29cc58c2838faad"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_linux_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_linux_amd64.zip",
+          "shasum": "2b57264df09bcdd6b20343f06459e074213dce81c168c1a34374fa07e9197811"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.4_linux_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_linux_arm.zip",
+          "shasum": "57f510bc6296bf04e6be7540823478588635538772edb8329e80f11392353a15"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_linux_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_linux_arm64.zip",
+          "shasum": "79cec15349d90a9e672e820bd945f22ce8d2e8809fd2fba5863fb62526f697ea"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.4_windows_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_windows_386.zip",
+          "shasum": "66dcf002f5151698c0477c8ff54e0e9f666f578b6f2464be234184951fb90bbc"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_windows_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_windows_amd64.zip",
+          "shasum": "18c3d7456f398c18501a36763b1c1cc75a4033c32d0e68bb8cc110db31c4634a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.4_windows_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_windows_arm.zip",
+          "shasum": "b60708aa6f9834a1a9bbc8950797036feb7d376cc69353dd8fee867b74b41ef2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.4_windows_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.4/terraform-provider-burwoodportal_0.1.4_windows_arm64.zip",
+          "shasum": "caf21711baabac2c5a71553c60f0d8ddbb203647b1f922d5425fd117fe25acdb"
+        }
+      ]
+    },
+    {
+      "version": "0.1.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_darwin_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_darwin_amd64.zip",
+          "shasum": "a8aa4fff6d0fc495616bbe37b488f1c3dbc63c8fd17eab97583a631d178b6b83"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_darwin_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_darwin_arm64.zip",
+          "shasum": "6edc0d7f569d39453da35b454fa77904d7f082881e7960fce93327161639ef88"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.3_freebsd_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_freebsd_386.zip",
+          "shasum": "eb458c73ccac7391fd6523f436fe1bcf9e9ef2a90e1af1c7acd8a4d719e48da5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_freebsd_amd64.zip",
+          "shasum": "9e4fcea2491d92add02fc6ef7c169977febcae0c936761bfc7e194fdfc5bcfef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.3_freebsd_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_freebsd_arm.zip",
+          "shasum": "558c27f4e8a906e713875e45a15000fcaeee1587619b48b5a28e0c26ad984375"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_freebsd_arm64.zip",
+          "shasum": "f6a32d81879de78b05337cd363f94f72b375f1c3c8b32c3f9bedfa6e7dfa2738"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.3_linux_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_linux_386.zip",
+          "shasum": "a5acad7e891b701d1f76d8086cec8dff70ac995bccc4992aa38f0166daf79b03"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_linux_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_linux_amd64.zip",
+          "shasum": "cd31da93dd63d2c907a5acbdfe3aff86ace309e9d4d32406e5941c250720648a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.3_linux_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_linux_arm.zip",
+          "shasum": "3b621f056b5a22f1ce11e882af4be32dd7dedb19e1d8f165aefddc476ab496dd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_linux_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_linux_arm64.zip",
+          "shasum": "182bbe57e6f4ef5ca3ba04549d5fe333b6f08cfa63a5e4f95638b2bd0dabc3e2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.3_windows_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_windows_386.zip",
+          "shasum": "561816173a61215ba80b3b580745f022fced4b18752105866b1f56387edb51b8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_windows_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_windows_amd64.zip",
+          "shasum": "eb6c4d2e165fe69e5ff9fde5f7fad54e049381fc2449f0b55424b0f1449ca6d7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.3_windows_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_windows_arm.zip",
+          "shasum": "a825af34a603ccef884c42cd09c316aac291dc34a64d3e0f3eccdd9435df1bb5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.3_windows_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.3/terraform-provider-burwoodportal_0.1.3_windows_arm64.zip",
+          "shasum": "69202e77f0b93cb8d21adcae503def46879abf65a492a2377b523412419dd4c3"
+        }
+      ]
+    },
+    {
+      "version": "0.1.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_darwin_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_darwin_amd64.zip",
+          "shasum": "64b1bbfc431f4d546dd926fa38098b2a94fb6960238fa3325e083d5ba9938277"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_darwin_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_darwin_arm64.zip",
+          "shasum": "fd59e012bb9c61ee63d38637e75e6dd2086bec9e63709e3a194da59b4e83c63e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.2_freebsd_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_freebsd_386.zip",
+          "shasum": "ee333430f35bbc7d8cd24a890cfda237a7d9a7f5482218c76321b31230412905"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_freebsd_amd64.zip",
+          "shasum": "a2a5e4af4733024ceb84740783dba0d7bb5efdf8d786879ab60c19573eb5ce1e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.2_freebsd_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_freebsd_arm.zip",
+          "shasum": "1ad6f9ac469d824315cddfc707b8be4552f53587144402f176cdc412a056f16e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_freebsd_arm64.zip",
+          "shasum": "963a6ca5bc3413aa749caf3e9a744376c531ee27d9a83cc758aef7e168931b26"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.2_linux_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_linux_386.zip",
+          "shasum": "71d5b47030fa95dd9e1b7beeec6dc236393f66e6052f876a89a0d269151ce363"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_linux_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_linux_amd64.zip",
+          "shasum": "68c62ea3ff9d979740e636a655b2342552a54fda3dfa50dcb89138d13ba26a6f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.2_linux_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_linux_arm.zip",
+          "shasum": "a690497dd24583fa03fbfd9c6c81fa80586ac41d482215022d6d6f61de1bde02"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_linux_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_linux_arm64.zip",
+          "shasum": "0bff70d09b1ccb0e93466e9aa96292614dc65d2a4a17ee473acf6e40ae4a3b51"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.2_windows_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_windows_386.zip",
+          "shasum": "32dd54be19d7c02fd44c1806a7b2e7aa994b97102a8117cc1f6ec6f94d4986e1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_windows_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_windows_amd64.zip",
+          "shasum": "b3a90a64eab15f828f77716b9451465d6ceb6ec606afe943e057a2d2e5736e80"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.2_windows_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_windows_arm.zip",
+          "shasum": "c57ed9f10cc707ea6113952047258ab9ea61bad8c8f3d7a19ce5764469db59da"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.2_windows_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.2/terraform-provider-burwoodportal_0.1.2_windows_arm64.zip",
+          "shasum": "8a9d1017d652f4365a6c23c24baf1729835b39824fef863e32058b6c4727c45f"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_darwin_amd64.zip",
+          "shasum": "26976898d706216d6bfd2eb7277217739564be6cc924e9c6ebf532a6a0bd7735"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_darwin_arm64.zip",
+          "shasum": "46f4216cecaaab8c7cddd31d6046d37697f9a870823efa008ae46d730414d890"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_freebsd_386.zip",
+          "shasum": "3511008d4ca1ff509ec7f66fbdacd7240ffb6e039eb9450d8bd66bb71f325af4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_freebsd_amd64.zip",
+          "shasum": "c2e58a6cc505af4dcaca5f44dc3cb09fe717033969b036dc0c0e03c42d5069db"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_freebsd_arm.zip",
+          "shasum": "94ec038f19add6da0026585a21c9e1e16bf3cca81a60b672da750c769aeb9cf5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_freebsd_arm64.zip",
+          "shasum": "12d4059efd1d86465ddbd59fe96ab6990e7bb562a194757943b9bdd703b7b2c9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_linux_386.zip",
+          "shasum": "466827ca40985be1e4ad345c6331613cfce13125a6c056753b67aefc90367286"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_linux_amd64.zip",
+          "shasum": "1eb5107e1729497c0d96af8b3224f0ef34523bd63d3faacafeafa1f07b7890c0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_linux_arm.zip",
+          "shasum": "916456fa3592cba902692f1f4933a460597bb4b700273725f51a9228725421be"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_linux_arm64.zip",
+          "shasum": "645fe1fb6eee3809d6c241a7428def23f94b10d5f75b46c2e5d635b65a85befb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-burwoodportal_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_windows_386.zip",
+          "shasum": "f9769b7292802b34b5c85ba324a8204dd0aca82f3e146fee9b53e0bb6dcb2734"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_windows_amd64.zip",
+          "shasum": "96b6aaccc0574a309e296cf71e48cdf9fe81d38c9392acbc25c4e95a13b7609d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-burwoodportal_0.1.1_windows_arm.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_windows_arm.zip",
+          "shasum": "b8315b879bc4cac9b8ed767019f8ae5fe93404b1c898cccbc95d56980f4a655d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-burwoodportal_0.1.1_windows_arm64.zip",
+          "download_url": "https://github.com/Burwood/terraform-provider-burwoodportal/releases/download/v0.1.1/terraform-provider-burwoodportal_0.1.1_windows_arm64.zip",
+          "shasum": "79d6ed3b8c0a846eb2832c80b05d064064bddecdf95af0cfa128a79d8d376ecf"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/c/coxedge/coxedge.json
+++ b/providers/c/coxedge/coxedge.json
@@ -1,0 +1,2704 @@
+{
+  "versions": [
+    {
+      "version": "0.5.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.2_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_darwin_amd64.zip",
+          "shasum": "94f5a72057d4ba1c2d21ffe63aa0a30a0c424203918fa1d47baf7fd502ee687f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.2_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_darwin_arm64.zip",
+          "shasum": "fe0a03fa7acea7c9b4e904c80a1ed3ad979fa1e43669f5dbcbd92f20736e9e4b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.2_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_freebsd_386.zip",
+          "shasum": "45d3f4c767c5a71de639f49705623b1f929378c4c8fa0fff508d5b52c2221150"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_freebsd_amd64.zip",
+          "shasum": "fcc8d8fb16bf714ca19a43051e853511659ac616a6da1c3e031bf63ee40a619e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.2_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_freebsd_arm.zip",
+          "shasum": "a0dcb08c5923a99e8968fbde9ccb6e95bb4ea95a42c05bf31f3d36bd8ba9b618"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_freebsd_arm64.zip",
+          "shasum": "6cac888afa93e7dca497ce296b97166f1a304cf18748e0a66812059a7195473b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.2_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_linux_386.zip",
+          "shasum": "7bf81db57020eab5e4d172ccdf6b32d784c5abbf1308d206b7dc9d4b09513cc7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.2_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_linux_amd64.zip",
+          "shasum": "38e80e027f05a97d205ff82a97da7f87cea7d587672b65935ec5204dd4eb45dd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.2_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_linux_arm.zip",
+          "shasum": "500c293ca09a9f4b1d2111fa1bea75ffde9e5c2ac6320d658f47f2cbbfad6352"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.2_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_linux_arm64.zip",
+          "shasum": "9ff9321a4421cc51e085dcbb5d9d5e4a94f81e1017459ed4e94c320429ee8fff"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.2_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_windows_386.zip",
+          "shasum": "ee53aaffdf2c9d8c66992dc5cb834d41f5e63abad64843f855f346b0af478120"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.2_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_windows_amd64.zip",
+          "shasum": "a21a40719d66d8ebc480d647e2e963ba6b49b0945e1f49d5e909cc91d982c8d3"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.2_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_windows_arm.zip",
+          "shasum": "d93273395a0645786ddf5f9c90f0b25409863a873d57dd9c363149a718948319"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.2_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.2/terraform-provider-coxedge_0.5.2_windows_arm64.zip",
+          "shasum": "798bd775e0ff6735e190740ad97056a96a2c86ddee27747da1b880b0b1b39e91"
+        }
+      ]
+    },
+    {
+      "version": "0.5.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.1_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_darwin_amd64.zip",
+          "shasum": "6bdee724fc10e836f8f178752672e1d4aea9504082030b102ff29ec741e7d723"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.1_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_darwin_arm64.zip",
+          "shasum": "97e5c0799c562e61df655d6141b15ac589ae6bd1e07712662cb0ee966abc4b39"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.1_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_freebsd_386.zip",
+          "shasum": "d3ffd4fe82cd2f1fadd2b5207fb1f4d866f2cd2bc87827f980f45c21292de105"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_freebsd_amd64.zip",
+          "shasum": "9dd261679a002daca3214ebfabbc07675888f769bc56b64935c4cd06008c4bc5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.1_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_freebsd_arm.zip",
+          "shasum": "ec1d0abc5d449dd496b14f3b1020dfedd0640396dc8a6ebdacdbfe93b6517143"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_freebsd_arm64.zip",
+          "shasum": "eddecb3999e3b4a870fbc26d2be482e4b59586a4790a412b59ee873a787f2ffa"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.1_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_linux_386.zip",
+          "shasum": "6f92be55a5c28a390df869f602f3aecbe5d2d8a79305a964673998a9a239ad82"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.1_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_linux_amd64.zip",
+          "shasum": "12ce42acfa9473024c19e7c4e48485ec113f31b9d71c9a12e5e19dea72a3ad94"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.1_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_linux_arm.zip",
+          "shasum": "133e6929cef639a3880a4a50aa6c2f7939768895c0bfc4acb3a3619340352459"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.1_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_linux_arm64.zip",
+          "shasum": "f8ca5dd30d0bcab015c1d6b5cd8bc972b527969e5fdcf21f3d57770f9fe83fff"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.1_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_windows_386.zip",
+          "shasum": "e19f37f7dba9d45b9f0b54c04b22471ee5aa43d474bffb14df93a625a56a6179"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.1_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_windows_amd64.zip",
+          "shasum": "1b58c2e7f76d23b135a005304801f72beab0a4537d866692947e46bcd6ae47c7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.1_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_windows_arm.zip",
+          "shasum": "f9dcca516fa2228092fcd77dc072e88fe8e8d2d8b81fd6cffa7ed0bbb17bb15d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.1_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.1/terraform-provider-coxedge_0.5.1_windows_arm64.zip",
+          "shasum": "d0e993ade0b6b7d55a04a1855b524ae981bad0bc29ac757b47f3d6f5732f7a93"
+        }
+      ]
+    },
+    {
+      "version": "0.5.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_darwin_amd64.zip",
+          "shasum": "f1025f0c06de672f2d238c32ebd2313dc4160c52496f6376c30191034365fa1a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.0_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_darwin_arm64.zip",
+          "shasum": "55cf1a423f71bfec7d32311f07934edb6f1da0108bf7f9145e65d16804714ecf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.0_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_freebsd_386.zip",
+          "shasum": "d2fc6adb0c1978f8acafb06428c6f41174e94d79d4a2ab9fbd71aaaa71bd3b53"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_freebsd_amd64.zip",
+          "shasum": "2a822874a3db37be3807a757ea5a1945efc268c83ad25a6f43c174fc80f84d3d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.0_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_freebsd_arm.zip",
+          "shasum": "bbfc428afa81780422c5bcb7f267f7c0714f97ae57c060987c6b7317e833d3f3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_freebsd_arm64.zip",
+          "shasum": "31e448dde64e9719b1d851e2a040aae016e7b37cc81e990700af8e31ccb9eacb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.0_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_linux_386.zip",
+          "shasum": "7e5dc1b6d4a0a2b361b9321d395f3e98df294a5e84fd547c8bb7d68c19286149"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_linux_amd64.zip",
+          "shasum": "340a8b2a101947c52477253a57cf8d7c2025ca86ae502ced84dad50f483dfbc2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.0_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_linux_arm.zip",
+          "shasum": "28c08a4b89bc80a099018fa1007c8c46fa031059eee61154544f4f8975c99366"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.0_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_linux_arm64.zip",
+          "shasum": "06ab585e834cdd84f72d6b67748c5a7d51d44644d8f1b551d47410762a3012e2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.5.0_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_windows_386.zip",
+          "shasum": "05fb2785330af2526cca2ecb69da48e68a5616a8fd42bda119c46f1737581c56"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_windows_amd64.zip",
+          "shasum": "2553df51f31f73d70ab754d1f1e5952a4219c66ec75238940d5f4a804da722e5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.5.0_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_windows_arm.zip",
+          "shasum": "cf6090747c20420981947c337dd54ab85225d3cf6dab8ce418e0aa89a4c5f1ee"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.5.0_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.5.0/terraform-provider-coxedge_0.5.0_windows_arm64.zip",
+          "shasum": "119c742627042e827d577deacef3ea415bea5380f2b7b163ac4e7df5ab289c8a"
+        }
+      ]
+    },
+    {
+      "version": "0.4.9",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.9_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_darwin_amd64.zip",
+          "shasum": "efa1a2b9aa0a49dc1bdc47db1722fb642b59ca7bbb81dc83baa6c2ebe75096e4"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.9_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_darwin_arm64.zip",
+          "shasum": "66acc1b55d6ca3df2b01227a4cfb44d4df0574f7306f0fc16d25d6f5aff0ee3c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.9_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_freebsd_386.zip",
+          "shasum": "4774d4626095b04bd4b116ef3b3fd65abf05278536692db4aee144981b38fb8c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.9_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_freebsd_amd64.zip",
+          "shasum": "66e294214e6f3356496f9237a99f87e26b80d2df02eb4e8d4d40d8217be1fa35"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.9_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_freebsd_arm.zip",
+          "shasum": "e53117d674c79c6bb30758048f2bdbd321a74465df32d9c5a7d3695646daedf8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.9_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_freebsd_arm64.zip",
+          "shasum": "77b58edcbf2c0590b769b5a0fb8de292d8f2cb85eefc15306ebdc331b65f6e22"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.9_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_linux_386.zip",
+          "shasum": "13e22e37aeefc773bb4d5d20fccdf0b61a2ec9ea7cc56e84df467b7423016d41"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.9_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_linux_amd64.zip",
+          "shasum": "a26b1175fc1cfbe6c5c177ea14f5131329f8eb1c33fbe919790d13963321cb9c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.9_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_linux_arm.zip",
+          "shasum": "b0289571126be6774d9d73f335b2e71e3f1e60f672646cd607e929a8022c17d0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.9_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_linux_arm64.zip",
+          "shasum": "6e1e32d67900f0a11f2d7f1192753f7d030dee14cc07193a0b0f62b16ca5f476"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.9_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_windows_386.zip",
+          "shasum": "846b3a9cd0ba736e3e4a321e89d50ff7281cb0b992e45b83c473a6d5fcf3dc16"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.9_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_windows_amd64.zip",
+          "shasum": "61efbb7294050717e68b1d21ae847d5d2550ca1218a2782dafca480c4ca1a6fa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.9_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_windows_arm.zip",
+          "shasum": "850a4d7319fa99915df174d1643862aa2e2031c6516d1d258ea9bacd0bf44879"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.9_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.9/terraform-provider-coxedge_0.4.9_windows_arm64.zip",
+          "shasum": "54ee6adce06ff0ed44aff355c861c915dca5e2ddeddb7fac3b9407746df57ee1"
+        }
+      ]
+    },
+    {
+      "version": "0.4.8",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.8_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_darwin_amd64.zip",
+          "shasum": "e42c106550fff081d1952d040d42e3e146d8521b14065cc6539f95be9c865ad5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.8_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_darwin_arm64.zip",
+          "shasum": "44120e2cc3f04a75e15cf97cb00a73bf2df0dc1a15b8207d731533658ada198f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.8_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_freebsd_386.zip",
+          "shasum": "bf9aca3f90cf4933a63e1eb0b204e62bdadbca3e5ac0e9b5b72665bc36e95e97"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_freebsd_amd64.zip",
+          "shasum": "65953af41e79d951686e57be0c79a5aa943177069db32ca0050c68554b8907b5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.8_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_freebsd_arm.zip",
+          "shasum": "6eae3ad7b6095101c130eb23c2bd14df384fe2eba8768c9efa1c1402dd26e8fe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.8_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_freebsd_arm64.zip",
+          "shasum": "fcb11e433d4dd17c471d36bc0071b6b62ce1f2a141c6249dcae605019521f604"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.8_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_linux_386.zip",
+          "shasum": "4be968934a427b9c127a652474a087286b1f102830247061b11ae09b71462b67"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.8_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_linux_amd64.zip",
+          "shasum": "844769ef2c0cc923d3cc4b6aa7fb1fd5c930ad1555d47a518d79647659789574"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.8_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_linux_arm.zip",
+          "shasum": "7fcccc806105074a2d6123de05e7e72dcde08c17624889899d1887cdf1170ccf"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.8_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_linux_arm64.zip",
+          "shasum": "0caffc66c79ab71beebc1c893ac05dedff4837036dabdf0f286cf5d3bda550a0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.8_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_windows_386.zip",
+          "shasum": "585469d890566c24629a3c522c63ab82871f1cbc3a81f6f66129d34d430ff621"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.8_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_windows_amd64.zip",
+          "shasum": "3ee9e475ceebeebc5e66fb7391fe157495d6c9e8d11118ff5f64cec9697a6499"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.8_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_windows_arm.zip",
+          "shasum": "db90c44696cad80182f2170b9fda9267e60d379a6e38c65885843fac57a864fa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.8_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.8/terraform-provider-coxedge_0.4.8_windows_arm64.zip",
+          "shasum": "c000188ece6d7c34593e4e2953971aac921383163425a63e786bf6bf1a1858de"
+        }
+      ]
+    },
+    {
+      "version": "0.4.7",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.7_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_darwin_amd64.zip",
+          "shasum": "090d5b0599dcda2b43ae58c19649d0151cdb070212c629832bb9e4033df4c25a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.7_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_darwin_arm64.zip",
+          "shasum": "c0e8babbc51530e5573b0ed58df9c0d1fa95ea83f85978b8b3eeba2ca28ea384"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.7_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_freebsd_386.zip",
+          "shasum": "105ed5935d94ae3e95b66bf6b1454bb905c4b36b659730a0e03d936080b637e0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_freebsd_amd64.zip",
+          "shasum": "1733a2edd2dcd785efd2309c2255288390aca4ff05bb6f8449e3aa2fe27e83d3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.7_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_freebsd_arm.zip",
+          "shasum": "edc86ac046489aa0b4406cf05986d918364564e0010c3d4e8347078f8fe59849"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.7_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_freebsd_arm64.zip",
+          "shasum": "fc6930597799ee569a1f89849c1a0ddf850c2b852bcb9479f092c79506fd83f0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.7_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_linux_386.zip",
+          "shasum": "ef797b73722b2aa08d101b4f6ec347d0fd35163fc05a83000ffd41299889e289"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.7_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_linux_amd64.zip",
+          "shasum": "017037746edf5bcf840f2fabb359e64c68fb8de266454d87469a327b1e6fed63"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.7_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_linux_arm.zip",
+          "shasum": "4f4b0b96c73bc0058eadfcf1b47704b150df03d2dcb30ad744dc587a78871fe3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.7_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_linux_arm64.zip",
+          "shasum": "e0115c36a232a2eede03df40b76cb5612ab53f9ede62d027cbe03d56a9cf12db"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.7_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_windows_386.zip",
+          "shasum": "d9db261617ea5eed17459889f821213b6b41a6f1ac3e525575f1c57d5e57a926"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.7_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_windows_amd64.zip",
+          "shasum": "01c4f06cad0bcad1a61819be5c1e9aefa3bcfffed56cf77911142781f35cd8c4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.7_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_windows_arm.zip",
+          "shasum": "c24c540784fc4f4af94ac64377e5cdab61c77235a985dcd6b713fec0e0321e80"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.7_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.7/terraform-provider-coxedge_0.4.7_windows_arm64.zip",
+          "shasum": "bb8e5029ec12bfa6a6d7f5ce6341c19f5ac33e96265a8ebae9f5351005c5ffe4"
+        }
+      ]
+    },
+    {
+      "version": "0.4.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.6_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_darwin_amd64.zip",
+          "shasum": "6e76c39df0e827688c33289b5246fa0b4da09da5d342a855b60308206cc7f9ad"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.6_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_darwin_arm64.zip",
+          "shasum": "9da33b57bec7f34e8133f9f8aa13ada5fc1738dfba57cd9abe66367110dffe5a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.6_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_freebsd_386.zip",
+          "shasum": "4258301c205a1acd52fde1cba74ddb143f3eb9d022b98337832047856bef7eb3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_freebsd_amd64.zip",
+          "shasum": "1822d7130f84ad3f917d31554dcb04229896d01d38382df6cffb54fb1d881ce7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.6_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_freebsd_arm.zip",
+          "shasum": "46e8344139dcadf413b81cde9215be1efd9114018a3c40822ea3ef52d5b750de"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_freebsd_arm64.zip",
+          "shasum": "58251cffa3647cb4cc1f11fda2b1389c3fc4c0632fc55bac95d3b2f2a9a91f9a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.6_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_linux_386.zip",
+          "shasum": "e7f7914e13e8cb29570d8b2e96540fc23ea8a9a32371fb891659cb46f463528d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.6_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_linux_amd64.zip",
+          "shasum": "f3f0b73714b6e4e794761c4a370bb6d076df80247355fcc74f6ff6496d30a174"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.6_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_linux_arm.zip",
+          "shasum": "735f8f0b71e40a4a542f4ee02e0ba51a6d453f219c2e897d0909e501606b4ab4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.6_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_linux_arm64.zip",
+          "shasum": "2b93988cbecaad135c6373e8d7981b24fca51fc94c46a25a95e966b424b56754"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.6_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_windows_386.zip",
+          "shasum": "5f39dba04bf3dbca38d160d58602bf546543f3810bc47d5390d06a18b5157af4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.6_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_windows_amd64.zip",
+          "shasum": "65795532a7c9070fd0db53f61615aa81ba9460932d4c65050dc196c10bee474b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.6_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_windows_arm.zip",
+          "shasum": "3f6bf5ad68c51dbb0fa1a9a0a0e94abc51fcd684b3b971017d0283b87021d782"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.6_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.6/terraform-provider-coxedge_0.4.6_windows_arm64.zip",
+          "shasum": "755b1cad965bd5b06985d58d1d109b998aeb9c182ab8ce4da4dfc4496a06c039"
+        }
+      ]
+    },
+    {
+      "version": "0.4.5",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.5_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_darwin_amd64.zip",
+          "shasum": "3e49540a9cba572af47f191001f2f4bf2a053a79a2deb9fee650d7b4dccda5e3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.5_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_darwin_arm64.zip",
+          "shasum": "0239d1e4f692de645e6632b7f02f40a4eeace62e63f8e9333ff13a0e2c406e1a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.5_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_freebsd_386.zip",
+          "shasum": "5cc7404bbe29de62923b9bfb65eda1b314ab154c3e314e144911b826a86b5c3a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_freebsd_amd64.zip",
+          "shasum": "9321b59c04e9c04198793df7ec8e1d519bfcfe769e43eaea55188a3f487d311e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.5_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_freebsd_arm.zip",
+          "shasum": "79e2de31c990ce612242e6ea71d1fcd7aa6112e10949de3713d734fa6311240c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_freebsd_arm64.zip",
+          "shasum": "b273acebe42e09301aa74071b32b16f2655d8225e90089d57265d29f36461166"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.5_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_linux_386.zip",
+          "shasum": "a8899b482823153cdbee7ada533db1ade9f52c5b24361ebd32405bbe537a6991"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.5_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_linux_amd64.zip",
+          "shasum": "da1ba5330997c4608d4ea9a49fc7d5368d316452f186f2da564a3d93b1148a9a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.5_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_linux_arm.zip",
+          "shasum": "6728a2b23ab663ca3cf9b58580106175822c3b881a8d746bad73379a5fcd7aac"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.5_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_linux_arm64.zip",
+          "shasum": "d0942eda8284caafbe801d23f72f5f3cded6c02c5c8dfba12eed083fa290b20b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.5_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_windows_386.zip",
+          "shasum": "67c1539a227383828227c06bbd38b94b61d0718c0c7d1078e2d24a56bd94482c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.5_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_windows_amd64.zip",
+          "shasum": "0cace90cb6e95b8e0f69e1dcf37a88056cf7b882855dda80d0a92906c5af5828"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.5_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_windows_arm.zip",
+          "shasum": "a575642391059a5cbfa0aad0aab157f890478e0cbfcd9234e772d168cd60ecee"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.5_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.5/terraform-provider-coxedge_0.4.5_windows_arm64.zip",
+          "shasum": "20604bca97fdcb309f3db788fe54d59dd740973bfb44fb41f40af7b7f061d939"
+        }
+      ]
+    },
+    {
+      "version": "0.4.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.4_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_darwin_amd64.zip",
+          "shasum": "05a309d547c7107a5e172262619c0445c32e7cf283e46aeae7330ffa19f78d41"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.4_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_darwin_arm64.zip",
+          "shasum": "e5a02ec25529d7dd93b55195138a2c1b1e897afb90c2b88a9bbb7126da0917bf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.4_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_freebsd_386.zip",
+          "shasum": "d12a375230162282bd9a36e4dcd9639880271c60f6f553d44f3fa64465d9f1d2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_freebsd_amd64.zip",
+          "shasum": "5932fdc0c1ae51125668cf8ae6b5b07ba19583082533383f7da5500de20db52b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.4_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_freebsd_arm.zip",
+          "shasum": "3171e624e76e9a1e35f86b7972b57163b7f04002f55c13981c35d29834a5189b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_freebsd_arm64.zip",
+          "shasum": "e56a2d955604c48af98bcd1f7d7c2c41d769815ff25c4e5d592a88d3ac168cb5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.4_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_linux_386.zip",
+          "shasum": "37d29948e948a43acc66381fe501348bec750e739fb42c1e2f0bb8f791b000c2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.4_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_linux_amd64.zip",
+          "shasum": "6f81c11832feab06b67513a2347f50785ee417a0ce66a93e711a8ccacb939ac4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.4_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_linux_arm.zip",
+          "shasum": "f8f9b1b10cf9853c8ecc8ff2b2acf20065ad4658fd18b4a0e3fde03b1dd37ea0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.4_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_linux_arm64.zip",
+          "shasum": "4d9aa574b92c5a32d12fde6ce048a72f47c92650c2b4118b11237944a402334b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.4_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_windows_386.zip",
+          "shasum": "9c15846c1459491bc16e970fb155bac96b5edaf3bfd687ed7ce1803da17deb78"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.4_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_windows_amd64.zip",
+          "shasum": "f1ad8b5d1081a0fe470f35f4ba40a722eca59591c55043561e692ad36a6e6982"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.4_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_windows_arm.zip",
+          "shasum": "8ad0664f98a36ec1a30612ab1e7b091708a3d5cdcad147980c09f499f0b22b66"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.4_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.4/terraform-provider-coxedge_0.4.4_windows_arm64.zip",
+          "shasum": "139a1026f0fc0b5ad5f94473bb4277f8c301da891dbc4b22552a7a7f7b244f22"
+        }
+      ]
+    },
+    {
+      "version": "0.4.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.3_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_darwin_amd64.zip",
+          "shasum": "8ebee8b20345498e6ba22790eb3d672a06b247f3c4b88dc993751a1974d49574"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.3_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_darwin_arm64.zip",
+          "shasum": "c2571fe406ecf8140fa43b939a0617d889d25a5d3c099bf8f456fcbfa1a2e265"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.3_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_freebsd_386.zip",
+          "shasum": "5b8a89b97028c37095b1a3aca0b334f6689933d7c8ae90910890cfcc137eae1a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_freebsd_amd64.zip",
+          "shasum": "6ae8a5df2ca250cabe2eddd0efd2b2d533c696a64871a08ba9d83f8ec86c10f3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.3_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_freebsd_arm.zip",
+          "shasum": "efaa234bebe3bc501bf6b46e00a6239707e703ffa8ec7a206d7a4e7318fe4568"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_freebsd_arm64.zip",
+          "shasum": "0298028bb35aff9505d774a8dc18315005b37c5edae5e17a48191b554fec4c3c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.3_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_linux_386.zip",
+          "shasum": "7b075bb54bf833bc0e282ca758b83f7274b510fd682605aefefc01e45cbd5558"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.3_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_linux_amd64.zip",
+          "shasum": "abb214f3fe4a35b1bdbd125fdc88ef4e26b13ea64796f816f1e4319467c290d7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.3_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_linux_arm.zip",
+          "shasum": "bd72bd20cb7095f22480b5a54de87a4ea5199169b6e2490f5e995095c475f6e9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.3_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_linux_arm64.zip",
+          "shasum": "6dd11ca2a846c681b315edcfc1bb24b47c8892669b111728e147b8abba54c92e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.3_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_windows_386.zip",
+          "shasum": "614a47cbb3ec2c13971bb34725feb89728a150b1af1ba0d5da73f9b92ba147fe"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.3_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_windows_amd64.zip",
+          "shasum": "13ed95fd41af41f96952beacaf2a8c7543937c846ef154da8d239ca0cfadbb3f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.3_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_windows_arm.zip",
+          "shasum": "a9424f53635331b57bd317836008165a895e7c0cc67f11e8140c3a744cb837b2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.3_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.3/terraform-provider-coxedge_0.4.3_windows_arm64.zip",
+          "shasum": "2f55677598ba8fec7e85d89a77dcc2abba2735d4bd12a9f0e5325c6c20d2b5a7"
+        }
+      ]
+    },
+    {
+      "version": "0.4.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.2_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_darwin_amd64.zip",
+          "shasum": "125a3382bacee55a921b2348b3c1e3105393915abdf27d2dd5f2abd8c42e4dbb"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.2_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_darwin_arm64.zip",
+          "shasum": "e1eecc65feccd62b546e30ba7be645be14362e425e7257115491792bd85bb300"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.2_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_freebsd_386.zip",
+          "shasum": "1c654266771834154f27f5bc932b3757c57fe485d8255f2eb8b3fa54ea91e25b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_freebsd_amd64.zip",
+          "shasum": "a5f2345faccae3496609aa8a5de4aed9f530d00d79780d2f63be3da9ffc5fd96"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.2_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_freebsd_arm.zip",
+          "shasum": "2258b17a4fecc00e7bf6ad2c80ab4f2721b60fac8ef0655997bfa868b832e3cf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_freebsd_arm64.zip",
+          "shasum": "100c424edf889ce323efed5f6cf44ecb87f3b77e6d9c3802ee5efe16794e1bc1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.2_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_linux_386.zip",
+          "shasum": "79ad74c0a9e6f3fba3f3e63fb8395b553cb2aa52d413ac493753da7d4b8fc260"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.2_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_linux_amd64.zip",
+          "shasum": "629726ddc2d069bea3b05a7204a87db5d982cae53ce73f240ff8e4f380f589b8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.2_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_linux_arm.zip",
+          "shasum": "ff54b9126eade0001aef0da791a0d941d21a1ccdeebcbb3caaf87bf10825412a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.2_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_linux_arm64.zip",
+          "shasum": "a74253ef6f15dba15c17216b07c428f594a866723ef678b7a3865221d0b0b800"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.2_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_windows_386.zip",
+          "shasum": "8fa939410b79d986e5e96c05ab85e4947ca11cea3e09d58cca1f8745bf435cc7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.2_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_windows_amd64.zip",
+          "shasum": "64ac466b26f87df91723ae94daa42959adca1d64944046c8491e39a588708148"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.2_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_windows_arm.zip",
+          "shasum": "896ba275098c470898bcdd367ef490120d113ec1d3035ffca89f2efa54c88b3f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.2_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.2/terraform-provider-coxedge_0.4.2_windows_arm64.zip",
+          "shasum": "c48d9d9ee3a9aebab7c88caad917969b95ad886278c657ac2de262d4ba74f007"
+        }
+      ]
+    },
+    {
+      "version": "0.4.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.1_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_darwin_amd64.zip",
+          "shasum": "4b973af5ef21456b1a0dc6dcadbdd22b70c9a5267900f1dca833081b6438b94c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.1_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_darwin_arm64.zip",
+          "shasum": "532966274a6986f42296732633697d8c506478d968948501d171a05de1d6d8dd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.1_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_freebsd_386.zip",
+          "shasum": "aba64526a42525e537256f814dcf4a325c70133b8ef5ed721ef467896acc78d8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_freebsd_amd64.zip",
+          "shasum": "b39437c75a202ad2047b2061aae6790811a6bdf66e6c50255b18eb9271c19258"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.1_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_freebsd_arm.zip",
+          "shasum": "36a9cd942e688964d8cfcd96d4f61cbbfeae3d3696429d96e56dc0615981c366"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_freebsd_arm64.zip",
+          "shasum": "4c55dc53f637ee78fadcb7355c31f19b3f42676b7472e7a50edf20c17845b12a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.1_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_linux_386.zip",
+          "shasum": "0166f886e5e785c8fee1bfe274acf1f01d8fb13ad32492cb143b711c4eced7af"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.1_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_linux_amd64.zip",
+          "shasum": "23d811ebc76e446b932afc8ab1cac0927b73e381361c84e099c219106434e5aa"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.1_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_linux_arm.zip",
+          "shasum": "96608fdb7bc127fc84f7f00b31c90b755653582cbfffd9b8d64a8a7ad104361e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.1_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_linux_arm64.zip",
+          "shasum": "ee77c9836d439b0be1b10258ada4fa953f4b336a2478dd5a10202438fb1ff4ff"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.1_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_windows_386.zip",
+          "shasum": "a549265f766e67446c8c8b265562aafaf8a5a35691c081522c486b1f03724a9c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.1_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_windows_amd64.zip",
+          "shasum": "1f5c8a61d5460670eb1cb877e02aa6cb632fe18cee56060dd9692a0f8aaf2815"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.1_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_windows_arm.zip",
+          "shasum": "a23b2b235073f91e9278bf35cb74c2dfbca129a4f5d28ef09bddc80adfd875b2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.1_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.1/terraform-provider-coxedge_0.4.1_windows_arm64.zip",
+          "shasum": "68f1269c41046c92528cbdedf2e874c7d130ab876d1c7b0a660467b84b0560ac"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_darwin_amd64.zip",
+          "shasum": "424dfbc1748d6377eb1bd1d1dc480d6ef3eb36cfe31108e4a0792872d55ef5b8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.0_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_darwin_arm64.zip",
+          "shasum": "7ed847b3390248c123d8e3ffe747e4c11a822be7a2c96a732f35629663c9ab3a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.0_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_freebsd_386.zip",
+          "shasum": "513c7af9009efa091df35bd45b710d06615f680f58b079807c7c81aa82b9bc51"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_freebsd_amd64.zip",
+          "shasum": "33429c9d253606d331efbe31c1fda846bc48965b2ba1e254758b823afef66ba7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.0_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_freebsd_arm.zip",
+          "shasum": "4a8e3d52ea545690c7474e0a8074ad76abce029fc13624f4e7c0ff3ed751657b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_freebsd_arm64.zip",
+          "shasum": "0c3e6473b51c2f489e0433d33a36f2d31293103cabb58742dd0ab61c8514b056"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.0_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_linux_386.zip",
+          "shasum": "a07c6615f40432e501b72eab78da163ac400b5c0f7910bc194b8d55fb2e350ac"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_linux_amd64.zip",
+          "shasum": "9c0ba4e11ba973eb542b85c68082a5f3764b3ee6fe13cf38bb3183a3f223205a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.0_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_linux_arm.zip",
+          "shasum": "6e291c730c8bf567bbd9f4041630feff01951580442421e026a112d86b4f122a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.0_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_linux_arm64.zip",
+          "shasum": "d9eacc747eb738d16cbd2afdac4f5105e37f1d70440eb34190faf8cb22bf9dfb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.4.0_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_windows_386.zip",
+          "shasum": "ce28725e7060716a96af235aed0664de4717c9fa812a1c44384279ea7e7f595c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_windows_amd64.zip",
+          "shasum": "b8f4fd5763c3db77fd91cb30aecc8415257537683d52de02a9f07af50f293258"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.4.0_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_windows_arm.zip",
+          "shasum": "f351e00560f19f29de93ef8d6931c21e70d7b46e493490afcd476305fa2c9c6c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.4.0_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.4.0/terraform-provider-coxedge_0.4.0_windows_arm64.zip",
+          "shasum": "b43a2b990ed8ee6a02ff665b02a3b3316c0759df463535c351fdfb6740d4c1c2"
+        }
+      ]
+    },
+    {
+      "version": "0.3.9",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.9_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_darwin_amd64.zip",
+          "shasum": "f2e4d6348a2b960655b65cb972cc9ce7bbaeb7078ee2af0bd2576ea45d4996e6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.9_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_darwin_arm64.zip",
+          "shasum": "d567dd25cd75d7e63d944e96b902c5a80e5e8c8bfcbb2c3d9ceb03323b47dfd9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.9_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_freebsd_386.zip",
+          "shasum": "9ca2b1650255a9dd92725f664aeec17bdff7e8a7c0932e4f7a7ad9bc55d15467"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.9_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_freebsd_amd64.zip",
+          "shasum": "0a35fb664093d780844c01e6872e7fcec34ebb161a4971ecc8f14d1c5c97ffc3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.9_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_freebsd_arm.zip",
+          "shasum": "9f17d1b16b07b7f15c63cf90c4bdeaad37f9c2847b51a2992faa4dbcaec08953"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.9_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_freebsd_arm64.zip",
+          "shasum": "e0b8099f9a3bfa0bcb4df3b48adce2cb88988745e501e54107cbdb3c5cfd00ed"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.9_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_linux_386.zip",
+          "shasum": "4299a3d070907f7d53752d77d015b36665183ad4402eda42b735dba6a575fefe"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.9_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_linux_amd64.zip",
+          "shasum": "554edde7ca9bab28492934e258bb1d98de8d8c65774535da6e94718db4dcbda1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.9_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_linux_arm.zip",
+          "shasum": "349e6b73135addd2a94a8eb9aa3f6a0e6060cc39c1e98bcc2c477666f8ecb164"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.9_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_linux_arm64.zip",
+          "shasum": "c722de91bebf61205abe2c2d5cf033dd4ddc80abb23365405158f88e6fc0f4c0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.9_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_windows_386.zip",
+          "shasum": "2fb142509ed2448cc0cda7f9d1442549b2ffd66311356fbc09e60ebfe11ce80f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.9_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_windows_amd64.zip",
+          "shasum": "2ef03e9271f7254582a950881b187d0fd45cefc85c562cc4447406b15d703b44"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.9_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_windows_arm.zip",
+          "shasum": "4241bc77e19b268106088ba494853f838718d2130fd8a6f85d01dd24faacbf04"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.9_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.9/terraform-provider-coxedge_0.3.9_windows_arm64.zip",
+          "shasum": "4e1ca799c2e84d04666cc170a3e8f95fb7c7d19a11db024ca6d4de9e4353cec7"
+        }
+      ]
+    },
+    {
+      "version": "0.3.8",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.8_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_darwin_amd64.zip",
+          "shasum": "8673870ecd13dfd85dd1fd0a975727126a35a7e2ac159709094a677c91ce7de0"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.8_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_darwin_arm64.zip",
+          "shasum": "8acf2e802e92e9876ba20772f56b5ee2019e21ccf874702b85870b589b2274d0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.8_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_freebsd_386.zip",
+          "shasum": "49cb6c243abeaf8df1d56df72040259e5408b3f3195030b8456da722f76a9859"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_freebsd_amd64.zip",
+          "shasum": "438778808114e56b7305f8adbfbf4ec92aa0a33822bcaca03559616d9e5817ae"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.8_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_freebsd_arm.zip",
+          "shasum": "1f2f465bb599be705001f963a67dcca213833ec4e34798b5a598e3823aa28ed0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.8_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_freebsd_arm64.zip",
+          "shasum": "c3cc388091982456fc094e5753203f82b972d06ca3c0a34e3640f456fbdaa81d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.8_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_linux_386.zip",
+          "shasum": "8cc4c5bf904cd6e5b0a17cd3f0b99eb6cc2ec2c065403b8ed891409798329f1f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.8_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_linux_amd64.zip",
+          "shasum": "c754c9b3a2b8d51878d7e61385b7029b2837612ab963c778007d4b2b416485e9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.8_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_linux_arm.zip",
+          "shasum": "92429616abfa2166c78a7456f5ff5710065eba22fb6fc2ca85b17becfb17fcde"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.8_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_linux_arm64.zip",
+          "shasum": "e28ad6d692fd22f56e0854c0314d5ad6a5c3182833e42e286e3c8092decf99fe"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.8_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_windows_386.zip",
+          "shasum": "828aa1907337be16959b21a24fb65be07555af369fb5d5386a8df9162d64865e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.8_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_windows_amd64.zip",
+          "shasum": "5a1dce0fc7d7dc12a64d861b9f0c99c3b5f8628ce65a35efcf4f8536b32c0c09"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.8_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_windows_arm.zip",
+          "shasum": "9219407bec18c89279afa578bf4a0527fea715209fa507fdc822f505d3ddc855"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.8_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.8/terraform-provider-coxedge_0.3.8_windows_arm64.zip",
+          "shasum": "c0364c9e967d39fa75210270eacadbc83964f3495ce3ce956c83c75cd532b142"
+        }
+      ]
+    },
+    {
+      "version": "0.3.7",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.7_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_darwin_amd64.zip",
+          "shasum": "115cd46ac209d0faca348629ed3b4c958379ee6f74033fcc0ec3313b1756bdcc"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.7_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_darwin_arm64.zip",
+          "shasum": "96b4cf8a6b5a6032160e21992013ca85b163ab9c013d0b0b37b072db049c1eb7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.7_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_freebsd_386.zip",
+          "shasum": "7f6ac4a117b5194ca5fd52191bd2a07d76b3b1b5dbd5fb6e61ea5ada90dc798e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_freebsd_amd64.zip",
+          "shasum": "92ad8e2ee0a184c76ace8d91009ba5cfe0a24c2c3a644d15772bcc3071595135"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.7_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_freebsd_arm.zip",
+          "shasum": "4897d6863c891dd201afeb8629af6278ad3e033098c2f92a6a970848a024878d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.7_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_freebsd_arm64.zip",
+          "shasum": "4f90c7e2594d88ac11e242990294e86d71f76c95d942fab60606dd6a814b7a0c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.7_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_linux_386.zip",
+          "shasum": "3c1273e60704bf913a322baca88ebc1b4a030b4ff56bb986918d52836ae46625"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.7_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_linux_amd64.zip",
+          "shasum": "2b1651fff7fbcefa1c1bdd6daae7dae592f89bd230fb58ab3b1166d7d4417ce0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.7_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_linux_arm.zip",
+          "shasum": "1d4dd536f2ec5b9e9d07659bdc5ed37f3cef5af017a7f64f9b9451cc14aedb60"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.7_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_linux_arm64.zip",
+          "shasum": "556a65993a32ea8b97df8edb7c2b5a3524f702ab42d25a88c5347c26a62b0da0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.7_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_windows_386.zip",
+          "shasum": "c2f3529eab4d08b1c54ea4f4a4601910d3f3f4401a73560064398c2bbee31293"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.7_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_windows_amd64.zip",
+          "shasum": "3784c91aab8915a1f03cfcf5e8e750db99a35805e36138e2e3d75e4401c832b8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.7_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_windows_arm.zip",
+          "shasum": "d3d20821c89cd846e56b0bb25d3f15d9049c7a8b17af08b3cfa4206a5cb5dd57"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.7_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.7/terraform-provider-coxedge_0.3.7_windows_arm64.zip",
+          "shasum": "f58afedca4f7bf2c9fa4ea1a753f2011089662017d3430b336085370823660f0"
+        }
+      ]
+    },
+    {
+      "version": "0.3.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.6_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_darwin_amd64.zip",
+          "shasum": "0d30a4688f716d719d1937d967d5e45890b9a364995e9de37637481c72aec3df"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.6_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_darwin_arm64.zip",
+          "shasum": "282cdeb6bd738eea26140308cc1037ed7767ae32e2aa07fabf0ccd6000354337"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.6_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_freebsd_386.zip",
+          "shasum": "247c09776b313c03f9b8443c05c029d9e987461cb49b41289ff434d77a679267"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_freebsd_amd64.zip",
+          "shasum": "169aeed65ce7b30c439945bd6095642659ed91c41fff74fabdf5d56fe2318145"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.6_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_freebsd_arm.zip",
+          "shasum": "b1ad6ddcae5d8d51cb240e08a4902f5d84b884c02b3ee48de074d0610472091e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_freebsd_arm64.zip",
+          "shasum": "88e8a1f06448651fbd90882265c9dab318f94e22c602219bf540ad358f76df97"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.6_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_linux_386.zip",
+          "shasum": "a69a4424ea5f94e1c642ce46a104a1cd1deb83b530fbfae98ffb28f85e687a94"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.6_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_linux_amd64.zip",
+          "shasum": "595ccdced1f6a3a84d4efa21b960da9e9fa4f1d3ae2469c0bdd2c54f853a99b8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.6_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_linux_arm.zip",
+          "shasum": "c78acb9986ec7adfea493eab9fb356abc044958b353102b8a81d84b003f5a2df"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.6_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_linux_arm64.zip",
+          "shasum": "5d9044b335ca5a0e71766e8c095ec0bf0a2a1c4d88446d7f7191aefb98766a75"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.6_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_windows_386.zip",
+          "shasum": "76944aeef702804e9f387e2495d933c4bc7d11efc4cc5e287e2481c1e4173340"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.6_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_windows_amd64.zip",
+          "shasum": "7e2271a9eba76d372a0c21b9b2b1624e4e01febe721f99408b8170a3c01f53cb"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.6_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_windows_arm.zip",
+          "shasum": "5d07a6ee4033c0f4b22edc425eb86f65a4be3f53a4e6a19dba18a51b015f2151"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.6_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.6/terraform-provider-coxedge_0.3.6_windows_arm64.zip",
+          "shasum": "9090a9b7bff76c9fd730c0edd46eec9f559b5e4bfc20627f61e229f2f2a90182"
+        }
+      ]
+    },
+    {
+      "version": "0.3.5",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.5_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_darwin_amd64.zip",
+          "shasum": "298490bc00b5b06c44df765ba1981efcd9acdc1dfea5f1e79f19a06a04f81f3e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.5_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_darwin_arm64.zip",
+          "shasum": "4cfc9b7e81fc254d9cf6b4ea1363a282153be49f6b9019e669c9629e9cdca0b0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.5_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_freebsd_386.zip",
+          "shasum": "3dc085d4f94ce8647ead2fa98a3bc06920a99436d8ffedab282d31b41347d6d4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_freebsd_amd64.zip",
+          "shasum": "d484c83359707ccd06dfeb9a2701b5c416f0bbfabb8fb50520b639cffeabc12a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.5_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_freebsd_arm.zip",
+          "shasum": "1562b0c319580c0d9c6fc956b673d49e207a0320f09a52e615b2cb2a3b053b9d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_freebsd_arm64.zip",
+          "shasum": "421659f3ff8208fb00eec625618488fd0ff32cabf85b16b2a31223d6cd08254c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.5_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_linux_386.zip",
+          "shasum": "2af39e2b0e7f10c9e1b4e7dfe24ce76112fddeb464a0397acb2b5ebe255764cb"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.5_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_linux_amd64.zip",
+          "shasum": "042dd4c836d4eea4b228eaf9882058201a770badbb05d99f89b190fdd262fad7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.5_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_linux_arm.zip",
+          "shasum": "ffb7dd87ac6b19f4a977f1ec85961f64760afcfea428c12fcc027ef212e16e2f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.5_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_linux_arm64.zip",
+          "shasum": "020feb16262fbc5ad680783ee9fd1223e12e5e7605e4db839fe3ad3df9775df6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.5_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_windows_386.zip",
+          "shasum": "092351b45fc3d8924053e9e7f5574661051ad8ca2040f42ddbd06b209a8bde3f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.5_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_windows_amd64.zip",
+          "shasum": "c1370c19d9742c905e629ba260f79cdc220e87063fc265d0989fcc19a4aa3a61"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.5_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_windows_arm.zip",
+          "shasum": "0efe6ad9f6dc1d884d43d361ccff26ebdb0f67b21729cd58aedb48d326150f29"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.5_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.5/terraform-provider-coxedge_0.3.5_windows_arm64.zip",
+          "shasum": "841396d175c5436902d097ce7271a31a089a94226e95f18d23fc1c57a3384a4f"
+        }
+      ]
+    },
+    {
+      "version": "0.3.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.4_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_darwin_amd64.zip",
+          "shasum": "1056750d6ac1458ca92202f5a66bbe8eb07380f64ec0909fb747ba6ec2d4472b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.4_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_darwin_arm64.zip",
+          "shasum": "3b65cb6c26959036318c6829b9646c6bd1ba0a8f2b01397678c5e099f664d98d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.4_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_freebsd_386.zip",
+          "shasum": "eaf2ae399cb7abc55217593dfcada2952353634933323417646f8f4bf48d9351"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_freebsd_amd64.zip",
+          "shasum": "baa3bb41423547d69c3d29eefc12277fdc631d6a775409fb35ad0988d9e75d9b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.4_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_freebsd_arm.zip",
+          "shasum": "abc4703868c058f4cad6f950f7aaaf71b25dc2bc6cafd293235c037dea1fa719"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_freebsd_arm64.zip",
+          "shasum": "58399c2834abff0072cab31540be3bdfee8772bb013708b82282ed0c21a6b45e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.4_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_linux_386.zip",
+          "shasum": "bc6dabc19499e86d03d8de7ab0e6cf14990896d7f95a6f956c9cfb138b5f53a1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.4_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_linux_amd64.zip",
+          "shasum": "b202e341085a72ee2a6be1e7d07eac47ce80950323f79ade0c0cf3d2c3d1219c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.4_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_linux_arm.zip",
+          "shasum": "844a43087da799416cc86ebc469f7fbba71caaeec6c326f70b18e9a21f033df7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.4_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_linux_arm64.zip",
+          "shasum": "c6d6c777aff481105eda232c59cfdd00d5f8d5d80a555a55f2f9e66a614f826d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.4_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_windows_386.zip",
+          "shasum": "ea02ae01c1957df0f1e78afc56a040c411b7af27c08b1f3c1bb92672ddd1eb80"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.4_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_windows_amd64.zip",
+          "shasum": "5652f0eb11acfbd1190c3910757fdafc9a81340773a49cd655d89b1dfd9220b0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.4_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_windows_arm.zip",
+          "shasum": "4f8326ab4c99889a1133583524b441f961cabbf056e927d2aa94b864c8982247"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.4_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.4/terraform-provider-coxedge_0.3.4_windows_arm64.zip",
+          "shasum": "e9f6ea61bec250483a2fbf81bc86dd2c5e1f7591791a752d03999548e5ad2d90"
+        }
+      ]
+    },
+    {
+      "version": "0.3.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.3_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_darwin_amd64.zip",
+          "shasum": "dfd069137309b0fb34b2d9e06d0782214611c576b3efadf7fe00d9fd61fd8575"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.3_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_darwin_arm64.zip",
+          "shasum": "abfce4cb424565ccc3fa45c9751c4c4e52e144755459fdfabb00107dc68fed2d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.3_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_freebsd_386.zip",
+          "shasum": "863d2908f8bb1de13638223031d3a17af13511ec0bf2aa71cc125cdd1b4b49c0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_freebsd_amd64.zip",
+          "shasum": "91187defe798ba9dc06b8f23cee8b87dbe572d71d4e643b55ac2634745bc8364"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.3_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_freebsd_arm.zip",
+          "shasum": "ee3059535b4a39b52f3bc19831f314d3110ef26d5fd89e98ca219ae995603821"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_freebsd_arm64.zip",
+          "shasum": "47cb209c2182e74480a60c4a4f04ca3ab9cf6b126ddad5a667e6990022ad4c53"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.3_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_linux_386.zip",
+          "shasum": "2e524dd15d01f48b35d362d9f4f62e4cf5ca69a16b203387bcd1f9959f94f8af"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.3_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_linux_amd64.zip",
+          "shasum": "f492034221bf0e423cc8a101ff4612f66e0138cec44b93d43409a634cb7a189c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.3_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_linux_arm.zip",
+          "shasum": "01c0caab235245b67b20ef2deffa4aa287d0af0192258827665a1914484d123d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.3_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_linux_arm64.zip",
+          "shasum": "31514c92f38a6f71cfd6c95e1f6f2d686f6deb3b4a4585efad6b398329a70c37"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.3_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_windows_386.zip",
+          "shasum": "f164e3a104b9f8c934b95ba8f8bdcace5551286bed7a29cda40d3e6ba5e2ffd6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.3_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_windows_amd64.zip",
+          "shasum": "b55b3953606d1366f1515a54f44f214293c3c2193a66148233ec92517ad0b8a1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.3_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_windows_arm.zip",
+          "shasum": "75b60009fb9046b62c6f37875fc5f3da06d3a17be603afe71338eed3b4e167bf"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.3_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.3/terraform-provider-coxedge_0.3.3_windows_arm64.zip",
+          "shasum": "ba493db68259cc429017e75e2f14d9fdd318c8c8d1adb203c1f2caf68245c3c1"
+        }
+      ]
+    },
+    {
+      "version": "0.3.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.2_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_darwin_amd64.zip",
+          "shasum": "d731b6d6b7e1414193c0c7d877afe9cd7ef2e4ed18d91f320038aca07027fdd4"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.2_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_darwin_arm64.zip",
+          "shasum": "a00b70902c940611de5fdb9e2efa5149edb8bf7238e2187b20b29d2182ab6122"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.2_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_freebsd_386.zip",
+          "shasum": "eb0d8cc45a274d69dfd16295a99491b3405c3af66b3507360cf883241df6e471"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_freebsd_amd64.zip",
+          "shasum": "638d1855aa0c8ed6b451bf51676ebc56ca2bc2bd1db47437d846825bc75fb481"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.2_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_freebsd_arm.zip",
+          "shasum": "06b81cfb797612d4e64fc73f702d46598e43dfd6cbace13de915fe06ba53c786"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_freebsd_arm64.zip",
+          "shasum": "faa4ab0f3e7ce2a55b71ae59952ed103e2bd813f8493772ecb57197e11c308b6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.2_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_linux_386.zip",
+          "shasum": "f1ce4fe567e0c7026f201cd8300ac70b13593d5f05305d00d01174fd9cd93eb5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.2_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_linux_amd64.zip",
+          "shasum": "99d352d589d5ec744f37938d9643a07b57a3fb4c65c9cd84f1473904ef59a3aa"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.2_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_linux_arm.zip",
+          "shasum": "8faabf1d6046bb218ee71474bb09e3fd3cb8dbfb4af3ed29a597d324b3240366"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.2_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_linux_arm64.zip",
+          "shasum": "1bf6b1f22e1cb9214d53383726f38b346796c5dd2456b828357baf9568429029"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.2_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_windows_386.zip",
+          "shasum": "a0637ef5bb737846c65080178da1ffb556015037feccfff37c149274ad981d6c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.2_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_windows_amd64.zip",
+          "shasum": "9d904a8c9a59b81c5f1b70698b95c5599ee65cc1e71fdc4d3ba34afdbc83d53b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.2_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_windows_arm.zip",
+          "shasum": "57b2287b9af085999735c00f362ce7d5a7c0774b06c8f56014c384859897bb75"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.2_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.2/terraform-provider-coxedge_0.3.2_windows_arm64.zip",
+          "shasum": "881bef2db7ebb001e0bb6337eec37b7b350a1be3668f2747596fb24404d17b73"
+        }
+      ]
+    },
+    {
+      "version": "0.3.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_darwin_amd64.zip",
+          "shasum": "4d56285384a464d220c7dd45f089a2e485aaf6de0cdb5a557d142f3e8cb1dd00"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_darwin_arm64.zip",
+          "shasum": "0c9f77362e9835ebf2215f8dc0b339fcab5314a2d1e12559d62fba05ad98be77"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.1_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_freebsd_386.zip",
+          "shasum": "1a50be2ffbb042ad8d5562e0ddc1be1bc84fce5af65134ac727e882aba14a414"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_freebsd_amd64.zip",
+          "shasum": "009c2643b4bd2ba6487c48ff5338ba6ca2f9e2bc9db80792535cd7099453f130"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.1_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_freebsd_arm.zip",
+          "shasum": "f9c4021a7e8d8b894257320747366e0467877859d0cd89985d52bdf97136be88"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_freebsd_arm64.zip",
+          "shasum": "15f24f2340c75464d11748d96db635063c860787e2fb05a189c7af40d37b711e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.1_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_linux_386.zip",
+          "shasum": "29e5983b829a84a5b422649337a3ca836b65b485296c50c6e86b92b1d9ec1ed2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_linux_amd64.zip",
+          "shasum": "55b25905b84c9c698cbeafcd6d5f768b74c1c87d2a4f367be36bc8b1574f51ce"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.1_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_linux_arm.zip",
+          "shasum": "125f882243220d6c500647096e64cdb2839c00739c2816176f224830ba23ed72"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_linux_arm64.zip",
+          "shasum": "e3f2df3ef97d1711f0da9f3a1fada99b04f7f7fe104135695b67cc954e214d5c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.1_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_windows_386.zip",
+          "shasum": "b6bdafb5fce85975469d48cccef8cf82afedc4ebc14dce86d1bfea3e71b33426"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_windows_amd64.zip",
+          "shasum": "c4d12caa462642f79f7f995491df68533b7107e3468c6185da34b8c3659037aa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.1_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_windows_arm.zip",
+          "shasum": "0ca62d7fb2c12156f7451fce1903fef527a3714b11e2aa2b44daa1e64dc38842"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1/terraform-provider-coxedge_0.3.1_windows_arm64.zip",
+          "shasum": "f309a4973d8a9c9a62260aa732b29a474d468c42e27b98bfc245e3910a09738e"
+        }
+      ]
+    },
+    {
+      "version": "0.3.1-pre",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_darwin_amd64.zip",
+          "shasum": "43895b8b93957aa2bfa9c13528d189d9056c36c32a157543896fe991c9dfaee9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_darwin_arm64.zip",
+          "shasum": "1e5378258528106ca1b5f3df7bfe6709680f8eab18a69f3e52381e7cd4959808"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_freebsd_386.zip",
+          "shasum": "bc4ff3768d6b6c944673155cb21643b7c1df73cb62de58ec4884a934d5e2ae66"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_freebsd_amd64.zip",
+          "shasum": "1a65e0abc0ba013697862a1a7e68860034b4c97fa21d178761330a72ef77c4aa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_freebsd_arm.zip",
+          "shasum": "e4a98a632d6caae0d6d5cc29a0ba2f1659b4777ba75c5ac45343b5187481114b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_freebsd_arm64.zip",
+          "shasum": "8f6785e2bd1690af8016865e1cf387bb41d803cb40ea41d7b4a74c072a3964ad"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_linux_386.zip",
+          "shasum": "52032806a65b50c2e3345a6d27d7c0992f85d752297c1a05e72f28f5b1ae3991"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_linux_amd64.zip",
+          "shasum": "519b813cf795e17ef47ec584897bd225507b88bc73f57197a1a6c90b90ea850d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_linux_arm.zip",
+          "shasum": "b419df38312039d8d114c869cc7dbbd8a75b12c4fc335b7c024bc606d169f17b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_linux_arm64.zip",
+          "shasum": "7966bcdfce87973d31ab7a06062e73c2cd513f0dcab0abb990cb3c33ad257b71"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_windows_386.zip",
+          "shasum": "0f35b6803906ee52177305fe1b7d39adb7e0ba86f3e152b4ec11cb2d42a3eaab"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_windows_amd64.zip",
+          "shasum": "5ce8ff23e07cce334102a4355e6c11524943672d2041f4ce21ee694134e2c8b2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_windows_arm.zip",
+          "shasum": "3136b0feb4175c0b7934c665b08824ae1029e5488e545e2d90963aab1898baf3"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.1-pre_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.1-pre/terraform-provider-coxedge_0.3.1-pre_windows_arm64.zip",
+          "shasum": "a5afcfde0af45e017c971c2f4ee7681127eece971b8680d8bca58404e293fafa"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_darwin_amd64.zip",
+          "shasum": "aec35bfaebd226e043c664a8c8c7412faf882c1908c76db51529d9ac098a7396"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.0_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_darwin_arm64.zip",
+          "shasum": "e898e5dd12d79e21bc17d5520568535906e5ba077d6dc2fe1d8c2a60dc7c7119"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_freebsd_386.zip",
+          "shasum": "7e43a66bd1471efb4686af6f8f59a19b4e3baf944cab98eff88bf2970dbee584"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_freebsd_amd64.zip",
+          "shasum": "e22181531b5782e61cecf50edb3efbd63f9e1127131b69684e674a764e4626fa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_freebsd_arm.zip",
+          "shasum": "3003077045089041779b45b2c026e0a6d1c5dce8f9d74b23f8af060abb4d4822"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_freebsd_arm64.zip",
+          "shasum": "fba29364778da9553d46b17c59c49e484376488cc572ec40c4ca707ac2e4e760"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.0_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_linux_386.zip",
+          "shasum": "6fbbc7b9dc9bb01213865aed781362b9b65f240b7ffa3d3c7cfde7d91dc3f826"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_linux_amd64.zip",
+          "shasum": "c313cbf048817db73f54a7d9510cd0802517c4543c51a4d21613455f05ed9dfc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.0_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_linux_arm.zip",
+          "shasum": "2f0f8407a95e61a8393c83d4b693676f6a01f7b2d4da9602611967289819e0fe"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_linux_arm64.zip",
+          "shasum": "af250bbe8a0dd05df7096811d8273db3af0c80581c78a24699cb10161e6614db"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.0_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_windows_386.zip",
+          "shasum": "026d1ba4b1f9f19d6d8ee5834ff46dee780ef977d10cc78b207cbe317a0cf991"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_windows_amd64.zip",
+          "shasum": "05e5d028c65fc85eabec167f5ef63ab7fb78e74de3e47536e81a6f77c32ff72d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.0_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_windows_arm.zip",
+          "shasum": "dfaa137e4be656136a1d1d8a88061fa63c9242ea9d515716246d7afd17d72e69"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.0_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.3.0/terraform-provider-coxedge_0.3.0_windows_arm64.zip",
+          "shasum": "16da2f4b38db22887bf5eb4da08038910a376fb73e4b1bb9582b80ef8a9c7d89"
+        }
+      ]
+    },
+    {
+      "version": "0.2.9-pre",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_darwin_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_darwin_amd64.zip",
+          "shasum": "af4fb7007e180d14f05582320375f5bfd142527c694ea060ebc0cd8e98e82e46"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_darwin_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_darwin_arm64.zip",
+          "shasum": "11be9cde83cf571758cd148348bd798822f1ac1917f8a489d08082760f365c2a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_freebsd_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_freebsd_386.zip",
+          "shasum": "1ec19db25101a701c8d56397637545d9fefa8b99ef5b560f334370857a224e9e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_freebsd_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_freebsd_amd64.zip",
+          "shasum": "bb9db69ff3dcbeefb0ba651fda2aec72397389a200c1656da24be8d7b4f08c0c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_freebsd_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_freebsd_arm.zip",
+          "shasum": "2a4cb8eeb03249b1ace41ba35e27b45fc28372783e552cdef89c97df3f1d51b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_freebsd_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_freebsd_arm64.zip",
+          "shasum": "c27f5798f75794b992535ba7bbf5da06e204c6d3b03e0aa1ac6c24641513f430"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_linux_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_linux_386.zip",
+          "shasum": "0434176623a474e791006191d7910c6a2bc1496d768688d438ae4499475d1ceb"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_linux_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_linux_amd64.zip",
+          "shasum": "310c87f2822ec3520c5e219e3c78613e234be934d95e8c765fa82fc97144faba"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_linux_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_linux_arm.zip",
+          "shasum": "c40e93d4343d53e750ad246038e0e52e014af38704c111f2f55eca930fc4848d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_linux_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_linux_arm64.zip",
+          "shasum": "90b4ab88a0330bb62eac7ba15e0beb409837c952c46a28cd2729ac6845428050"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_windows_386.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_windows_386.zip",
+          "shasum": "a077612d67ce8a03d58ca4e5bfc3753f00219a7778a1857c68bfd06b58203ea4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_windows_amd64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_windows_amd64.zip",
+          "shasum": "777c8e7c880485f5319a610bb9f1be8bc92b840ea5258b76a175bd9023b0fe32"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_windows_arm.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_windows_arm.zip",
+          "shasum": "5b6eeeeab95f9619a3bd94ca92c40afa7786f5a9cc307e98109d95a8224c1d04"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.2.9-pre_windows_arm64.zip",
+          "download_url": "https://github.com/coxedge/terraform-provider-coxedge/releases/download/v0.2.9-pre/terraform-provider-coxedge_0.2.9-pre_windows_arm64.zip",
+          "shasum": "be8a570381930722fefcc3c1464e3150dbf8ab393131ef96db7e48287247650b"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/d/davedotdev/junos-vsrx.json
+++ b/providers/d/davedotdev/junos-vsrx.json
@@ -1,0 +1,28 @@
+{
+  "versions": [
+    {
+      "version": "20.32.101",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davedotdev/terraform-provider-junos-vsrx/releases/download/v20.32.101/terraform-provider-junos-vsrx_20.32.101_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davedotdev/terraform-provider-junos-vsrx/releases/download/v20.32.101/terraform-provider-junos-vsrx_20.32.101_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-junos-vsrx_20.32.101_darwin_amd64.zip",
+          "download_url": "https://github.com/davedotdev/terraform-provider-junos-vsrx/releases/download/v20.32.101/terraform-provider-junos-vsrx_20.32.101_darwin_amd64.zip",
+          "shasum": "3914c080005ae9b871e681b3cd822cb1cda18c8ec62475b1b038c9d68eff5d45"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-junos-vsrx_20.32.101_linux_amd64.zip",
+          "download_url": "https://github.com/davedotdev/terraform-provider-junos-vsrx/releases/download/v20.32.101/terraform-provider-junos-vsrx_20.32.101_linux_amd64.zip",
+          "shasum": "208eb603e307f763ad7d69549819b6032dceb443e3fd113f0e262e262b993d2f"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/d/davidschile-automox/pipeline.json
+++ b/providers/d/davidschile-automox/pipeline.json
@@ -1,0 +1,1038 @@
+{
+  "versions": [
+    {
+      "version": "0.0.16",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.16_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_darwin_amd64.zip",
+          "shasum": "a266b114ec270940e172ce88b61529e587dd1423981662220a2d74d981ee46c1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.16_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_freebsd_386.zip",
+          "shasum": "8ff109e6267bc559f87e370d839351b36905b7de3e7e2356d1dc5302113a76ed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.16_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_freebsd_amd64.zip",
+          "shasum": "4de1e1c61c073f837242ebd7ca420e787df805e53cd5b2ca17defe5ede981bf5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.16_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_freebsd_arm.zip",
+          "shasum": "a73f6f30e35699945fd0426e918cd4d9a626b574ebc96d640bab5d1337af8762"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.16_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_freebsd_arm64.zip",
+          "shasum": "d2c37d77736d93afe0b7e231188c892089198af2e517fe5ec22298047791429a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.16_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_linux_386.zip",
+          "shasum": "2ad60f0b2429ceccfaab03e11bc1ea336718fdaa0f6e909d65739f9d996713f9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.16_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_linux_amd64.zip",
+          "shasum": "908610dff4300f9443b68971adb9722ee769f20bb0fb0acf1cd2e3f0b42162fd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.16_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_linux_arm.zip",
+          "shasum": "f7d1e6dd50a661c12ef2a1bda19e69041359aa6191ad2ccf451513dc59fae9bf"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.16_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_linux_arm64.zip",
+          "shasum": "3ffe129047242a423e92c52f211e1094eff5a03ddebca3da9465550e6ab69aff"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.16_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_windows_386.zip",
+          "shasum": "a280e3eeb0a0f5cccda8e8ce2abe91f0024acad6ab4785afe4f2d52639cf738b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.16_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_windows_amd64.zip",
+          "shasum": "3cf44864f259966d87918c1f9b376be7c05fe90b172818c11ed6bcbb5029ae50"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.16_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.16/terraform-provider-pipeline_0.0.16_windows_arm.zip",
+          "shasum": "0937467ebabaac73b09e95604bed0a42ee59f848ab2f0f6549f1077c112a0458"
+        }
+      ]
+    },
+    {
+      "version": "0.0.13",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.13_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_darwin_amd64.zip",
+          "shasum": "2c0592774071c1e0b000faa8ee696206b9fd1cd9b3e6086c1c8b43367d9a4628"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.13_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_freebsd_386.zip",
+          "shasum": "b23b007a26549a47fff5eab8c79dc0a320681e8b00c162cc04febc76ec765495"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.13_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_freebsd_amd64.zip",
+          "shasum": "68d682f6312d2d55ec23e87ac1466cb8830bd6a853b2b5057060d0ca77b24934"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.13_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_freebsd_arm.zip",
+          "shasum": "80ba7219ce0fe1a29ba154c7834ccd2fe48bdf2457a8394a2bd7e9a3de1fd700"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.13_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_freebsd_arm64.zip",
+          "shasum": "2e64d79bc370c4fe4f5d0d39c5bafb96fa3d55c3af22f8d668d4efd308937024"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.13_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_linux_386.zip",
+          "shasum": "4f0ab1ed25835a030206548687b735be66a6bd3189e18b0904eb8d9130000bd0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.13_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_linux_amd64.zip",
+          "shasum": "3b56f874a65541e3e331f6ed3b72176cd541e2f9bb62cde2482cbc31ed56e578"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.13_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_linux_arm.zip",
+          "shasum": "07687c4e4cc74de8387aba24469d6d28168ba722eaecec933ed747ebc0836ad9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.13_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_linux_arm64.zip",
+          "shasum": "8c8e0ca7f3ec08f80757f1908e330c47c037276e55ea90a6f04051f6ac25e963"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.13_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_windows_386.zip",
+          "shasum": "d00fe7eed61ef9045f71ea5fb6fa392f26294af253a51d59405af3a051e931b4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.13_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_windows_amd64.zip",
+          "shasum": "224c969115e66baa7f17c5170479b35f8529f021cbb6aacc00fa94dba9ae909d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.13_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.13/terraform-provider-pipeline_0.0.13_windows_arm.zip",
+          "shasum": "e942b39b205f0ebeab8b177e668fe197f2d06a38b3a85dc11a85580f653099f6"
+        }
+      ]
+    },
+    {
+      "version": "0.0.12",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.12_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_darwin_amd64.zip",
+          "shasum": "9f6ba34ae82cf8c5a3a2e89f451b43916edf97bc0593e09db0323b95f446999c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.12_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_freebsd_386.zip",
+          "shasum": "4ec335005955b325a92ffd000cb8ebdab7a7917fb8c0b04995b587f8152916d2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.12_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_freebsd_amd64.zip",
+          "shasum": "2959d002a73a41780a14266a65427ab77429dfa5911894014a3ffee825fa9360"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.12_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_freebsd_arm.zip",
+          "shasum": "f6f6b3c970d632ca4db9cf1a7e17b67c9626bdd00bcba2e4424a3e0a6e63890a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.12_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_freebsd_arm64.zip",
+          "shasum": "036436c463d087f4296c73ebd56e0fe95fb5b8db1163e9fb72ef0639ac2a33f3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.12_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_linux_386.zip",
+          "shasum": "b3e65b9e19551023812e1dbf66853a1ee194da3827f29b8a25be18a629ac51ac"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.12_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_linux_amd64.zip",
+          "shasum": "0cf44b8b79f104f7daf53f3f399a0b04637763bea84a435ed1c67f46818f5bac"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.12_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_linux_arm.zip",
+          "shasum": "e01ffe3b81c36b018b33f0032039d1a7a9e167e84121583e711b147d11e69531"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.12_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_linux_arm64.zip",
+          "shasum": "103ccdd7261e1ead74d16681d9de313fa142d8b3681d06be6b1aa4a1048ff22e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.12_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_windows_386.zip",
+          "shasum": "891ffb5b83cfc9485f093ce7e833e79576a38c75508aec470a31d902c35c8789"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.12_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_windows_amd64.zip",
+          "shasum": "7113f6d06d1fc88d40c64f9cacacd4b85fe53776c6920b97a658e8bf3b32b8d0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.12_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.12/terraform-provider-pipeline_0.0.12_windows_arm.zip",
+          "shasum": "76718d1ba855df0008512b1ad63ec84fb131737aee6bfe18bbd0399938af693b"
+        }
+      ]
+    },
+    {
+      "version": "0.0.11",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.11_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_darwin_amd64.zip",
+          "shasum": "1638fa5ab14971f7ac37c7b174b676ebaafe2787340a1541baf1daac6930e054"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.11_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_freebsd_386.zip",
+          "shasum": "f9cc1d34c73389a2f6e2e56b4e03b65b1aa5a28b6c0d28bb515015ad8aea6654"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.11_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_freebsd_amd64.zip",
+          "shasum": "3cc3b9bb067e97ca86be6208e132e4648a267a4d61c3efdafea1714950d9e09a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.11_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_freebsd_arm.zip",
+          "shasum": "18e49ddcfe9767493ce6a3cc2867cf3350c43660084e159ba8816bff288f519c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.11_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_freebsd_arm64.zip",
+          "shasum": "2be106d784a83bdf4aa6f7287111e49552132b1b345af26bb2bafe2095245e6c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.11_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_linux_386.zip",
+          "shasum": "8972e82559a5b4d845f7e04d4a31ee4f796c938ec8c74654791db194aa7b59f7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.11_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_linux_amd64.zip",
+          "shasum": "facfa9c1f393046a933a7503bcacfe1e1506160450af7b7a16936283204ed0b5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.11_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_linux_arm.zip",
+          "shasum": "7d800c3e10735a34008bcd726e37b416934b838ecd96a6a0ea0c66618ee00301"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.11_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_linux_arm64.zip",
+          "shasum": "d97ebf5403261d1482e2f0ec9407924b339fba3bdb80119a3b2e17cad60c8c56"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.11_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_windows_386.zip",
+          "shasum": "494fb427d361e7cbbd216bf349d47e79f30ebfa2adcd46b291645dfbdffd1983"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.11_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_windows_amd64.zip",
+          "shasum": "77e04f458a8c1e18374b1b3bb227b46f51a6361e3846581c3a5aca0590664a3c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.11_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.11/terraform-provider-pipeline_0.0.11_windows_arm.zip",
+          "shasum": "154abddb1adf773c5a427fee01080b990f448a6104add13695a6e72b9c8f2d06"
+        }
+      ]
+    },
+    {
+      "version": "0.0.10",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.10_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_darwin_amd64.zip",
+          "shasum": "ef4d90d6e07961ac7156728b0cc433966466b7352569a41ed6193046386a3870"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.10_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_freebsd_386.zip",
+          "shasum": "57cc95473e8b0e5ff442d0f015aadcbad62b25106c14a20f3330af18606d49b2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.10_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_freebsd_amd64.zip",
+          "shasum": "45df5eea03b561f7a443b618daa9267b8c09637c0a9ffa80c61a3ce0eef9a706"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.10_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_freebsd_arm.zip",
+          "shasum": "52a650c2344f7f309b615541a1b7f2078fa0e47ef32ecd7937e5cf053fb84a03"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.10_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_freebsd_arm64.zip",
+          "shasum": "3563458b85c08e670131c17d501fbff456167e3dd0d710a46dc4e6e52c0a1cc8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.10_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_linux_386.zip",
+          "shasum": "24c13b3c531dc1f676445380b863ec37cfb433cfa970c6306dbe91855093a62c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.10_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_linux_amd64.zip",
+          "shasum": "26dd20374f23a770886accfa22b6cbf421dffbb1fbf471fc93d8c13d86c3404a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.10_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_linux_arm.zip",
+          "shasum": "79c6b4d5e35ae478ca00686a08f4a705f008e7b3c874f43667f423071575e5ea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.10_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_linux_arm64.zip",
+          "shasum": "310d70dc72ae487b111947d6478fae5920c3dd4ab8c4024b4a3cdb72ed0a67a7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.10_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_windows_386.zip",
+          "shasum": "d1059297046adaccb039343635f5e29c4b0cee9b9c62514c93b7716c06660094"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.10_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_windows_amd64.zip",
+          "shasum": "d869dac5cd2e86ebafc32d018647a6bc3688e790e6c7a6e52135f5679bc72db6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.10_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.10/terraform-provider-pipeline_0.0.10_windows_arm.zip",
+          "shasum": "ffec1cdf8e5ff3f5af306c723857cef9494c5aaec87dd8454d4179879c87cc2c"
+        }
+      ]
+    },
+    {
+      "version": "0.0.9",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.9_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_darwin_amd64.zip",
+          "shasum": "2b3e13efdb2a70b596cc822cc77b192ca25dbbc52e522ff2ca4c32cf0e29208d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.9_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_freebsd_386.zip",
+          "shasum": "809e7dafe622f1f527802d7e4c8457dab18c767256ad946550de57b3bd8d875d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.9_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_freebsd_amd64.zip",
+          "shasum": "377129900020233d725fa41ebf2a946ed0ce52b48a2113cde5c5b63d3e55bae4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.9_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_freebsd_arm.zip",
+          "shasum": "c9078a4bc5f861763d374f016d77f94f2ea8fe3a6d2b6bd1fe9635a05f0bb659"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.9_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_freebsd_arm64.zip",
+          "shasum": "de4d45d2b80da94dbdaf4236c7a8b7a841d4d2f3a1a879adfed450c048faa7d2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.9_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_linux_386.zip",
+          "shasum": "bea0b52bc28b57963520943b97dcb4b1cfdafe2bcc818c13e6790de70ada069f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.9_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_linux_amd64.zip",
+          "shasum": "2b945585c70f88a646ce17d7ac772dc1fc7c9351c64b9f1a3df1aaade54e9dd8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.9_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_linux_arm.zip",
+          "shasum": "806e75fe9ec79c31af841f49b749f1301567fcc78650a60ec944929ade2e8519"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.9_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_linux_arm64.zip",
+          "shasum": "d5f2658f3e10c90a90036acfc2b81c13cb4e5c661e9e83d0173f64aa1b29f60f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.9_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_windows_386.zip",
+          "shasum": "9c4ab35e28bbadddb1736007803e6104a5f5a0372cbf239f440d5fd977ee85bd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.9_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_windows_amd64.zip",
+          "shasum": "1ea4b86e8bfca270f007dcb22b3fcb829f43f51a637adc509220088cc56991f9"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.9_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.9/terraform-provider-pipeline_0.0.9_windows_arm.zip",
+          "shasum": "8b3b0675553841e2cbd00724b54ebfbfa830f6811fe2c085ce91bc4737d0ec9e"
+        }
+      ]
+    },
+    {
+      "version": "0.0.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.8_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_darwin_amd64.zip",
+          "shasum": "14833e436499035d97e68f033545f2ed653ff0c865493622984173fe0d81f7dd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.8_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_freebsd_386.zip",
+          "shasum": "350d6a14ec0f3ae13a4037675779a1acc1bb23e1bcec12e8a1d923286252d582"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_freebsd_amd64.zip",
+          "shasum": "243a00d52446fec6c5cf4d57e032fff3d05f2190f355c53994eba14d11a91ded"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.8_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_freebsd_arm.zip",
+          "shasum": "056b9e29c6794b5b75192980fb752964007abbc019d687be32c3c4a634965726"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.8_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_freebsd_arm64.zip",
+          "shasum": "7e6954d5081b064468a0234de52d59778a78a6962005dce73d912fa1d1630485"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.8_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_linux_386.zip",
+          "shasum": "8d83b46ef3371d67fb1923f6527b6da38b1f2a51d3f402915dc0b2b18dc7c9f8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.8_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_linux_amd64.zip",
+          "shasum": "19b6064d2b61f91c0b389f67a0a0c330d8e363119d4ccd14ba137cdc610c39a1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.8_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_linux_arm.zip",
+          "shasum": "21283a738b5880009cf6d7ee11673cbc6a138e0ef40b78d301363f06bf856ff1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.8_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_linux_arm64.zip",
+          "shasum": "76202e2ca8912caf5d97a9dfaebae76fa72b261f7fd3f472b0b3b570cca472f6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.8_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_windows_386.zip",
+          "shasum": "63a3a1099cd43826f3d535a3302bed4e8ef430bab5f67bbefa43d00d44f49fba"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.8_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_windows_amd64.zip",
+          "shasum": "83062e93747993c178ab771017ae2f41b92974cf14ec351c85c6f6dc258b300b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.8_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.8/terraform-provider-pipeline_0.0.8_windows_arm.zip",
+          "shasum": "9cfa06b28ab499d58abbeea258807c1b7dec7c054a57c1ef6e5b2ed68483d694"
+        }
+      ]
+    },
+    {
+      "version": "0.0.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.7_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_darwin_amd64.zip",
+          "shasum": "b66f4bf1fd11381e890145097c445e891d6587aa01880f9ec599ac2fd2bc8b94"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.7_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_freebsd_386.zip",
+          "shasum": "143e2ba9b610bdfe6d6ce183f3b87df05a208788d5c822daff2b308d502fc41a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_freebsd_amd64.zip",
+          "shasum": "c0da8c600cdc0c05b8a5ceeaeba85c11d1f4f0c5ebe2fbd35d4f19b85b67546a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.7_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_freebsd_arm.zip",
+          "shasum": "7e99af8a4cf5d7fa92aadf77cb44901c7f14cea24c0cb731d098e008ad611dc1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.7_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_freebsd_arm64.zip",
+          "shasum": "1be1f6e81f1a4015dbe232068d2b5d2ee148869cddf7e1a013900ba179731cc0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.7_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_linux_386.zip",
+          "shasum": "68675c1ff7f22c8051efff89064e7d712bcf863b183c10c2dede4f8cc03d5557"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.7_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_linux_amd64.zip",
+          "shasum": "69123db4832e1b904b6d55e00cde6a0ab381b5f52378db27f387f7c36eec4c39"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.7_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_linux_arm.zip",
+          "shasum": "e9caba75023d841afc093f2d92b12e1ed4645955c543a5f05d42ba11373c5159"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.7_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_linux_arm64.zip",
+          "shasum": "bdbdecdeed576b9c3bbfc62b48c72e61fbaf7063802fcef6b62d2fc034faf139"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.7_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_windows_386.zip",
+          "shasum": "d6be87616ce265aeaa25ea259958807ba6f47f7307f8480d43b2c97d5c2b065e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.7_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_windows_amd64.zip",
+          "shasum": "d9d446b23716d84c91482cb18cf63aa39c7c7bd07fff46298291e949570cb0e8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.7_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.7/terraform-provider-pipeline_0.0.7_windows_arm.zip",
+          "shasum": "1e0562eff69a9f61ee73f06ff54b9eec5e53817d2d792510a00aef2797c53b3f"
+        }
+      ]
+    },
+    {
+      "version": "0.0.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.5_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_darwin_amd64.zip",
+          "shasum": "338da08d998c70d125c40a864a9d8e58a3d151d05fdfef2bfa1ff63e0426090f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.5_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_freebsd_386.zip",
+          "shasum": "5d273afdd25e6b8792291bc042d3404eb708a29510760b04092cbb86268f4ff4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_freebsd_amd64.zip",
+          "shasum": "6de3998507e73e0cbec4f3357fb8b0bc425bcf3e09e7b204fb5938026e199cfe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.5_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_freebsd_arm.zip",
+          "shasum": "143fb2f59f3cf1f39db71765c7444d0cf12166383a85d1d17cea372470ea361b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_freebsd_arm64.zip",
+          "shasum": "a057768b530fb70fc83851f47b5940b9a02beb48039b6fb326154cb29f8163de"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.5_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_linux_386.zip",
+          "shasum": "f8f7be2a6d055a62fe83e7ab81f609bfee90bcaf7cc703fde3a6b02c332fc55c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.5_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_linux_amd64.zip",
+          "shasum": "2451dd799f7c2d66f09dedfd4dca6dc3f4ce861457528c3b9c3d87121485efe9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.5_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_linux_arm.zip",
+          "shasum": "739334f24b21926c893f44daf99fd4a5622164a94f24b94598d5286d5f95bcab"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.5_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_linux_arm64.zip",
+          "shasum": "4af2bfced391c6e0e1d75ed25e36ef59d641bb7f8e084f9f5bfc46f523182839"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.5_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_windows_386.zip",
+          "shasum": "f19de57d54f8907894c17961f187c0840e2cf57bd83891b4e42511d92639a9a1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.5_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_windows_amd64.zip",
+          "shasum": "6b355859b518a4f6acfe47154a2b9590bfe7ec64f2c44b528a0e2ce473632c9d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.5_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.5/terraform-provider-pipeline_0.0.5_windows_arm.zip",
+          "shasum": "3176765befa587026fecafa88f8f02b2a2886a79c4f831f2390a056c6616cd55"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_darwin_amd64.zip",
+          "shasum": "c9b8f9f8568b20ada4bade9a7dae5aba909c6435fbe37fa69cd3cefa036ba9c3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_freebsd_386.zip",
+          "shasum": "afb35893aff082dcfd7aef89270b5a1e314b9497f044f931ac49c7a0cd96ce7c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_freebsd_amd64.zip",
+          "shasum": "283273e9df7e97f3ab1664edc7fb9b0aeac403b4443c6f81fe01f6090f035684"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_freebsd_arm.zip",
+          "shasum": "43561b585a27eeaa509ec8bb1e2e8ab751445fb562155f4d8fdabb6842bf7460"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_freebsd_arm64.zip",
+          "shasum": "3e0f60f5b5a0b69093e41bcb90dc8a80d0b722c1461b7dd230a4b39d833fc605"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.4_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_linux_386.zip",
+          "shasum": "c98bfa52cf1ca032750121cd42099150bb1e3341ae5997a358eccae702f51573"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_linux_amd64.zip",
+          "shasum": "5f77343a1e895016e218ca1ea2b5784b14f4fe0a5d6b9a79832c9f1548cc2426"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.4_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_linux_arm.zip",
+          "shasum": "8154e1158a4da849dc42dd59c14e8bb29b349fd98837e8f653cf2bf98ca7736e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_linux_arm64.zip",
+          "shasum": "a31c33020311da81cd0f0687f66440e504283493299896099c2dc29752294113"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.4_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_windows_386.zip",
+          "shasum": "c1f0921bb3caed7aba191aa459eba6ee544e01ac82be88443680979a8095804a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_windows_amd64.zip",
+          "shasum": "be0f53d84a6ad7cdb73fe3e52781c54a8c2b737fdbf60a8b08077d841abca0b1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.4_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.4/terraform-provider-pipeline_0.0.4_windows_arm.zip",
+          "shasum": "512555da2585267b1e7f3004e3d97136796a52ac31b1baec03be7fa69807d8c5"
+        }
+      ]
+    },
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_darwin_amd64.zip",
+          "shasum": "526962c5da7207bb91e7c2cadd7e883de8d4fad7e5e30322efd62da6a039df88"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.3_freebsd_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_freebsd_386.zip",
+          "shasum": "89e51e51a28dc90742d922dfdccde9c55eec610b7922eaae0b063dc3c61aaf89"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_freebsd_amd64.zip",
+          "shasum": "62e6b5b827021f779a6abc15210b033ea375f8b5b403833361081bbdadcecf23"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.3_freebsd_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_freebsd_arm.zip",
+          "shasum": "a9567fe4f867c197c040571ab7ca407908f10dea7249e29cfcac9649938840c2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_freebsd_arm64.zip",
+          "shasum": "aa34cebe0e84c9056d80e7aef0c98dd8640ab91872ba42f7fc015749d0b034c6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.3_linux_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_linux_386.zip",
+          "shasum": "78f99af35965b2161bd66bce67399c88547d76c9e95139cd3ade9a5a859ec2a7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_linux_amd64.zip",
+          "shasum": "017e2d0ee0f3e49f2a858a4e7e77f3b1e6a8fe9664e442326128f88c3593cdab"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.3_linux_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_linux_arm.zip",
+          "shasum": "d70b976ed4b8153c22c6ec1ea2d840a8392cc8939b311e78b21cab697604c158"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pipeline_0.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_linux_arm64.zip",
+          "shasum": "bf342a7d5fa6e3ede95f058ee753ed321fd878c817e08143f253197571374e58"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pipeline_0.0.3_windows_386.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_windows_386.zip",
+          "shasum": "a2d2c00271647112e450d7053955516a86c9c9a125fdb0c482fa814c05d4fc74"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pipeline_0.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_windows_amd64.zip",
+          "shasum": "88194d8baa457e055dc759ee1117b2ba287324351fb268f2c7a50335ffc9475d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pipeline_0.0.3_windows_arm.zip",
+          "download_url": "https://github.com/davidschile-automox/terraform-provider-pipeline/releases/download/v0.0.3/terraform-provider-pipeline_0.0.3_windows_arm.zip",
+          "shasum": "2fa36dc790e9df65e876b6de10f0bd444851a96136e7250e650614bf27cb23bc"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/harpooncorp/coxedge.json
+++ b/providers/h/harpooncorp/coxedge.json
@@ -1,0 +1,220 @@
+{
+  "versions": [
+    {
+      "version": "0.3.11",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.11_darwin_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_darwin_amd64.zip",
+          "shasum": "5ece3deb1ccfbc64ee99983b5fde1f33923365c50124b39335ab0b27ec598104"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.11_darwin_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_darwin_arm64.zip",
+          "shasum": "1a9cd8295d15d1aa8d50ee8aabf32a2e6cc438f3e5474219c7241dbb53266b7e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.11_freebsd_386.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_freebsd_386.zip",
+          "shasum": "17fa85e96fc5573533e7a4c01c40c2bdc325e284d714132e9c2bdbe8b0d5ab6e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.11_freebsd_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_freebsd_amd64.zip",
+          "shasum": "f1cf82f9b7c419bef6b0bd73c4ebbbdb3cbd8370d528c0839b71be60e0b4a019"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.11_freebsd_arm.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_freebsd_arm.zip",
+          "shasum": "81965668d374d5a58015fb1bf60c540f4b4334d0dc1aeeb37876174edf21600e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.11_freebsd_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_freebsd_arm64.zip",
+          "shasum": "7742ac7834e70c136c650d3f692f793032e8884dbcca7d21047d750123cbcbe3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.11_linux_386.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_linux_386.zip",
+          "shasum": "f6a9eda7815c6521c8186938c425ef856b3c03f58ca143f9bf9a2c6431608355"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.11_linux_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_linux_amd64.zip",
+          "shasum": "611ad74fc7d5804591402a799ed8f18cd75cb30456bd6fa36c3dd90dc83b1ab9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.11_linux_arm.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_linux_arm.zip",
+          "shasum": "c9cbb8b7efba088f4990543e504dc6b73f1e964ebe54294e0b0ed8d60bd37761"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.11_linux_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_linux_arm64.zip",
+          "shasum": "33352b3e98e9ddac90f124697cf04b733f5cba719a14c843a62eb382da5502d6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.11_windows_386.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_windows_386.zip",
+          "shasum": "2fc4d6114e0ed4af9cfeb3782b432a5e670a4f92a2eb1c48b5d4a8a0674ba53c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.11_windows_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_windows_amd64.zip",
+          "shasum": "08b5ad62825f6bb7e8eeb429dbcb97f19839022480cfb5b9745c048f390c9980"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.11_windows_arm.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_windows_arm.zip",
+          "shasum": "118c6cd6081301921eb5aa19f1a190476b920ebb6606f69c7ad7da1a6c34dd44"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.11_windows_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.11/terraform-provider-coxedge_0.3.11_windows_arm64.zip",
+          "shasum": "c9e5d3baa58778131715fc2d79d20ebcd96ca52a76ea144310021e65fb7d9dea"
+        }
+      ]
+    },
+    {
+      "version": "0.3.10-pre",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_darwin_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_darwin_amd64.zip",
+          "shasum": "374a1603de4994fc56a4403dda835a27f090f6d9dd57e1d0bab85732b6d35f6c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_darwin_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_darwin_arm64.zip",
+          "shasum": "25f11a091a47aedd88b6c89a1920fca3b69ac66db2e9e6520d0921169b92f08a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_freebsd_386.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_freebsd_386.zip",
+          "shasum": "a41284074bbdd565289cb6cfd5fa0100d1284cdb456e17463dcb83f1c0ecfd3b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_freebsd_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_freebsd_amd64.zip",
+          "shasum": "242d4ff626dd2cc4d1f4413366e6c66187bd4c73561cf3e3fa4ae3fc2695b4ec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_freebsd_arm.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_freebsd_arm.zip",
+          "shasum": "7cae28743a0290ce857f33eb1632d1498048d66389e035f4946fd8253b1cda50"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_freebsd_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_freebsd_arm64.zip",
+          "shasum": "28617934c97d05e9cfc4c20852da87d68cebcdbcac047fa7b18e3a6d4296e2b7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_linux_386.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_linux_386.zip",
+          "shasum": "4c7d9a767f710edbe3834acc5e949e7215b6ca4131a43b13e2a3c063feebc39d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_linux_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_linux_amd64.zip",
+          "shasum": "5fb1d7fcc41116f2d373554898c4826c9cff524ddbdecc9ac7758149f02af9be"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_linux_arm.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_linux_arm.zip",
+          "shasum": "c85abc8b90b8c1ef2b422e73d00aa3ee71a4b927cace1bb7789813d428d39dcc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_linux_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_linux_arm64.zip",
+          "shasum": "6aba0b54735ade4166fa083e71196b30957ac4ab04b46b5acdf2fa43c8dc28a7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_windows_386.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_windows_386.zip",
+          "shasum": "d7acef42cf7ae4864ce5c07dd7f0dd39e61e78fd0f7ec6930eb360ac3b77fa05"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_windows_amd64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_windows_amd64.zip",
+          "shasum": "90793805be01b7e15a3411a06a4073ed9ce97f487a37134091ea2d378a0d7b6e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_windows_arm.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_windows_arm.zip",
+          "shasum": "6b02aa306a9fe39dc9d60e6609a043502d84a04b780a42ff0c14030997f93537"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-coxedge_0.3.10-pre_windows_arm64.zip",
+          "download_url": "https://github.com/harpooncorp/terraform-provider-coxedge/releases/download/v0.3.10-pre/terraform-provider-coxedge_0.3.10-pre_windows_arm64.zip",
+          "shasum": "5360783442ea353a3140a9cd2a4bdbdf59c757c36c2759a4eb44a1f4e546fd30"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/j/Juniper/junos-vsrx.json
+++ b/providers/j/Juniper/junos-vsrx.json
@@ -1,0 +1,28 @@
+{
+  "versions": [
+    {
+      "version": "20.32.106",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Juniper/terraform-provider-junos-vsrx/releases/download/v20.32.106/terraform-provider-junos-vsrx_20.32.106_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Juniper/terraform-provider-junos-vsrx/releases/download/v20.32.106/terraform-provider-junos-vsrx_20.32.106_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-junos-vsrx_20.32.106_darwin_amd64.zip",
+          "download_url": "https://github.com/Juniper/terraform-provider-junos-vsrx/releases/download/v20.32.106/terraform-provider-junos-vsrx_20.32.106_darwin_amd64.zip",
+          "shasum": "3914c080005ae9b871e681b3cd822cb1cda18c8ec62475b1b038c9d68eff5d45"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-junos-vsrx_20.32.106_linux_amd64.zip",
+          "download_url": "https://github.com/Juniper/terraform-provider-junos-vsrx/releases/download/v20.32.106/terraform-provider-junos-vsrx_20.32.106_linux_amd64.zip",
+          "shasum": "208eb603e307f763ad7d69549819b6032dceb443e3fd113f0e262e262b993d2f"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/j/j-lgs/talos.json
+++ b/providers/j/j-lgs/talos.json
@@ -1,0 +1,464 @@
+{
+  "versions": [
+    {
+      "version": "0.0.13",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.13_darwin_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_darwin_amd64.zip",
+          "shasum": "9f7490e40abcb211d1e22f6d88a9a74e9b43ed6000257fb8d79e48d6bde68797"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.13_darwin_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_darwin_arm64.zip",
+          "shasum": "21717675bf325d97b940f0d40f80210f389c01a48f97edb06238ed406ace8410"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.13_freebsd_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_freebsd_386.zip",
+          "shasum": "9d8beed47b246ae82567380ec639735160b3ada5943654cb9bbcf239d5734649"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.13_freebsd_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_freebsd_amd64.zip",
+          "shasum": "f8f82a62c6f29de9f11a9b98e5007348634eb0076e59268288e14a613090acda"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.13_freebsd_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_freebsd_arm.zip",
+          "shasum": "6ac91c558bb78a895e6df05d432263456a3a52b522c48d0b19f190481f3f7a02"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.13_freebsd_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_freebsd_arm64.zip",
+          "shasum": "3043b373606a5b3b94e0dcfe233c8abc123c8bdb59756d3a865166bdc7aa8e3f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.13_linux_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_linux_386.zip",
+          "shasum": "a6ae53c9e79530c13b7b8fb604bd8ca2f24d5fa3fcd46e46fd712836b4bc1209"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.13_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_linux_amd64.zip",
+          "shasum": "5c02b41dc2b150a9bc2c04ad93128d5872fc15805a7dc600c6461b3dcf7eda79"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.13_linux_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_linux_arm.zip",
+          "shasum": "ca9ba4c309212b155c3294bffdb6c049557f9cc52a96cd9d2aedbb36ac5d6024"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.13_linux_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_linux_arm64.zip",
+          "shasum": "7512cac524c85bcfb524fd2307f0e6360abf3e68d5fb6147eec14ea008dbfebc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.13_windows_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_windows_386.zip",
+          "shasum": "9229412eebd66223d163e494a23aaae8925ba9642f34b959bf1629e70836b7b2"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.13_windows_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_windows_amd64.zip",
+          "shasum": "18263979ceeb2546ddb9de646fb72e066ca003ff3b3120400ebc4b8d00451cdf"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.13_windows_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_windows_arm.zip",
+          "shasum": "5cfc6da1a25e159841ee946aa5eb32ec029574623a24c14ba1c849493fec8073"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.13_windows_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.13/terraform-provider-talos_0.0.13_windows_arm64.zip",
+          "shasum": "5035da544cf8623f1bd1137dd4b3feadcef6a745c2ceb500f1b77b6501a395ac"
+        }
+      ]
+    },
+    {
+      "version": "0.0.12",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.12_darwin_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_darwin_amd64.zip",
+          "shasum": "e0989e92fbca7105e40e3e964f87a5e97f828a10293ed6aa81bc53e5b7c76650"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.12_darwin_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_darwin_arm64.zip",
+          "shasum": "40ba596c1bcc402dbc41ecb95b948c6e5d6dfda6fb5c1c58aea3d776fa6359ad"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.12_freebsd_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_freebsd_386.zip",
+          "shasum": "a4cb054d7db76d90dfa1cf0936a3454884f82a7f5273e0c0ee6d208241c4d167"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.12_freebsd_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_freebsd_amd64.zip",
+          "shasum": "cf4f40a1929f65c0f493a0d790ba32306abcf67d680d5e7931fd5e29c0b32ad9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.12_freebsd_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_freebsd_arm.zip",
+          "shasum": "8fb37ea85ca611dc60d2397256b9036b132f365d1151db781b23746a2f528cf0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.12_freebsd_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_freebsd_arm64.zip",
+          "shasum": "10b8b4956df2812c7044603bc257738a490da7bc1f6783caf078f7eda156af03"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.12_linux_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_linux_386.zip",
+          "shasum": "122c07ba0a67bb36b7985a6abfbc0b3653f9b19c9422142ab4f3a9dc138e572f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.12_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_linux_amd64.zip",
+          "shasum": "a5366e9df14a0309071ccff8b2117d6b6c6355ac67263b04fb5785fc7f6d4c1f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.12_linux_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_linux_arm.zip",
+          "shasum": "b50433b1102a1513b5e6e86117c7bbec45bcd357a71f5a9b1cfb1d41b21aa410"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.12_linux_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_linux_arm64.zip",
+          "shasum": "b6146ac0657c7c7b8546bc39b6d2a4b75a7cc04a744c9767dd79c9a50c70805f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.12_windows_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_windows_386.zip",
+          "shasum": "9593c4cc435a33eabf7e7c2dcfdfde322bf4823d047675389ccf01c087b3ec72"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.12_windows_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_windows_amd64.zip",
+          "shasum": "a17ca1880ef0b6aefcbd953a11fa1d7d576c9b29b31201bd46470ac8d594cf64"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.12_windows_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_windows_arm.zip",
+          "shasum": "f48a3dea5b08b21b18a06c1ea3fe9a64a4c9750304d91d3157c89a4f041e52fc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.12_windows_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.12/terraform-provider-talos_0.0.12_windows_arm64.zip",
+          "shasum": "d387a8b2f621aaa30b52a07932a5788001ee084d4e56d0d4d63a963965c0b938"
+        }
+      ]
+    },
+    {
+      "version": "0.0.11",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.11_darwin_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_darwin_amd64.zip",
+          "shasum": "af2e972b084dd0aba7afbd2c24da6dc135d0dfbe5579fcc921bb7b589bcdaead"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.11_darwin_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_darwin_arm64.zip",
+          "shasum": "608949f6c57d9b0dd5f83d7b6a701f9e45c02d0d1742fe33cf584757ecca6923"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.11_freebsd_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_freebsd_386.zip",
+          "shasum": "1fc237527b82f0fec20592e6daf6ae93faf5869fa59321c302fd2361c2cbfdbd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.11_freebsd_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_freebsd_amd64.zip",
+          "shasum": "adaf7b2972390d9abed9ad455e8a77927cacb15b19ed5319a7118785c75d4e0e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.11_freebsd_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_freebsd_arm.zip",
+          "shasum": "b30451e1d0af607ece1ecab91e8c9371a0cefd8020f6f8684aa4a5c11e0d27c5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.11_freebsd_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_freebsd_arm64.zip",
+          "shasum": "43c65d7e541a5bb8e6fd86dfe2b2ff5dcce391c1e4681ea7e24019d26dcddd71"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.11_linux_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_linux_386.zip",
+          "shasum": "912f58516e4e6efb94f3e3a39af1217dae7aa38d49f2299db77fe7d8fdc593b0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.11_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_linux_amd64.zip",
+          "shasum": "94f5d6338ac85c0f0db9e53721fdc6cb9077f1e9536e5f779de6181788fc233d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.11_linux_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_linux_arm.zip",
+          "shasum": "136e8350f6cb671b5c890589510adc88191df9c1c007214618c71ab3c66389c4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.11_linux_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_linux_arm64.zip",
+          "shasum": "8efe906bd97b8b6837e5fa81aa91e162aa3e067596ed9bd023320ff7e851c8f0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-talos_0.0.11_windows_386.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_windows_386.zip",
+          "shasum": "12b2329457cbc9f419ea57c98521be7de3d0d508bb38b00c276435cea7c37e3b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.11_windows_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_windows_amd64.zip",
+          "shasum": "50d8b78e30d765e222fdf1972f0a54a23aac718762ae388e8b0c3994b2643f03"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-talos_0.0.11_windows_arm.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_windows_arm.zip",
+          "shasum": "d6fc3b2630d41eefa105f9e83c1e54ddd2a7c17af523f8d4ed3836cdce056b5d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-talos_0.0.11_windows_arm64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.11/terraform-provider-talos_0.0.11_windows_arm64.zip",
+          "shasum": "bcb3b5f3fcc384f9fc5f40cf2ea722f6a8e0c1a729aa8abfb9ca13d41fce811d"
+        }
+      ]
+    },
+    {
+      "version": "0.0.10",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.10/terraform-provider-talos_0.0.10_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.10/terraform-provider-talos_0.0.10_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.10_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.10/terraform-provider-talos_0.0.10_linux_amd64.zip",
+          "shasum": "1f71098dbfa580db25199651fcf5a32b1554465be26ee14d004b6695793141fc"
+        }
+      ]
+    },
+    {
+      "version": "0.0.9",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.9/terraform-provider-talos_0.0.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.9/terraform-provider-talos_0.0.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.9_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.9/terraform-provider-talos_0.0.9_linux_amd64.zip",
+          "shasum": "a785f8cb68b9fa078eb6de600a390929441259d3bdd1df4421381e5684599369"
+        }
+      ]
+    },
+    {
+      "version": "0.0.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.8/terraform-provider-talos_0.0.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.8/terraform-provider-talos_0.0.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.8_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.8/terraform-provider-talos_0.0.8_linux_amd64.zip",
+          "shasum": "bcdeb8272e153db396247bc833351b4fd7f847e900374e375fe85493ddf92272"
+        }
+      ]
+    },
+    {
+      "version": "0.0.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.7/terraform-provider-talos_0.0.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.7/terraform-provider-talos_0.0.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.7_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.7/terraform-provider-talos_0.0.7_linux_amd64.zip",
+          "shasum": "f53d61bd6ab5d76eb5e6565f97d23607ddc06c0e5da1b44ef4b45748b32ebfa6"
+        }
+      ]
+    },
+    {
+      "version": "0.0.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.6/terraform-provider-talos_0.0.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.6/terraform-provider-talos_0.0.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.6_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.6/terraform-provider-talos_0.0.6_linux_amd64.zip",
+          "shasum": "a48a46205ce56c8f5b1a2a92b6aeeb2cb6a17201566f661ebf49e7240efd48df"
+        }
+      ]
+    },
+    {
+      "version": "0.0.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.5/terraform-provider-talos_0.0.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.5/terraform-provider-talos_0.0.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.5_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.5/terraform-provider-talos_0.0.5_linux_amd64.zip",
+          "shasum": "5a0d4923a6f548f86e864315de3bbdb051fbbf1cb48f3fa10db309c26a08052f"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.4/terraform-provider-talos_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.4/terraform-provider-talos_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.4/terraform-provider-talos_0.0.4_linux_amd64.zip",
+          "shasum": "bfe6edac19981a4ee6d2f0f24061eb9db0ebc0f93125da2c183f8232ffc20939"
+        }
+      ]
+    },
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.3/terraform-provider-talos_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.3/terraform-provider-talos_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-talos_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/j-lgs/terraform-provider-talos/releases/download/v0.0.3/terraform-provider-talos_0.0.3_linux_amd64.zip",
+          "shasum": "2950893fe1689e4e4e62218cc6bea720f63f8cfdd33985dffa0d700f833b60e7"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/j/jimmydavies/eventstore.json
+++ b/providers/j/jimmydavies/eventstore.json
@@ -1,0 +1,326 @@
+{
+  "versions": [
+    {
+      "version": "0.0.11",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.11/terraform-provider-eventstore_0.0.11_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.11/terraform-provider-eventstore_0.0.11_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.11_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.11/terraform-provider-eventstore_0.0.11_darwin_amd64.zip",
+          "shasum": "cce2d549d6a954eb89789c2f514bfedf8be5ea47392a4d06fac62b145a6f1866"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-eventstore_0.0.11_darwin_arm64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.11/terraform-provider-eventstore_0.0.11_darwin_arm64.zip",
+          "shasum": "56839a6d42729d8cc3b92d5b30e4239f2ef3f14bc1520174892ebf4e3a055461"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.11_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.11/terraform-provider-eventstore_0.0.11_linux_amd64.zip",
+          "shasum": "74a35e31d0785a6022776b541dd19ee3dec25a5f05bd4e476127203359ee011b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-eventstore_0.0.11_linux_arm64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.11/terraform-provider-eventstore_0.0.11_linux_arm64.zip",
+          "shasum": "d594dee52f1f71f8e60082eb81d7ce2c87d73fa058849ecfa2eceb5e6b1e4a66"
+        }
+      ]
+    },
+    {
+      "version": "0.0.10",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.10/terraform-provider-eventstore_0.0.10_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.10/terraform-provider-eventstore_0.0.10_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.10_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.10/terraform-provider-eventstore_0.0.10_darwin_amd64.zip",
+          "shasum": "e5414fcf17c0ae5f9924927ca0a853a2bb1fc919619b6662645c496982cd5461"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.10_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.10/terraform-provider-eventstore_0.0.10_linux_amd64.zip",
+          "shasum": "f56d70e9767fa5558f7683663084afa82bd349874262d56ee6df79e3136c1ec5"
+        }
+      ]
+    },
+    {
+      "version": "0.0.9",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.9/terraform-provider-eventstore_0.0.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.9/terraform-provider-eventstore_0.0.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.9_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.9/terraform-provider-eventstore_0.0.9_darwin_amd64.zip",
+          "shasum": "f3223c59e5bf39339e00f199f88a8afe68c3a93000eb93e8f2f5ef945acd1ab2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.9_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.9/terraform-provider-eventstore_0.0.9_linux_amd64.zip",
+          "shasum": "23b50066854f9c167d77a458d9c27e5c75d86475d8fea7a3380fe8cbd4d4b820"
+        }
+      ]
+    },
+    {
+      "version": "0.0.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.8/terraform-provider-eventstore_0.0.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.8/terraform-provider-eventstore_0.0.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.8_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.8/terraform-provider-eventstore_0.0.8_darwin_amd64.zip",
+          "shasum": "5d4198d4fa0e27ae918308bd050a964e25c300037736472234433d6ca2d5785c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.8_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.8/terraform-provider-eventstore_0.0.8_linux_amd64.zip",
+          "shasum": "6893aeed622853129130a5b0aee3486e2e70b029112c29333189d05ce374fca6"
+        }
+      ]
+    },
+    {
+      "version": "0.0.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.6/terraform-provider-eventstore_0.0.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.6/terraform-provider-eventstore_0.0.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.6_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.6/terraform-provider-eventstore_0.0.6_darwin_amd64.zip",
+          "shasum": "a062da3aa4c3feb672cbdba079b1dc9ef934cf26229584f24d48b236416a0032"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.6_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.6/terraform-provider-eventstore_0.0.6_linux_amd64.zip",
+          "shasum": "e3d07e3eafc6be991c21e2d5bfbc48829a22b5442f1c692ac6fc20945db222d5"
+        }
+      ]
+    },
+    {
+      "version": "0.0.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.5_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_darwin_amd64.zip",
+          "shasum": "c2bb5ac66e20cf2e5feffc8bb031d5188fd18bbe524377610c1271f100319db9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-eventstore_0.0.5_freebsd_386.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_freebsd_386.zip",
+          "shasum": "ec6d8fea85105ce1cc17c9d081780aed589a6326e3bbd5cfe86e1f608ba165b3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_freebsd_amd64.zip",
+          "shasum": "ec4296dbcd845cefa450924d3a6a793c5b048006143437f369f93c947f5b976f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-eventstore_0.0.5_freebsd_arm.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_freebsd_arm.zip",
+          "shasum": "69c292ba624b658fbb7ce514d5c593add8b1e170eeba6cd62ab6e7f9a0dba134"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-eventstore_0.0.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_freebsd_arm64.zip",
+          "shasum": "6fa50104dfed882ae124bc094b97e4dcbd15f1cc2b49489986f4d927a30820fb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-eventstore_0.0.5_linux_386.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_linux_386.zip",
+          "shasum": "0a2a9433aaafb057e9571f85c41e25435b51b553a5189319a3c6acd70c7181a7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.5_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_linux_amd64.zip",
+          "shasum": "0deafaf3b410bd5bcb604e02d726e7cb7fdae9a92c8a8cee73e03e6658a1ed78"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-eventstore_0.0.5_linux_arm.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_linux_arm.zip",
+          "shasum": "c769ffc3929b0fbeac94de874f9b3d0900b5fd723646aae6867d94a6d986a36c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-eventstore_0.0.5_linux_arm64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_linux_arm64.zip",
+          "shasum": "e51059aa12e1cae52a7027271574830d50ff0af424144ca104b2e7dcd8fc9c5f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-eventstore_0.0.5_windows_386.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_windows_386.zip",
+          "shasum": "3f43c3064fd73b75e129d1c77827fb53c5dcb98f467eff101e68ae30e8cd55f8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.5_windows_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_windows_amd64.zip",
+          "shasum": "59076775f1018d3c2778b44c6e7626af3e01216e73ea662589f73afe8cd88357"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-eventstore_0.0.5_windows_arm.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.5/terraform-provider-eventstore_0.0.5_windows_arm.zip",
+          "shasum": "8391acb888ae953c0276ed6a593ef0da88b6e3666c0fd0733fd16c421325c25a"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_darwin_amd64.zip",
+          "shasum": "61cdf4f6109495618635079cdfb7e737a6dfcb1f93f55950c0b9e6358eb2c0a9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-eventstore_0.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_freebsd_386.zip",
+          "shasum": "23982c9007b9d38d1e14f3d99209a5eae1fdc102eae83f4c63834199ca9b2f28"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_freebsd_amd64.zip",
+          "shasum": "af85c53449f7fa7acf18f1134cfe83d8fd93158045a2045e9b079d843022447e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-eventstore_0.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_freebsd_arm.zip",
+          "shasum": "72a5410339e368ee0b347c0d2778b7d1b58ac9d808795cc50cbb11cf988a412b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-eventstore_0.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_freebsd_arm64.zip",
+          "shasum": "2ce86c10779986ccfb18a316513ffcd7df8c8e365407de28e49fc4bd4d0354e0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-eventstore_0.0.4_linux_386.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_linux_386.zip",
+          "shasum": "e44efc6ef4ddfca8f179c2be63584c8c77624ec1dcf413921a78b5625725f3d5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_linux_amd64.zip",
+          "shasum": "d95e4af6bd90b1fb83265ea3415d2eab5bda7274b1776ea503389a2e7ee65aff"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-eventstore_0.0.4_linux_arm.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_linux_arm.zip",
+          "shasum": "e4b54c5e3a7a5a4acc31220177f5426aeb5b81c1ebca9b348f1983a13bae371f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-eventstore_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_linux_arm64.zip",
+          "shasum": "83c49e92345349a72fe144994fdc5257b57f561ae24829c4bf09f1d994078995"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-eventstore_0.0.4_windows_386.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_windows_386.zip",
+          "shasum": "66b87c13215af39ad4204d42bd823a647cb3cdc9254c1b40744a5527f9213245"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-eventstore_0.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_windows_amd64.zip",
+          "shasum": "61316841ee72fbd2c07a4f2c11f6100508102bba1934ec45c1c32bf76d5cf489"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-eventstore_0.0.4_windows_arm.zip",
+          "download_url": "https://github.com/jimmydavies/terraform-provider-eventstore/releases/download/v0.0.4/terraform-provider-eventstore_0.0.4_windows_arm.zip",
+          "shasum": "bc98d274ce1ff6472b728b134f88a88c60739aa12ac056409fad68a457f87f87"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/j/jsporna/pesel.json
+++ b/providers/j/jsporna/pesel.json
@@ -1,0 +1,328 @@
+{
+  "versions": [
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_darwin_amd64.zip",
+          "shasum": "c2cab6b85f41d68b9d47e1d1514b5024af6b6518c9ebe22dc70ad442a1fc4885"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_darwin_arm64.zip",
+          "shasum": "43333d576d55b041ee79e93dfaf8c2722f0a79ea0bcab380033147f66d319f45"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_freebsd_386.zip",
+          "shasum": "b99a4ba796d0fd47606823db8486abd20759b7c2da8916e13906fd08ea1cdae1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_freebsd_amd64.zip",
+          "shasum": "e135da7c77a46c5c4b1641ce1ede7cfe01d6e932837a3403ea19683947fcd899"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_freebsd_arm.zip",
+          "shasum": "23703f57bee5aec2e90d77cefa21103d19bddf607095e292b1f8775cdb9eb69a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_freebsd_arm64.zip",
+          "shasum": "7459f451462bad8e9f01e12f042c70afceb5c37bbbf223c4924527b4e8467d52"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_linux_386.zip",
+          "shasum": "3e1833b67a67e6e1a4574d246d28c594e1c0ad3716240c41dae25d7ee07560d8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_linux_amd64.zip",
+          "shasum": "806bcf226a72d7811d4336bed7e62cd5199fa7e705280a560463b7ff28e4324b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.2.0_linux_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_linux_arm.zip",
+          "shasum": "9243da6e86a64161835636537a681924da60951e24424f2281baf8f7fcec4a8a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_linux_arm64.zip",
+          "shasum": "ccc8615b53b5472279fc176742a304139485ac5b440984abd36f61729ea97e87"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_windows_386.zip",
+          "shasum": "694e9842b2175a9eda2351a4b076344ba45046c36838c58292df0885af7e7a43"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_windows_amd64.zip",
+          "shasum": "2453f513a58f60e277138293c5c5ee9b693b423d0f5287e5042533caddb7f247"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.2.0_windows_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_windows_arm.zip",
+          "shasum": "19b09c7964dfb0c7a770cbe8bad969de7bf92bb374be9c633203b8f2864f1abc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.2.0_windows_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.2.0/terraform-provider-pesel_0.2.0_windows_arm64.zip",
+          "shasum": "31ecdf79bbb265d4a11d836ff77c81b56822addf4686938c8b3501bbc6f247ea"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_darwin_amd64.zip",
+          "shasum": "9bd12a3335759a858e90d22d9badae6c1ee63d9b0f59576099c3e1ff2ff739e5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_darwin_arm64.zip",
+          "shasum": "65d0254cdd26d3959f87c7e638a69ab892884d57b45a48df935a5de412ebb30e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_freebsd_386.zip",
+          "shasum": "ffbf72082d796d69b1437cee838f1fcbe02b11c40bab94140c82b80e4a6cf080"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_freebsd_amd64.zip",
+          "shasum": "248c568c4cb3d8cf0839e8b0b027313a3cc61238eacec300cdcff190ac683abd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_freebsd_arm.zip",
+          "shasum": "ccf6b734a846a7988885a808cc946c349811644ad50f38e6538739120d682033"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_freebsd_arm64.zip",
+          "shasum": "9f3a8013ee6fddf94d88889a36b8c45355511ce67722ef50ea4a72b9e7daf8ee"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_linux_386.zip",
+          "shasum": "5ee813a7cd9b5c9322683c5619a94d092297911f02640dd7757a44d1a4351745"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_linux_amd64.zip",
+          "shasum": "89c901d10dcb9df70f9beb285f9974d97fe52aa4315dbf99c16a2894430e704d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_linux_arm.zip",
+          "shasum": "3314e5989f0eb276735545a5fbaef05439a87a2e6d3b3c453aa81e6ac3ea60ca"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_linux_arm64.zip",
+          "shasum": "2b5e8713f3028a8d8995068a875975e186c8311330aa990568a1b6094417ab67"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_windows_386.zip",
+          "shasum": "bc0945834c95ce6a895e56b655093689a609faf62358b002e10744f16bda8f21"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_windows_amd64.zip",
+          "shasum": "f7658704cc33a5db41dbc4752a718f59ad40df700a2c0ad87d124e41f57037dc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.1.1_windows_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_windows_arm.zip",
+          "shasum": "cb4a8993cc541cb9144603b27a6bd2668929abcdd46a114ee53ccf49710368ab"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.1_windows_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.1/terraform-provider-pesel_0.1.1_windows_arm64.zip",
+          "shasum": "ab1eef36b81fc0df118d150024d13c6f91f3fcc381c54e7398e45a1d29659312"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_darwin_amd64.zip",
+          "shasum": "6d7be2ca34001a39d78b849d568ac27356ba38a907f5ef06fdf7400accc80a1d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_darwin_arm64.zip",
+          "shasum": "3d202f65c0b1394e0fa8e201eb5655669d12622bc9915c4aa47efcebfe12c70f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_freebsd_386.zip",
+          "shasum": "d83cf33b9f6f9f894e0afef6ccc071d9c50995823b963714ef344945672b845f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_freebsd_amd64.zip",
+          "shasum": "91719cb67539b5131e674628801d07477c6223b48409a7541760250feb5ba2bb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_freebsd_arm.zip",
+          "shasum": "4b0c8d0a145e15b6cb59bf1735d5ae9a8a7d8371e5e1050c68584212c09d5964"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_freebsd_arm64.zip",
+          "shasum": "35a7934c032ef1ad30fd3200639c71ffc3d62dc33e6744dd53537652f9b022c8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_linux_386.zip",
+          "shasum": "c8ed02e8e5e32c79237869bee5cd07b1e2119e9239a41ce7150634e4baf58981"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_linux_amd64.zip",
+          "shasum": "620ba573e2dfb6d2bd4dd5b856e51a5174e746cbd8cca3d9d4d67a38fb98d721"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_linux_arm.zip",
+          "shasum": "1aa674a1c679506db27f4bab9134eaa47dfee33e0fd8b4576fe4886b2937ec34"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_linux_arm64.zip",
+          "shasum": "71c3d7761ef42b63b98bee1fe304e69ad391d83313c77e6b883e16e6fc03bdb4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pesel_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_windows_386.zip",
+          "shasum": "a0690b1d4d6279ef2385700f87c3a50378aeecf028c3a1c3d737542c08e8e110"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pesel_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_windows_amd64.zip",
+          "shasum": "f99c36b998f8d6b59ba8faccf202f4367533039e19a0a038315e356d5a4060c8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pesel_0.1.0_windows_arm.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_windows_arm.zip",
+          "shasum": "de85dd4cafe9cb0f6e0cbb650e3a815e76fc07feee39e16ebc017a1b91730ead"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pesel_0.1.0_windows_arm64.zip",
+          "download_url": "https://github.com/jsporna/terraform-provider-pesel/releases/download/v0.1.0/terraform-provider-pesel_0.1.0_windows_arm64.zip",
+          "shasum": "6d168242cce1612b4caa315e6c9ee8f789c238fe8c56d4aaa3e350bd296c13b2"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/k/Kamatera/kamatera.json
+++ b/providers/k/Kamatera/kamatera.json
@@ -1,0 +1,1376 @@
+{
+  "versions": [
+    {
+      "version": "0.8.11",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.11_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_darwin_amd64.zip",
+          "shasum": "94687b90566d72486e4056ed3e08227a897979d3443a2adc56047593bfa80e31"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.11_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_darwin_arm64.zip",
+          "shasum": "3c36c5f0da954e7117c2c49204a9adbf1b3f213c94bddcba8bf9de27af205a33"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.11_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_freebsd_386.zip",
+          "shasum": "26c5a9fe9b7e9e04e28fa545bef69c8d4a2363e1f9e0b5942ecf526fb61da5e7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.11_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_freebsd_amd64.zip",
+          "shasum": "8caad9f0a4c5114a776a6ecf36d6da5e1c5b896214dcc1ed4da870ecaa23238f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.11_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_freebsd_arm.zip",
+          "shasum": "7aa6cd76b72c9bbc660bef5136e666ef04610ab6d350954fe288d33d518c752b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.11_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_freebsd_arm64.zip",
+          "shasum": "740d8aed5b39f635db82091d14197b91bcf3f5cb0524e8397dadb55226b0acff"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.11_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_linux_386.zip",
+          "shasum": "d6568b922b1b54c28aab4e1e4b1a12a94b26785a353a45b2e3c0255a8f6debea"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.11_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_linux_amd64.zip",
+          "shasum": "ca96d40b83c2fceac2190bebcaeca335dd78caaf94a8b5fbf2975f9f006b2d2f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.11_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_linux_arm.zip",
+          "shasum": "0037236ce31742e191cdece74e05e4d2df343081d187b9e473de6cab2139f864"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.11_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_linux_arm64.zip",
+          "shasum": "9cb766f18303ac2efbfe059fe96663eb607aa19d900f1bb809a2f479dd3de419"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.11_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_windows_386.zip",
+          "shasum": "c66ebd2a0fe7e570dee500c6c40c0e8f349e2d079298636109243aeb9058939a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.11_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_windows_amd64.zip",
+          "shasum": "ad18674466d8827fe29d7334366e558ea273d5eaada9954a44c6b6e80d55b387"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.11_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.11/terraform-provider-kamatera_0.8.11_windows_arm.zip",
+          "shasum": "bcad4e7a4a3cd84869f4c3ad6c1286a76b47a9488f3897793ec06e5f1a0b44f3"
+        }
+      ]
+    },
+    {
+      "version": "0.8.10",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.10_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_darwin_amd64.zip",
+          "shasum": "8aebe75d29a9e868ab70bc3617aadef84620989c41bc13a3b2a490198678e1bc"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.10_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_darwin_arm64.zip",
+          "shasum": "0a53e1e94757aa4ae6a4d289ef594573e32e8e4853ff78c87dc546e4ae22cecc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.10_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_freebsd_386.zip",
+          "shasum": "0b76e27a08df371230aa888ddf2074113351db2f06eed0c8fd028d1f99093a75"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.10_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_freebsd_amd64.zip",
+          "shasum": "b50c6c9c9dce35a5f4f8d3076a69624e737faae256af0f30e5c9490c31a26661"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.10_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_freebsd_arm.zip",
+          "shasum": "10d8a63b3dd929808911632ec52e8276d256257a200f9f8772a34e84a36af779"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.10_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_freebsd_arm64.zip",
+          "shasum": "0bc844a2df156e7382c9faa745b8fee7340244853555d8be453a6be8990f0d3b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.10_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_linux_386.zip",
+          "shasum": "e5d518967fd6398e029f85b1e9629abbc158822516e566395b62a97e19ec843a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.10_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_linux_amd64.zip",
+          "shasum": "5a807800ed42a58b19f4a792871eaa5f9de2f369d5c239c42c307d8f517384ad"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.10_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_linux_arm.zip",
+          "shasum": "b6def048b10431a166ae8bd22e2d6dd1f2a7ff65fa650769350106ed511da6cb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.10_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_linux_arm64.zip",
+          "shasum": "80bee2c478a274c2fd94eafe382274e46e224810f942f95e2cfeae9b3f66dffb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.10_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_windows_386.zip",
+          "shasum": "c695eadc414b642f03ac4cf270ab60dbc0262cc78692eda9723c67c4560db753"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.10_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_windows_amd64.zip",
+          "shasum": "e87624163b1d51f92507fc01088dc17268ea33011a9dba9d6b8ad8fbbe80b32e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.10_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.10/terraform-provider-kamatera_0.8.10_windows_arm.zip",
+          "shasum": "c36adedd90359d3851ea957adf33500eb7dfdc1ac30621a0ddbe7a7b79705c9b"
+        }
+      ]
+    },
+    {
+      "version": "0.8.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.7_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_darwin_amd64.zip",
+          "shasum": "62b2e0d840c504aeafef9f358eb93b3b0a6964d4465bc709fd7daccd68c7b323"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.7_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_darwin_arm64.zip",
+          "shasum": "614ce02eb2f29b9be6a3d90bcf618f8f5dff14417ae3c5d6c41a71490bbb6800"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.7_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_freebsd_386.zip",
+          "shasum": "c60b43d128f3eeb110695cb096f7536ace92765b7a8d1d584fecb92467c56da4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_freebsd_amd64.zip",
+          "shasum": "3c354430751f3f1b966bce3c971ae817034de0de7034de20c7d0344d38b09750"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.7_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_freebsd_arm.zip",
+          "shasum": "e88f35aa57e5a78f19b9228ecaf313c190049a3b11a8a1182b17d7d4c596d77b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.7_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_freebsd_arm64.zip",
+          "shasum": "1799a1f819d1de61dbeceaddc047c1727d3449b824722fb6f42809dc7844ae4a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.7_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_linux_386.zip",
+          "shasum": "dc243caa401f54afb4c16f03446af2f99ebdcb4ac8d5716a27e73a60e5a9ec31"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.7_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_linux_amd64.zip",
+          "shasum": "66fa33463d8a0b64b45821214f8991f58325fce441bb9cebb9198866618803e1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.7_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_linux_arm.zip",
+          "shasum": "70b51e47c4a00b49182accbd101cb80775c815db0fdcabb14f4af05569e0baa1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.7_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_linux_arm64.zip",
+          "shasum": "e09a94f1a6550fbc5c589fe10b06268250c879971d0ffb1562e4e77fb17255bd"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.7_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_windows_386.zip",
+          "shasum": "d0f507704008b543c3fe7a01d28d54e1f20e42e8b7a15630b7f30b15d270737a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.7_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_windows_amd64.zip",
+          "shasum": "7e42f8a693fe142394188f3f499892e905ea35c4ed821c0a31824a68ffd36a68"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.7_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.7/terraform-provider-kamatera_0.8.7_windows_arm.zip",
+          "shasum": "1e7a48373bf67ed1bba316059a5c1b51f3a2d66a73f16b528e85bae1b6d36e43"
+        }
+      ]
+    },
+    {
+      "version": "0.8.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.6_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_darwin_amd64.zip",
+          "shasum": "01d03244264d97265e972ee7e526f8280c437e5b8f8334059cfd531872fc0f0b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.6_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_darwin_arm64.zip",
+          "shasum": "72b55f719baba4cb22545e98dbc41ef2390448512a2364ed668ab30bbc9c062a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.6_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_freebsd_386.zip",
+          "shasum": "0bb2ddb3d896a8499ff7badd67479d80db39a40f98e7931f5d9274adc607ad2a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_freebsd_amd64.zip",
+          "shasum": "d6a2c975cc24ce9ddef03db1b1e884be747dbaac187dac11d833e053a5c6ef9f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.6_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_freebsd_arm.zip",
+          "shasum": "50d51957490c40b6ffccc9afd3225c0e5e17142f08209fc0a05149858bd06101"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_freebsd_arm64.zip",
+          "shasum": "915b88c6d8f095ad9bab80fa516d60d87e88addcf94a71f4cfd1c5a5d1fbb3ce"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.6_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_linux_386.zip",
+          "shasum": "98015edf869defdf115a9e66e4f258e4d2e5b371eec6ff170fb7ac82dd53b030"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.6_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_linux_amd64.zip",
+          "shasum": "38fa988db3a1e97081e330f2323ad749b020afe9324bc29f19a72407942b448d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.6_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_linux_arm.zip",
+          "shasum": "5289875bd72b197b1af1b41598bde2a8dd5d8cf2b3b9d1ae73c1c7d114a47943"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.6_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_linux_arm64.zip",
+          "shasum": "62b4556be53d6d5c6aa6b065f830976d2f8bd6ef99f45d1d84274f875bb2c0af"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.6_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_windows_386.zip",
+          "shasum": "2ddf4fa2cfaa1d2d151903fed0b0ed1a2d43761091240358bf4e9df336afc0c8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.6_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_windows_amd64.zip",
+          "shasum": "44184d64b3ac93e6fa820b092ca0561cdbe769f105fbdca895b253f1a14a3f87"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.6_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.6/terraform-provider-kamatera_0.8.6_windows_arm.zip",
+          "shasum": "653e08980e862929be548b8e52678a3e9cafe3bf5bdf4c681575ad2778f4f65f"
+        }
+      ]
+    },
+    {
+      "version": "0.8.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.5_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_darwin_amd64.zip",
+          "shasum": "cadd247bf395e408a3cc95111a9d609e5bfbf616be4483344e00311c987381bf"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.5_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_darwin_arm64.zip",
+          "shasum": "365058ce042d01fb8f8f1588138a4bfd6413e013ee9bdf9b40f67f409e4ae1a6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.5_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_freebsd_386.zip",
+          "shasum": "1a3695455e1bebb275fb7a89c0d712ecb7619c2ab2b990bf0304b45f67b5cdf7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_freebsd_amd64.zip",
+          "shasum": "b9e9bbd73ec0f045f2040030762f3b4db010de8e5f148fc84b352207df632ae6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.5_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_freebsd_arm.zip",
+          "shasum": "078ccc1916b0066d263f074dce946c7eee6ba25e9a6b6b76f82ecb1d6fa71656"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_freebsd_arm64.zip",
+          "shasum": "2020752aa68f733f682d14d00fc1df7c47d64e3136fba914fb614115322ac51e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.5_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_linux_386.zip",
+          "shasum": "45b0640e6b8a3d591ce5bcee4b86ff73a8cee910d9a51fd7cab35d3321f7f593"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.5_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_linux_amd64.zip",
+          "shasum": "92a67c114dcc834d5c5a1b64708a3058ddd9b61a25c7ad6d855bf4c7bdbb5239"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.5_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_linux_arm.zip",
+          "shasum": "fb10cd4d474b2b7194e42fb26de65a2e757fd99af61e8d99326499c3c4dad050"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.5_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_linux_arm64.zip",
+          "shasum": "6450861e2ffd25c154771d6291fcb79fb4f2b474bd436e46bb93aaaf44fa0fed"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.5_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_windows_386.zip",
+          "shasum": "e7f16fe1e38f0b20ac991aa16f479bf550f0d6d74ab7ce2a87f1669e71f72506"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.5_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_windows_amd64.zip",
+          "shasum": "f4ffc53a6237c5ae0a9887f23e7698bc83543b405fdfb5e3017a8a56d6e7624f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.5_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.5/terraform-provider-kamatera_0.8.5_windows_arm.zip",
+          "shasum": "2a887cab91744581c45fde3c914b561f38af0e5f04bf945c294ad57dd7f6559f"
+        }
+      ]
+    },
+    {
+      "version": "0.8.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.4_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_darwin_amd64.zip",
+          "shasum": "ab86e04d488a853eefb1f668092af9879022ae3867860ed215f4ce53b2074f86"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.4_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_darwin_arm64.zip",
+          "shasum": "93aed21d0a921d15d9964c96f6a56e3e55efac7024803be87730289cfc91c23b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.4_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_freebsd_386.zip",
+          "shasum": "82d0b9cfe3d292912a7e1559547f69a9a1fc825c9da3206afe057b19077adfa3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_freebsd_amd64.zip",
+          "shasum": "1385d7a6ae06b6fac42ec67401c2e8f0970d8d1bc7b6b92618cb08315c50fc6c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.4_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_freebsd_arm.zip",
+          "shasum": "a07c718a6e95cb3a7c692f0a3181f7bc64489c4dfcb1d64fce47ac66e3009c01"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_freebsd_arm64.zip",
+          "shasum": "e0fff6f7aa43c6b2599a70d2ddb4e3fe5ce22ba484296be18c5f8f9cda7605a9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.4_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_linux_386.zip",
+          "shasum": "e9da753ac80dcbe005ded976b62e5ceeb9edb3f22fe5ed15dfaa6094bf14b6ee"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.4_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_linux_amd64.zip",
+          "shasum": "bc0812fb5ce3d82601245b46e2dd00fe4f3081478dabfb381683176de9fafbb0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.4_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_linux_arm.zip",
+          "shasum": "77ccdc52f27f29da51331881b2acbe5851c5ef1c861d72084124bac99890ae61"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.4_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_linux_arm64.zip",
+          "shasum": "28a3266ce4bd99762df808cfb9859b4014792fd497c6990bf3020721206b343d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.4_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_windows_386.zip",
+          "shasum": "967ed375659ef11585b24c0732c5ab4603cbedb61389621eb7d76f1d1ac6de59"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.4_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_windows_amd64.zip",
+          "shasum": "f0968082f68e200cb04a6bfec05dd8878b8a9c667d300f7b2ea64cef3efe2c0d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.4_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.4/terraform-provider-kamatera_0.8.4_windows_arm.zip",
+          "shasum": "8c9bc4c4a57da6f4f956e804ec65bf353779fc9883f2da56e95a2990780d69de"
+        }
+      ]
+    },
+    {
+      "version": "0.8.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.3_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_darwin_amd64.zip",
+          "shasum": "8cad3593ca0fc24ecaa4e35d8b1c5e14bdeeadd555a745f5066d8704e250aaaa"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.3_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_darwin_arm64.zip",
+          "shasum": "929659b70d9a3193a91d5b9d17cd5af970026461492f0f87068cdfea25969129"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.3_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_freebsd_386.zip",
+          "shasum": "d5371976dbf5bf2d7c465bc366f8075127589063e16e46a8466c3512c68c3b67"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_freebsd_amd64.zip",
+          "shasum": "d48bfefdddc44674b2f022036da2cda37cf0c14fab15b01c939e2d6a4af58366"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.3_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_freebsd_arm.zip",
+          "shasum": "57a7782bd675dd7ae5a75ae03b94a56bcc0783350d4d5831d6b90030ae1390b9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_freebsd_arm64.zip",
+          "shasum": "c129a36324eddb969e804b373d288ec89c332bdef8bcc4ebebf3f262e3c2392a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.3_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_linux_386.zip",
+          "shasum": "c5d6301a0e23e0c7e7248a60c7d9b6e553df63a7dee3fbcefcd7cd5743b339c8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.3_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_linux_amd64.zip",
+          "shasum": "1f7506e732f14c1e3716bd2dd7efa4881d5d83d734be37ed6cd7e4b43ddff8f4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.3_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_linux_arm.zip",
+          "shasum": "7e0b927619b718ddbee843bd2d9ead2266feb1a9cee01b9ad9c78a8b42fd0024"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.3_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_linux_arm64.zip",
+          "shasum": "541601f114c6057e6d51407fd605039f6d467c0a4daa9b31a19309780fec9f0c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.3_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_windows_386.zip",
+          "shasum": "7f06504137059b21828ab18d0bc2e5257f79f04390311f5e82442ba537058465"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.3_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_windows_amd64.zip",
+          "shasum": "73c2578095a590122e63bd4196fec19b2276794af72bcb1f318ea9c79dd519e4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.3_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.3/terraform-provider-kamatera_0.8.3_windows_arm.zip",
+          "shasum": "228d8eeac3e777e3c9ac9f6302b76afded229ab4b6ff68ca617f4a437f4a5427"
+        }
+      ]
+    },
+    {
+      "version": "0.8.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.2_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_darwin_amd64.zip",
+          "shasum": "b69d864b3f87c2172f3209dce3af4ee292bc8553953b2047b994abe5ea81cc27"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.2_darwin_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_darwin_arm64.zip",
+          "shasum": "c5d06cc0231347351e633146ed03061ce0670c1022082418c0b2a3be2439eb52"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.2_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_freebsd_386.zip",
+          "shasum": "8589e94d44d405a71958d1b8fe10cc88b375c5b74ddb54f60d5ecd9f02f41160"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_freebsd_amd64.zip",
+          "shasum": "6ed7015e5d24d73362a196942a39f8d37fc22ecff4a3c1e75deb583ee0c529f7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.2_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_freebsd_arm.zip",
+          "shasum": "c0c80fdf3ccf057b66395c97b7b65dbe4c0081f2ad0202b7eab27712d92e5ea3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_freebsd_arm64.zip",
+          "shasum": "a191e8e6f028a88cac4f1d29302e40190fc07942d2b2188870bf3577697247a2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.2_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_linux_386.zip",
+          "shasum": "2c97c2b9ff365ae2200a5632d00c78137108116b9ded48decbf7e7f0dc483c70"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.2_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_linux_amd64.zip",
+          "shasum": "87f88d405e21ea6d087da2dc13485503f87bdce1e8978ca425b9700c664fc9af"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.2_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_linux_arm.zip",
+          "shasum": "a9cb581d9c21b05464c21f8355940dfe27bac3df3eba134b3d77a1f4e62bb976"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.8.2_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_linux_arm64.zip",
+          "shasum": "68a59165156bcce0ada463bb00489a2c108e5a2476f358eb3136dbec5eac402a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.8.2_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_windows_386.zip",
+          "shasum": "f699dc24660279477dd59cfc5c9f8f0e0bd667aad2a68ee339aca4921cd59be5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.8.2_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_windows_amd64.zip",
+          "shasum": "0c01add9b16dfe2e0fe7e565737be6f4e4bd46cfa0fa25094132f5853994ee1b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.8.2_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.8.2/terraform-provider-kamatera_0.8.2_windows_arm.zip",
+          "shasum": "de59a5ec9a31859e706529bec8e9809bc912bf1ab89d70fe9e2db332a05d9ba3"
+        }
+      ]
+    },
+    {
+      "version": "0.7.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.5_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_darwin_amd64.zip",
+          "shasum": "c2e701f877cbfe6794efb4c265b6cf472b1b85781dcb546f014f3bb75fa3f004"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.5_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_freebsd_386.zip",
+          "shasum": "3cbedea7a4af4f22eea52f5b52d3db397c29c9e843fd76aa5318ee483cde68e5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_freebsd_amd64.zip",
+          "shasum": "23437a0d5ae73973cb75ad8d3281e381118c2f8be08b78970f4161cf34a25712"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.5_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_freebsd_arm.zip",
+          "shasum": "74e37c94df6ba535e89c6728aaef774f09860bd7f0e1e4902e1defaa083e6f47"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_freebsd_arm64.zip",
+          "shasum": "47c19f35a4a85e4df28797348ed58e42bd08ddef53dd1c25a03003545787be0f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.5_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_linux_386.zip",
+          "shasum": "4540688b3e5fe6bacfd18f8ae40015f3aec97c5c1cf42f0bfac66445342bdf59"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.5_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_linux_amd64.zip",
+          "shasum": "534341b896fb59ee7c122c7f61af56027834ac3bed5a1ccb91bd1fc765bcdd3b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.5_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_linux_arm.zip",
+          "shasum": "d1d827aa4c8777e297936f3128b2c42c464160853bc2d8197b61cf89a73109ff"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.5_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_linux_arm64.zip",
+          "shasum": "7fda21abe565968f7d5f54e991d16562d8a3ee0ec94412b73b097fa846ba42ea"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.5_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_windows_386.zip",
+          "shasum": "10f903e775340f7fd1ca95d67a817f5947efa18543ee1afcdcf1083bf95c342d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.5_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_windows_amd64.zip",
+          "shasum": "0c36c035eab2bc476493e23f47a2be089b5d7e731bfecbd906bcc4be543cf399"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.5_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.5/terraform-provider-kamatera_0.7.5_windows_arm.zip",
+          "shasum": "00fc8a06a80c20a9399c1bc29b8e627d98c92cce17b7049f5f06ac48cd67e48a"
+        }
+      ]
+    },
+    {
+      "version": "0.7.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.4_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_darwin_amd64.zip",
+          "shasum": "e18e64a4660a3d19ca7c2d3a79146b2d01f180a915dccda1a12a0d6db998b286"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.4_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_freebsd_386.zip",
+          "shasum": "a58df8f34b7bfbfb266558a1bb73e35363da70f02fcec10cf2dcaeef79f7397b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_freebsd_amd64.zip",
+          "shasum": "6329d91c935de864c017a13cc0df6e1a7fce998c3aa21d9f884b281cfb4c6198"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.4_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_freebsd_arm.zip",
+          "shasum": "088b92f9cf9cf3ec69160ecb102c6770ee465aa5d368b5cb382c77f94accccaa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_freebsd_arm64.zip",
+          "shasum": "d289761f285ede6f99fd7a4349ddd3864543ef78ea7b2e6f7c529b85f13bf760"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.4_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_linux_386.zip",
+          "shasum": "f139b3c8c75dc74dc4aefda5cfbcaa59a4b2e55e50651b013a521c32e51f3203"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.4_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_linux_amd64.zip",
+          "shasum": "c02910b5eaca19c11eb05d48d4e8e25803411e8005828a531639b5176ea19312"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.4_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_linux_arm.zip",
+          "shasum": "0aa0d51a7b3c9699fcb79a43d058374cfb3e23a54eb5f44c168edd1c0846b474"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.4_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_linux_arm64.zip",
+          "shasum": "e6ba1fd0a7553f2c8a47ba331851645ae8a6925f6197db0ff421350a298deff1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.4_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_windows_386.zip",
+          "shasum": "ba9af765787ffbe44c1d00911c08125d782156b427aa121024f986f959c5c097"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.4_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_windows_amd64.zip",
+          "shasum": "8361606977362f3fe5513929a802b073d874ab1936b2b789fca0e178a4653bea"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.4_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.4/terraform-provider-kamatera_0.7.4_windows_arm.zip",
+          "shasum": "8dde929fde4e624c55ad717df5fda5910af1f9da49181489aede74c85d24843d"
+        }
+      ]
+    },
+    {
+      "version": "0.7.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.3_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_darwin_amd64.zip",
+          "shasum": "f725d2dea99f67be49fc0c4461b9ffa72d243059104edf68258adcdb21a9c025"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.3_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_freebsd_386.zip",
+          "shasum": "b0455eb9e4996c59b92a8ea9e08c4a150e8893a0d1efd79d57604cfadd335ec3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_freebsd_amd64.zip",
+          "shasum": "d2d170f3230914889ab3719f576a9ab99abaf9780a4f89d0f71c6123f9e131e1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.3_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_freebsd_arm.zip",
+          "shasum": "25493a5d7499ae692de534dd05766aea45daa648d6230b84797de649e8302afd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_freebsd_arm64.zip",
+          "shasum": "f1ece89290ceefa12dab4f58609146293677638cb1e7afab1559619de33f43de"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.3_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_linux_386.zip",
+          "shasum": "51e2912f639611d06da3cba7f80f5243e3dc9d32bc0b65f018bd6c813f1c0f75"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.3_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_linux_amd64.zip",
+          "shasum": "b6041fa19b8244a11af295bbe2f85c02de642be2614393bde67803979008781c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.3_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_linux_arm.zip",
+          "shasum": "8465fb573d90e9ecd534f1661620a79b418d8cd419143fa0888113a3ac88aece"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.3_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_linux_arm64.zip",
+          "shasum": "8eb307d368d10e8c41d911c5344d19745e9d6d3e6d50957c0653ae423d350d41"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.3_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_windows_386.zip",
+          "shasum": "2b11a496fb91c643aaf248111a407f7a56f326db1bcf4eda1aff2a9de205bf8d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.3_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_windows_amd64.zip",
+          "shasum": "f4b0afd18e05aae541bb0ae877e5c211923b667b4ef9179f29b13109cbae9b4c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.3_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.3/terraform-provider-kamatera_0.7.3_windows_arm.zip",
+          "shasum": "1728c5ac657c60e219bbca6293236313c978ff27da5db818bcb0a2a35014e40c"
+        }
+      ]
+    },
+    {
+      "version": "0.7.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.2_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_darwin_amd64.zip",
+          "shasum": "32f38260cb0ba6e78a82885904dbdb9868a399144c365249629cd577788c5f86"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.2_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_freebsd_386.zip",
+          "shasum": "567b551bdce4b04bc396116492c86c2954969f8a78798c96fb8f6f108f706752"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_freebsd_amd64.zip",
+          "shasum": "b0d658d67b7861a7f4fc815d9d268979a1ad8456adfe269c87b26c091be3c43a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.2_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_freebsd_arm.zip",
+          "shasum": "bae5418d4f7056aab8e225243b82a28542a87656facd851c34ee5b4231dbbd01"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_freebsd_arm64.zip",
+          "shasum": "4d003c025aaa978e290e2ddc6ecaf463d9f95e2f6dcc185b61fa88f0b6f315cb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.2_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_linux_386.zip",
+          "shasum": "6e0f2b1ce2d9fb9c2097155891abb146029700a4278d4d446bb01ca9d7957610"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.2_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_linux_amd64.zip",
+          "shasum": "98bd4956cd9ee0c1fbbadf64fb5621b911b06b94d615356c9f4f652292a2d458"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.2_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_linux_arm.zip",
+          "shasum": "860e2bfbb2354c16107aea4b283d8feffac86da97dfdd91484bfda819b6f84cd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.2_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_linux_arm64.zip",
+          "shasum": "4aa0cff8c72b430683d5280c7da86d02a10027ffed766288b43bc379073e4227"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.2_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_windows_386.zip",
+          "shasum": "197d1bbdc62cb0c4b5bc766bd213f57973a46f34196a76d3f86d958af7d32278"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.2_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_windows_amd64.zip",
+          "shasum": "493dd426a25a5edeea24f8b077717e14b7e24396bb1c3dc9c478ca8e417121d6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.2_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.2/terraform-provider-kamatera_0.7.2_windows_arm.zip",
+          "shasum": "9fd9e3de0941cc7fa1996358ae161cbfb43eac7e4595db2d195dbb0d33f08e74"
+        }
+      ]
+    },
+    {
+      "version": "0.7.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.1_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_darwin_amd64.zip",
+          "shasum": "b993b2dda9fcc26ac54892e0d2948541b0ba5cf2bc14e652c1b1ab15f9242051"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.1_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_freebsd_386.zip",
+          "shasum": "c6fbb871365405cbd7446d453e43a8e9cedc1aa0453b1921411335495edb50ac"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_freebsd_amd64.zip",
+          "shasum": "c9de3058cea709c2e46293e2d55e7e96960183b61337dd63b87db78a0b3eae5d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.1_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_freebsd_arm.zip",
+          "shasum": "d6a5dec5a2a57a38dd62c7960f100d9f3cf5f7d6da9fd0293d1461fb188543a9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_freebsd_arm64.zip",
+          "shasum": "921ab0bc321a7602c1c6e74472ba4945c45c58843176263ffc83ff1b5b3e9013"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.1_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_linux_386.zip",
+          "shasum": "75098c461c0764f45ec8fd5c442ac7cc1e7fbb8f4e5b9ac4d1313013df86d512"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.1_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_linux_amd64.zip",
+          "shasum": "19da35d171ec56ca61571d08851bcfda9518d44d66c8f6ecfa682c60bf540246"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.1_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_linux_arm.zip",
+          "shasum": "e44eb1138a5792b36782f11317c0a402bd269c3a3b0853eb741c5ee7a16d740a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.1_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_linux_arm64.zip",
+          "shasum": "40266e00b783b404bda8391f483eb984d29a35349d649cab4b0c61b2444fb681"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.1_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_windows_386.zip",
+          "shasum": "cf0e932c1c023f278a7c76cd51fd40858e5fa0cacf7434b788070d60dea11590"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.1_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_windows_amd64.zip",
+          "shasum": "1478a73b0145df43b2a86700ef4340cc5078bba217b715e56448b1497a148bc1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.1_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.1/terraform-provider-kamatera_0.7.1_windows_arm.zip",
+          "shasum": "0c2d11b125eff07f6392a9ec2ea5087f2b40209c72fb3c82a6aae3990a320753"
+        }
+      ]
+    },
+    {
+      "version": "0.7.0-test1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_darwin_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_darwin_amd64.zip",
+          "shasum": "059fea01b0eb21a2fa4360f7d0aabdad7d7cb98dbbc93bed4a2554bc4ce707b1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_freebsd_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_freebsd_386.zip",
+          "shasum": "f65542d766e9e8ff117b99c9ba94d1290108c20a5212d7389d8e8265fa582c7b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_freebsd_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_freebsd_amd64.zip",
+          "shasum": "9da4b66d824dd9a50a9d1bcbbb46672a38835b8084573df6475c668137d2beb0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_freebsd_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_freebsd_arm.zip",
+          "shasum": "2f5cba1c1c20e0f2e93d24f895a04e715344daf3bf8574a9e56083b6a9dfa6e4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_freebsd_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_freebsd_arm64.zip",
+          "shasum": "31f4caf5e0a1b1bd997190aac7c7934f290c2e029e45982989ae2e277be5956e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_linux_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_linux_386.zip",
+          "shasum": "4695075fdb80f4ac3ce28c1200c4d7e94a8916faf85c30a218b9ddd646c604ba"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_linux_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_linux_amd64.zip",
+          "shasum": "635176c53f32a5666be0f64fc508ab566b834a9b9e497179232fe962518b76f6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_linux_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_linux_arm.zip",
+          "shasum": "becfa2e92c23ebac977a5ffedd73a34a982295fc84fea7d75bea271103121cee"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_linux_arm64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_linux_arm64.zip",
+          "shasum": "c4c1e529ce8a40a50620a3fbee90c012dcc00878293243639148bb72719e414e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_windows_386.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_windows_386.zip",
+          "shasum": "bb49f23f58fa3364708c49d8d36751999f7bee0e6465f72a82a385c98dd2d3c4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_windows_amd64.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_windows_amd64.zip",
+          "shasum": "674ff8ef3872f6403fe219d1996c84ff4628ee45e546ae6de1048cc9c4079dcf"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kamatera_0.7.0-test1_windows_arm.zip",
+          "download_url": "https://github.com/Kamatera/terraform-provider-kamatera/releases/download/v0.7.0-test1/terraform-provider-kamatera_0.7.0-test1_windows_arm.zip",
+          "shasum": "6a3645ef53cdda70e93513932a482b9a3d57db0b2cd0b4411fdc4c7fa96d0e1e"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/l/laltomar/hashicups.json
+++ b/providers/l/laltomar/hashicups.json
@@ -1,0 +1,112 @@
+{
+  "versions": [
+    {
+      "version": "0.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_darwin_amd64.zip",
+          "shasum": "298f8e5a366ea3303c78e22f587d8ee7b9fec61a58b62ba11c7934e74012392c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-hashicups_0.2.1_darwin_arm64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_darwin_arm64.zip",
+          "shasum": "6e3276c8ff0cbdd4822cb6c6463072c522a53c25e30e9a8f081d67360a19c209"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-hashicups_0.2.1_freebsd_386.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_freebsd_386.zip",
+          "shasum": "1bf28ec542f053087bbaf61936cc34136c0ce207e63f8df48f1f1b86be25b76c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_freebsd_amd64.zip",
+          "shasum": "89f897cc81b37d04bd40aff3df6f5d28beda76737e6d43d745c40c877f216423"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-hashicups_0.2.1_freebsd_arm.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_freebsd_arm.zip",
+          "shasum": "aa1baedb0f770c2fc7b35c0e2c71060bf142bf19347f05c9e29cc68d8ecd83fa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-hashicups_0.2.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_freebsd_arm64.zip",
+          "shasum": "307d4db62bf8da6cf7eebbbe7193d1a4a124670feb964c844ae23d1d4efbf79d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hashicups_0.2.1_linux_386.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_linux_386.zip",
+          "shasum": "647d3395409295bbebd5c894520677474de54f0a8679c3eb10e29e1568f9c281"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_linux_amd64.zip",
+          "shasum": "ddaabc0088303a027318831eec8ea6ef3ebfb3457caa0d6f3cb993f63ae50f8c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-hashicups_0.2.1_linux_arm.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_linux_arm.zip",
+          "shasum": "d030265094165739e6e059f9c4a6110a44271574faf5fa6d50630b98727576a1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-hashicups_0.2.1_linux_arm64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_linux_arm64.zip",
+          "shasum": "35bf5e3890c9023a508195ca8235a63ed372809fb18db84e6d365eb241ef5550"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hashicups_0.2.1_windows_386.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_windows_386.zip",
+          "shasum": "2d8a264ac8586a2b9dcca73f3736190060787b329fab1fe940ad0cdc6d268499"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_windows_amd64.zip",
+          "shasum": "4d38233ef0af4ec584260f8419ccdf48d60cd3edc3a949b8b69a2fe82273da7f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-hashicups_0.2.1_windows_arm.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_windows_arm.zip",
+          "shasum": "8dfc0eeb7928203c3f430f5e6b997b69d80539aa6195d376952d1d4951b4540a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-hashicups_0.2.1_windows_arm64.zip",
+          "download_url": "https://github.com/laltomar/terraform-provider-hashicups/releases/download/v0.2.1/terraform-provider-hashicups_0.2.1_windows_arm64.zip",
+          "shasum": "c1b1a936484206929bb18dea39ea388c9978b026f73d22c3ff4d9144537b7915"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/m/marshall7m/dummy.json
+++ b/providers/m/marshall7m/dummy.json
@@ -1,0 +1,328 @@
+{
+  "versions": [
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_darwin_amd64.zip",
+          "shasum": "5e3baeb71c963ca2a49235ae9ace44b420ca1830a11cd4b195001a61cf4c2865"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.3_darwin_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_darwin_arm64.zip",
+          "shasum": "15a2e7164c52a44f9b5be140fb33a24e322fb10ffb96d04549e1d6898cb66b9b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.3_freebsd_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_freebsd_386.zip",
+          "shasum": "65a83a184d92e6589ac04bab230a979d407e7b577e45ac46692aada59da9cfe4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_freebsd_amd64.zip",
+          "shasum": "7e9b55944f9bd4c0ad10b8b2353e5d4eccf6073f1d274fe23993cb69f013d697"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.3_freebsd_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_freebsd_arm.zip",
+          "shasum": "d5b159a7346f6ec6ac3a10de44e2ea803c3c8d5866bd30b111c9416278dc8a5f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_freebsd_arm64.zip",
+          "shasum": "cbc4c3e8ace18d3b02d27634c546a8ff4ddcc3e395b5dedef4db060cfc61490a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.3_linux_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_linux_386.zip",
+          "shasum": "85a32967be095e4abf3c0daa3e667ed3c697a098e9fd4a67656be95166955662"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_linux_amd64.zip",
+          "shasum": "456b4e176df55687983970195e55086f83d4a7ac0bc704d83146d462186d66a9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.3_linux_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_linux_arm.zip",
+          "shasum": "13312da7ce2d69a86da1f332967972d0623ad780dab47e27d8b1d4005b52e8a1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_linux_arm64.zip",
+          "shasum": "6589de59373fb1c079d03b59fe7ce72880bde2b8d02a02527af080a7e2a4b689"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.3_windows_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_windows_386.zip",
+          "shasum": "4e331e17bd887d0cf3391077e031efc58da3d9f76b1354a98e25d8808b3174af"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_windows_amd64.zip",
+          "shasum": "87b238b5357f1716329d0d9030bf2768bc48455d6ad4832cdca17fc05f417669"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.3_windows_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_windows_arm.zip",
+          "shasum": "d75d064ba674e07a7301b8a82f93799b5d274272fa14986772c17dd8d0e88aa6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.3_windows_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.3/terraform-provider-dummy_0.0.3_windows_arm64.zip",
+          "shasum": "62afcc551c7895cfc1fe8cdfecb1ba91605082a3aa4432aabdee0aff013e9fe8"
+        }
+      ]
+    },
+    {
+      "version": "0.0.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.2_darwin_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_darwin_amd64.zip",
+          "shasum": "283904a149c8fd7bbbf259ad7fd6161b08e56ae9b4e607caad81ec5196f38adf"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.2_darwin_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_darwin_arm64.zip",
+          "shasum": "828c291043557ba420d56c44f0a3fd7ba357e01de88ab71b0cb852cd3deca4bc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.2_freebsd_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_freebsd_386.zip",
+          "shasum": "6a77c11b329b2f7dceab7676f40516fd4a7cf37ea0e15cc8e3e9211a0ad5a67b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_freebsd_amd64.zip",
+          "shasum": "29f57ecbc501b660e5ecc9012ab8b6fc83b3393e1e103265f06c31925153e9f2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.2_freebsd_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_freebsd_arm.zip",
+          "shasum": "766bcb28ab97eeb68f8870476c8b797377689c3ce439651ec73129a90d9e4c8f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_freebsd_arm64.zip",
+          "shasum": "8eaf30297931225b28575ede4a32eec80211e859ba75bfa6ada6882716ce9765"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.2_linux_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_linux_386.zip",
+          "shasum": "f0f5d85d9169411f72e02d9e7c9b1717606b0e3ea250ba9e91075c1e892530d4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.2_linux_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_linux_amd64.zip",
+          "shasum": "998e883684e7e7ef63fa3f83a721f00c3791179a50ac92c801a25268101ad85f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.2_linux_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_linux_arm.zip",
+          "shasum": "9aca50e9fef12261cfdc860e5e5b145c20a71102be32ee7ab3f29e5905ac8fe5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.2_linux_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_linux_arm64.zip",
+          "shasum": "980b87d4a1d8f4f13c9c15036cecfcc70ae8f6388ab221860eba51b15aba0e2e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.2_windows_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_windows_386.zip",
+          "shasum": "3c1005e5d928434c941e8d2ae0408c507b7609fe8ecb59c9c3ade4a4152b3566"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.2_windows_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_windows_amd64.zip",
+          "shasum": "51d02369adabc67e549646ee0db25b6b77aa1713be51b1fdf91807d4ebe6b8c4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.2_windows_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_windows_arm.zip",
+          "shasum": "cb1d866c047a47e2ddc7f3bcd865e3b52b9449e53d85a39869b38fe124491050"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.2_windows_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.2/terraform-provider-dummy_0.0.2_windows_arm64.zip",
+          "shasum": "778d8209adc65b52def634ef2ca964309c6da0dc27706a7b1b1c2723efc1f123"
+        }
+      ]
+    },
+    {
+      "version": "0.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_darwin_amd64.zip",
+          "shasum": "43ac38cedb9934e585148bc9bd99701ed63a89e0d340442af17d3bf87816f4ba"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.1_darwin_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_darwin_arm64.zip",
+          "shasum": "beecbf6d5f2b5754f985ab4de78657ba1ee5d243e346b0010b57c5525996c0c5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.1_freebsd_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_freebsd_386.zip",
+          "shasum": "f7048cb9d44c4446b75166e3941d6fd3a273613c7a29e7b7511fb58812a997b2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_freebsd_amd64.zip",
+          "shasum": "50078dfd1daa4dba556716aadee65efd76b8e0d527a8078663fc6a6e7b173b50"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_freebsd_arm.zip",
+          "shasum": "666f90d8ecfa4176aa319fb7da84033ae10c25a87952eafc3c0df5623b749966"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_freebsd_arm64.zip",
+          "shasum": "0807ce0644ff8a1c5c3881940e4c205ab2f9c0857a597b3dda76fc47fd21c50f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.1_linux_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_linux_386.zip",
+          "shasum": "3140cdd34a3953da5e2f5affe6822c8ce1e598462bc43a0e41ef65d79da08ebb"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_linux_amd64.zip",
+          "shasum": "eccf1f005e57c6d89cf74fe381c11effba96a4786b1d9d9dfc9c6dbbcc02e07b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.1_linux_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_linux_arm.zip",
+          "shasum": "b8e103412e472938cb141c5eebcf06c905a9cd8eab42bbc11b24b8fa99394db0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.1_linux_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_linux_arm64.zip",
+          "shasum": "f005aab63b37f505786d39de5902095e2c9a1a33086fc90a0020d83766e0f707"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dummy_0.0.1_windows_386.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_windows_386.zip",
+          "shasum": "a28ed99a0c3be8453e8a77af67802c1f8666a6de8e06b9427193d29af4aa3590"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dummy_0.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_windows_amd64.zip",
+          "shasum": "9ede55b47a8b6c5cd6545486baefa41fd14204a5d1198ce473f2da25ae47d1f5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-dummy_0.0.1_windows_arm.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_windows_arm.zip",
+          "shasum": "260e3887e1cfd35b4db15eeea05fe0532ae1b5e4d4247e4d310eae86bcaedfff"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-dummy_0.0.1_windows_arm64.zip",
+          "download_url": "https://github.com/marshall7m/terraform-provider-dummy/releases/download/v0.0.1/terraform-provider-dummy_0.0.1_windows_arm64.zip",
+          "shasum": "2fc12d18f7ca78b39bd68904769866fb409ed3655e42501dc8ac0db649552f72"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/m/mdrakiburrahman/hashicups.json
+++ b/providers/m/mdrakiburrahman/hashicups.json
@@ -1,0 +1,98 @@
+{
+  "versions": [
+    {
+      "version": "0.2.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.5_darwin_amd64.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_darwin_amd64.zip",
+          "shasum": "ce9a9848b5e6a99f92281729353f26e4fab86f93fb542bd7edc3eced13cd52df"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-hashicups_0.2.5_freebsd_386.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_freebsd_386.zip",
+          "shasum": "2b2193cb90083e17a2d4a95833d2bd109226382e56949784a65ccd74e5861df9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_freebsd_amd64.zip",
+          "shasum": "5ed3ad9c1fa1d5fa1b61dac7845e1ff9554ad82d28061864752d04760357ee4e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-hashicups_0.2.5_freebsd_arm.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_freebsd_arm.zip",
+          "shasum": "9f802cdbfa082292ac76bb718405f4a92489d1f91a310a78768d8685612ea8f6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-hashicups_0.2.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_freebsd_arm64.zip",
+          "shasum": "d0a2dda96bd1dc702f8c139887888d99d926b9200fef96b70cb5abea880658c8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hashicups_0.2.5_linux_386.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_linux_386.zip",
+          "shasum": "efb82249e914a5f9cfa97aeb7deb4b07413fca1ac5a2eb58278956f3004a1cf8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.5_linux_amd64.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_linux_amd64.zip",
+          "shasum": "7479cc7d07cc2b7dc8112357bdbcc8ba563458d7f855021c3b6dfed484ec241c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-hashicups_0.2.5_linux_arm.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_linux_arm.zip",
+          "shasum": "3520f889c12285383ece44eaae084660972fa207c9e94e3206c27330f78d5d38"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-hashicups_0.2.5_linux_arm64.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_linux_arm64.zip",
+          "shasum": "9c78df69b3a5db60ca689d1ee7011b807a77becba09ac41dc66da24138adbbef"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hashicups_0.2.5_windows_386.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_windows_386.zip",
+          "shasum": "1822ceb98263eb54af0eee186b6d27d6121f56defea8724a11a94863e18fb780"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hashicups_0.2.5_windows_amd64.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_windows_amd64.zip",
+          "shasum": "a2145ad527e726187077cc5ba9ab20e96c8c90d04be0d3cc31ec42b8a8194d2a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-hashicups_0.2.5_windows_arm.zip",
+          "download_url": "https://github.com/mdrakiburrahman/terraform-provider-hashicups/releases/download/v0.2.5/terraform-provider-hashicups_0.2.5_windows_arm.zip",
+          "shasum": "8dec9a8d0c378156da021ca33c76ff99ec4eb5abd5298014dd929458b7ed586b"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/m/mecodia/pass.json
+++ b/providers/m/mecodia/pass.json
@@ -1,0 +1,328 @@
+{
+  "versions": [
+    {
+      "version": "3.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_darwin_amd64.zip",
+          "shasum": "5b81908b42abbbcc8a1ca043d9b053a1d2679af9296801e33bf378c6bb37a9ca"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_darwin_arm64.zip",
+          "shasum": "ccd1db7245739121f343d0461b1f6a77bdbc0da4ab3fb7ec391f4874c73e727f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_freebsd_386.zip",
+          "shasum": "5de7fee8e71d370d02e8215d7102b768954fdfd2b1dbe587873d8e71a35d0a95"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_freebsd_amd64.zip",
+          "shasum": "a097c92527345059b9464ae092de9ef6124c8313c300e05d3d30b978dcba3c39"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_freebsd_arm.zip",
+          "shasum": "772c76a0d58eec84d71743fe92d878f430f149ae3fedd96d23f8a8f949820f61"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_freebsd_arm64.zip",
+          "shasum": "9b3696062f55815ff7bc63a2af8e9b5770660f85a1ec902c9a56f8e00eda14e2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.1.0_linux_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_linux_386.zip",
+          "shasum": "ad5d663013b226cabab5c388015860a11a6c623d31ee40fdd0e311fa9f733ff3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_linux_amd64.zip",
+          "shasum": "30129159550a34f4fbeec90f344d5aa23e1ec71ea3322ab230e48db83d25d4fe"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.1.0_linux_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_linux_arm.zip",
+          "shasum": "c53078164db237f7ed87e9ffa89c09d72446da31ef56acc217108103c307ea32"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_linux_arm64.zip",
+          "shasum": "9c15aa1779dc1c73c0906d557b4d567a21542af2b128aaaeb2c93d6361a15924"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.1.0_windows_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_windows_386.zip",
+          "shasum": "e9b69576c7d0db46d147d8085f1d40099fb186d72af1cd5cbb3cf78198720e82"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_windows_amd64.zip",
+          "shasum": "5da39cbebbce758a0e327f7a8b7c0014853d9ba7183e835be78f7960a7ecd629"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.1.0_windows_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_windows_arm.zip",
+          "shasum": "bebb4e8488455153b4bdf8d58e6312c7499302fe9201c9a5fdd30785396c06fa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.1.0_windows_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.1.0/terraform-provider-pass_3.1.0_windows_arm64.zip",
+          "shasum": "a1a8d669663e99475d5bfdaf217c013fdfb159018f00fc639f2b0d9fc7fcdb9e"
+        }
+      ]
+    },
+    {
+      "version": "3.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_darwin_amd64.zip",
+          "shasum": "bd4f925674c67915b4a1927b5600e12c38c4d675388026e80d46f318793c8deb"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.1_darwin_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_darwin_arm64.zip",
+          "shasum": "b9707f69a976041cfc530f9459463752972487aa76b21c78aad2b6f7305d08a5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.0.1_freebsd_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_freebsd_386.zip",
+          "shasum": "3f9c9a828b5180b05c48e70aeebfb8f659cf4783fe09111585276e2cf2961801"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_freebsd_amd64.zip",
+          "shasum": "e2d7cf87be9d376c7c3ad134353213b3d0e5ce005a55a19c4dbcaad43b7e5040"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_freebsd_arm.zip",
+          "shasum": "75eaf19f1cec3de1c2a7d2dece6847d537c3c9034b0ba5c29b405c8890bb6b94"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_freebsd_arm64.zip",
+          "shasum": "eceb8b5bd1259e16c44f086b7c371b6a94607d6a61f94082dfeaf1645733f2a8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.0.1_linux_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_linux_386.zip",
+          "shasum": "f5b097850ee14e1aa10df044a0100495407ecae838d944314bfc112a042d242b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_linux_amd64.zip",
+          "shasum": "8ec74fbc27800ea93f78c97e1892ce3f83dd0365ebd50d4465a0ee840a5da796"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.0.1_linux_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_linux_arm.zip",
+          "shasum": "c0be37798e146f3edd0391731f76ce6cca128eeb1e524c2d1a83b4b772b996ee"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.1_linux_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_linux_arm64.zip",
+          "shasum": "035d6e9899352e0d8ad8b4ed0fbfafb17a8745a2bd65eab311717a730eeb648c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.0.1_windows_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_windows_386.zip",
+          "shasum": "828c4ee03cb5a26f17cbe7d66fcdfa75d8fb9b21559998a8e27a3f33d453da0d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_windows_amd64.zip",
+          "shasum": "241f79c317e834acba4d7c028a6336ec0a0216d3c5a550e9ad4e6c025824a6c7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.0.1_windows_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_windows_arm.zip",
+          "shasum": "2c4b838b2b2ce9ba03f84bd12d0496229fe145e1ef36e6624da72935c7cf3934"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.1_windows_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.1/terraform-provider-pass_3.0.1_windows_arm64.zip",
+          "shasum": "a9f6c80c68086f1a273942a924d8a8b45ae3992625ac1e0edbca13dc958cf3a8"
+        }
+      ]
+    },
+    {
+      "version": "3.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_darwin_amd64.zip",
+          "shasum": "e1d170bf09f6ecffaef9a73a8001614d578d0cc933c3fbe19fde7816722846a1"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.0_darwin_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_darwin_arm64.zip",
+          "shasum": "67ed7b7bfebfbfe28a42454f5c94a18617b84d4e91aac1e5cad59641ba12c86d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.0.0_freebsd_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_freebsd_386.zip",
+          "shasum": "eab4551507a804737573b54659189c1fb9ba883405cc86685333023a9fff1926"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_freebsd_amd64.zip",
+          "shasum": "36bff8c5adb764d113acaebc3c2dab2ed89abcebc5c1b244a085127a5f8849b6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.0.0_freebsd_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_freebsd_arm.zip",
+          "shasum": "1b53c1865107d8b07721d582ab5f1e8f641bb52d79aa9b0a2427b7a0f0983895"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_freebsd_arm64.zip",
+          "shasum": "7d7476f0e163e76698ea598dba18a6c3a7a2383c5072981d2a2aee5bb2e6a0f8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.0.0_linux_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_linux_386.zip",
+          "shasum": "c03aa4b6346dce7f84df4bf542d9d32477a7758be62efac68365b9641c41416b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_linux_amd64.zip",
+          "shasum": "3df1d41ff630b34f67caf620bed85b729307e2c1145b92df5c7918c443c37873"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.0.0_linux_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_linux_arm.zip",
+          "shasum": "1387857e837bce5e409864a36d06970ba5139bd27bd80f0f9daf8b14fb36316d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.0_linux_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_linux_arm64.zip",
+          "shasum": "1f321c94c35b50ea8043e262542bad2bf2612e413560f6646679138cd178cf6f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pass_3.0.0_windows_386.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_windows_386.zip",
+          "shasum": "65fb63bb7b2def4e2dbc4f0ea51ee94ae1b1cfdce58566275935841f7eb92d27"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pass_3.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_windows_amd64.zip",
+          "shasum": "71afd8acbe9d95d94f1721eaf35007dbcfde2e5dbc8f16fb6c1e725827aa59c6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pass_3.0.0_windows_arm.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_windows_arm.zip",
+          "shasum": "5ec7fb542cadc89b3106a6aabacbc69f6be733b5eb7c4c54ab4a52ae0e965d3f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pass_3.0.0_windows_arm64.zip",
+          "download_url": "https://github.com/mecodia/terraform-provider-pass/releases/download/v3.0.0/terraform-provider-pass_3.0.0_windows_arm64.zip",
+          "shasum": "5164d55a48406feb0c9e4f7ba03afbe5b0427a3d40cdc2fc7bbac0b82848d4a9"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/n/nukosuke/zendesk.json
+++ b/providers/n/nukosuke/zendesk.json
@@ -1,0 +1,544 @@
+{
+  "versions": [
+    {
+      "version": "0.0.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.6_darwin_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_darwin_amd64.zip",
+          "shasum": "88a194431157af2b994c7c28b0b127703890273eca15b0ad4c1c605f0a9ef6d7"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.6_darwin_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_darwin_arm64.zip",
+          "shasum": "d459fecf25f422a6cf6f46433cc6a85e4f207f7c7d70a3e0a3c08c6148dbc5fd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.6_freebsd_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_freebsd_386.zip",
+          "shasum": "5b6cbc91f4e754fe000eb420f6c31bdd01ca2e1ff238330a2e2654a58a7767f9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_freebsd_amd64.zip",
+          "shasum": "d52364c8aea6c0a2596745b246ccf40002a76ed8030f79b48b07aace9c67bf48"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.6_freebsd_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_freebsd_arm.zip",
+          "shasum": "e9bbf85d3da8447fa34e40af2d04ebe05c007842157c8ca8fd1352d8bd95556c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_freebsd_arm64.zip",
+          "shasum": "559cd7be85954ab84246337c44fc42b60d6bbb1f648b721ced4862bdfb46312d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.6_linux_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_linux_386.zip",
+          "shasum": "e7447047dcd19b725043969c9b2cad4d0c3b119347cb692e19bd3bc1ea941be3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.6_linux_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_linux_amd64.zip",
+          "shasum": "8c44644265511b2a46ebcdbda5ab919c39a4451558b5db783ea588250941aba3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.6_linux_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_linux_arm.zip",
+          "shasum": "f6c4b870e84e83a08d18cbe3fb4bdc847877226ebc56aba4119dc3b2d09960c4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.6_linux_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_linux_arm64.zip",
+          "shasum": "f2937f1522b829fc076e40e558e981ec7cb2e6da6e2f09ba933bea5c6133bac3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.6_windows_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_windows_386.zip",
+          "shasum": "64eb75fe46f8e87115a1d3f9d1eef460d3bb6ddc691e9c72b40db9eacea8100c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.6_windows_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_windows_amd64.zip",
+          "shasum": "55d85f9fbc6b7c3f766d13bfca717fa9488b81c5473bab959e65c6f18b02bba1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.6_windows_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_windows_arm.zip",
+          "shasum": "84935b8f404daa5c54f9c3c7b03b37532b5ec4e46821ee8dcd2aad489fe87afa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.6_windows_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.6/terraform-provider-zendesk_0.0.6_windows_arm64.zip",
+          "shasum": "f3212ba98c777342811fe57650eae592a76a07cf9a78f816dd58b33d9d0a3924"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_darwin_amd64.zip",
+          "shasum": "207adad5384400cd360db32e93958cd0c735398b8ef5df63354036407606c96d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.4_darwin_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_darwin_arm64.zip",
+          "shasum": "1f4357fd2d009d67c4db45b21bc515924df96dfe8584ca269c5ea78be30d6a0b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_freebsd_386.zip",
+          "shasum": "99d53e9f014666cc85f91f431c0868aa26c79ea633216af444d186d325ebe96f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_freebsd_amd64.zip",
+          "shasum": "b6b50ec8c2d3981f7b926a6760914b7252a395baca4e9218c927b9d9d0ba9922"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_freebsd_arm.zip",
+          "shasum": "215bcf66b4e91cf510e24600425fb4c5d5d5194b173626775c59ef31e64e8f3a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_freebsd_arm64.zip",
+          "shasum": "f13ee6609db85c58bf365ba1bf2775fcd969ffd92c660d0a927f1a3a21d18c8b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.4_linux_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_linux_386.zip",
+          "shasum": "3f626a7b6eabd0261e589fc94115ac5b49ae5c188f6f64753efff11b2d508290"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_linux_amd64.zip",
+          "shasum": "1e654423efde84d46655eb56b0bfb3671a4e7f29fede710eccf1b3dded5b63d4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.4_linux_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_linux_arm.zip",
+          "shasum": "007602a644b8ed7966a465d3495074731c1c8ecadb821f093eafffc8ae3d2d3b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_linux_arm64.zip",
+          "shasum": "c87eedc079a468350b65e904c0d4373a32a738489d5284b3b571a76ee2225dca"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.4_windows_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_windows_386.zip",
+          "shasum": "4a43187f0d46bbec38d6dc20a3286b2b5e41ca5f445ea4648d8aa4685912fa9e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_windows_amd64.zip",
+          "shasum": "9ff909303856afeb7a23c981dc5667ef535fbb63449ab05500257c76c404231e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.4_windows_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_windows_arm.zip",
+          "shasum": "218067590c29156a1d8ca612c139e6be4c003a0712c54974ae9806b4f59bff4d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.4_windows_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.4/terraform-provider-zendesk_0.0.4_windows_arm64.zip",
+          "shasum": "5599257cd056fd8d99f090394b8e602597c6153016b3d115ca4df27444659a71"
+        }
+      ]
+    },
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_darwin_amd64.zip",
+          "shasum": "aeb6656b53c2c634c0360f1ed65d8dad082ec81acc2fd9420eef53dfaec8e1e2"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.3_darwin_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_darwin_arm64.zip",
+          "shasum": "1d6c53c17e85cd7f3f351380e897540f4962b7a84706a6088cbc116e397ed862"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.3_freebsd_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_freebsd_386.zip",
+          "shasum": "7e2562be4f12dd069856b54690cf468f98304e6b2559bd84721d1a86cfd9f0cb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_freebsd_amd64.zip",
+          "shasum": "225612f2e4d65763a82380eacb1ba74045cf5c96bbf8ffbf3e978ad178df340e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.3_freebsd_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_freebsd_arm.zip",
+          "shasum": "911e73dc752af8a929495c1596be1e9ff686f5b0794fe7c2e0f9ab5832a71cd4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_freebsd_arm64.zip",
+          "shasum": "97a4163974fc8aac1713d6a771fa2948862dae22709e6b1f6603d73583310df0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.3_linux_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_linux_386.zip",
+          "shasum": "81fec1b9fb51b052627be50fa50f1af67fe45c8f60e1c4cc0ac2c7608271f1ba"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_linux_amd64.zip",
+          "shasum": "e0630d36fa5d5ef129b72de1132b8ffe49b50b6bca7015b3eb51f00c00003c7d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.3_linux_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_linux_arm.zip",
+          "shasum": "7f0c68af96b41297ed8e6a34afd983bfeefd71e9d8925820affefec93d4a2a12"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_linux_arm64.zip",
+          "shasum": "5a84e5bcfaccb6842b80d688cca9482811b46fb7cfea2db45372064528b5c0fe"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.3_windows_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_windows_386.zip",
+          "shasum": "f624a8d03a5c5f59283855c83d9f002101bfbd971795cd5a270accc91e11e5a1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_windows_amd64.zip",
+          "shasum": "2c4b0b978a7c893dd342fbb6dd6b2f6c3a8bd32f53c59318bd0101734aa49f3a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.3_windows_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_windows_arm.zip",
+          "shasum": "6980bb7b8261fbe48dc7e22480287760707943808f4b11b1cd4f9f871ae8367e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.3_windows_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.3/terraform-provider-zendesk_0.0.3_windows_arm64.zip",
+          "shasum": "55f222c3360f28ebe169feab88def3a90ca596e799078eabfb72bb813483cd8f"
+        }
+      ]
+    },
+    {
+      "version": "0.0.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.2_darwin_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_darwin_amd64.zip",
+          "shasum": "0a35373747470c5230f4fea986ffa8e8131d4f9605ee76b6f215b9e84264c581"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.2_darwin_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_darwin_arm64.zip",
+          "shasum": "09cb614b97822343c33ede6f6088c55dac5998d0442b4f703cac69fae95c1de9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.2_freebsd_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_freebsd_386.zip",
+          "shasum": "954dbc3ba0ba16e9606917a1fb5bb9a11708cac6e2424c81210cbec34fde58c7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_freebsd_amd64.zip",
+          "shasum": "2c0459e7255992537fc87c09cfb5926a7a68234efa5cf3858da0ef1a0eb67f50"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.2_freebsd_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_freebsd_arm.zip",
+          "shasum": "88f20703e22e1abb60664301352c991017bc7a969acdf594419c4f47a4fb2013"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_freebsd_arm64.zip",
+          "shasum": "c23c828e88b7b212888f57ee5c7cc2f137c297f1e8371d2b1a08d1d916c70ba4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.2_linux_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_linux_386.zip",
+          "shasum": "0a26ecac68f61f43c786b31c19a28629726537eab6981510154ec7b90acb0049"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.2_linux_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_linux_amd64.zip",
+          "shasum": "038589a809fa6cb0d794a2cac2b93f0926c76f6b13956d3f3b123d507e727dc7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.2_linux_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_linux_arm.zip",
+          "shasum": "d1bfacfc46c6c7128b75c4a529bee502d6d5652be5df6b3f6eb465d27bf10a03"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.2_linux_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_linux_arm64.zip",
+          "shasum": "b820f3e0dc15bee4e942e72fa5afd67a264863381ee7798cae9988e2c5156a7d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.2_windows_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_windows_386.zip",
+          "shasum": "45398f141b9251641b7be6a294cacbb9a83077f2fdb141402b877bf522dc1c79"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.2_windows_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_windows_amd64.zip",
+          "shasum": "2c955a7884f9fe4ce898a3bfdd5c2a2bc265191d2dc5bd0a44d3501dac98099f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.2_windows_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_windows_arm.zip",
+          "shasum": "732a64f0e0a986979ae77a1df836207e451e801d92468c7fe91f51e669098921"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.2_windows_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.2/terraform-provider-zendesk_0.0.2_windows_arm64.zip",
+          "shasum": "a8a149fb9a6e5f46babb67456e48da96bd6022460509df1dd3c056e182d96e70"
+        }
+      ]
+    },
+    {
+      "version": "0.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_darwin_amd64.zip",
+          "shasum": "993b3161e78d3e6bf06ed652596cccd058f7b9e46e350bd3cf6e03ca23c72c05"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.1_darwin_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_darwin_arm64.zip",
+          "shasum": "2e80433ea249e317c9d1de63bd71002b7151d91793566f6d6d0d907e5190321d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.1_freebsd_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_freebsd_386.zip",
+          "shasum": "39dd0296885e1b2565a30deb05adaf1134af53adde77db21e7a32f593af18d48"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_freebsd_amd64.zip",
+          "shasum": "2c3091123d4846352dc49739d413b5830f286c8088d04e06db4a3f8528fcd021"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_freebsd_arm.zip",
+          "shasum": "5a64a36a0669398c207d51b493bcfa8735a571c06d13f52db6fa2bf40251cab5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_freebsd_arm64.zip",
+          "shasum": "55c77b200922786b7973050368af533d1b238120e431d193e25075a57dec7b3d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.1_linux_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_linux_386.zip",
+          "shasum": "41af18570155157ba3b56244e6113d07f56a3908e2a706c3ad0b9e164a7211e6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_linux_amd64.zip",
+          "shasum": "a25d03758f0c1909c66b1d9a5d36815dd0b13199eb9b46315f2e928ed7611e23"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.1_linux_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_linux_arm.zip",
+          "shasum": "f0213534fd80a8d7edf82b29234db42b89133592b29d1c69300abaf083e77ec4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.1_linux_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_linux_arm64.zip",
+          "shasum": "dd287aa6be8e179392d10a20188cd89879a6d1527f97239dc4b289ccaa7b01b7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-zendesk_0.0.1_windows_386.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_windows_386.zip",
+          "shasum": "ea1a1ea251f689af127a7e694954fb3354cc75b77981efd79a6440f346a3f532"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-zendesk_0.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_windows_amd64.zip",
+          "shasum": "848c6c9436efe10dced747b9a7891f5f50ce551b7c74233e3cc3f91968024bb1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-zendesk_0.0.1_windows_arm.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_windows_arm.zip",
+          "shasum": "09cb2aea87f8d8dacc70c8a975de975afb28e9a80b02e694b56c7103ebba6b1d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-zendesk_0.0.1_windows_arm64.zip",
+          "download_url": "https://github.com/nukosuke/terraform-provider-zendesk/releases/download/v0.0.1/terraform-provider-zendesk_0.0.1_windows_arm64.zip",
+          "shasum": "7b7df2bf80cc7e27ca3fdb61e5ced0c21f9c40222ecb961317cab19d5df4d8cc"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/o/operatorequals/universe.json
+++ b/providers/o/operatorequals/universe.json
@@ -1,0 +1,307 @@
+{
+  "versions": [
+    {
+      "version": "0.1.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.2_darwin_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_darwin_amd64.zip",
+          "shasum": "49291420eeb8d52a043a04e14e93b9d9c21389f40afeed047041c5c304209ff9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.2_darwin_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_darwin_arm64.zip",
+          "shasum": "5a2fcdf19b7ea89e9f41edac35a5c0ab19a1215dbd472b3cef3757d6a49a43e5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.2_freebsd_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_freebsd_386.zip",
+          "shasum": "4982df1c3fa4d680299dde6768e1cb96558b2f305433a949ce18a6ca503a9c75"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_freebsd_amd64.zip",
+          "shasum": "b5e099c0139099be48a32eae8da668bd2b81fdbddbe179f3bdc207e9ce6e22bd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.2_freebsd_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_freebsd_arm.zip",
+          "shasum": "457c3bba4a451f54d5139e6aeb8b476bffdfe4b48953ff1e107fcdb0a90b2a9d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_freebsd_arm64.zip",
+          "shasum": "c5612c5b1f9b632ed35063f2f93948f55e3b7f4d7acf1d18f6adbfa7521fe2bb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.2_linux_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_linux_386.zip",
+          "shasum": "10a8671be68168156dfb613b8d6c2ac4ca8ef1411b5c5c35dcc6800f3c1d1d97"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.2_linux_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_linux_amd64.zip",
+          "shasum": "0d80b8d198849256ae63e5065200daa1864214ae2f6964880fe29d34c92ce320"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.2_linux_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_linux_arm.zip",
+          "shasum": "3634138001175eabd4ec14ac1837c0308796cefc441495ff23ef2b3207b2f4eb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.2_linux_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_linux_arm64.zip",
+          "shasum": "facaae6c76bde6f1fa0129b1e89da204e797a0fc541b9c3404fc5256341ee704"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.2_windows_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_windows_386.zip",
+          "shasum": "072a82999e201bf8068f8298bfb07af28d65a7b3bf2cb280db1801fd5c0caa45"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.2_windows_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_windows_amd64.zip",
+          "shasum": "e8ff8cd832acee9b61db31ef1b1bd677dd6705e241cbe3e37017ccd4bebf86b8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.2_windows_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.2/terraform-provider-universe_0.1.2_windows_arm.zip",
+          "shasum": "8d66c9f8ff4f731f5a312ebdbe844e95fccc9fe65f2287f1832893fd8c5b09fe"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_darwin_amd64.zip",
+          "shasum": "4b38d842605b912bff6f1eea2ac8269bed3c21fb0ab1616dece445744ffc486d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_darwin_arm64.zip",
+          "shasum": "75c674197b86cbfe4c1fbc5441dcef02cb0d2bab8d3f9d73f091f4a81995cfaf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_freebsd_386.zip",
+          "shasum": "5ec1df757533c3574380dca43784f50474a51130b6f6058b7c8be505aa17645a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_freebsd_amd64.zip",
+          "shasum": "f60327dbe64a0f9d6c1b53fd15488d57faa3e58b87d65f80828c9a7df6e636a9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_freebsd_arm.zip",
+          "shasum": "fcd107c400f8e24ad92cb39e18d34bf1c6f69056d0cccf58f84ec8013c51c8b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_freebsd_arm64.zip",
+          "shasum": "039581f92c613d52a6e7ed66831500635651fbe3b3fd1a0ed368a7fc455d2956"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_linux_386.zip",
+          "shasum": "c24e98713a56ee36eeecb6d6c22d8c1b530a6cf7f05cc63533ec3d0b7b0d8c3c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_linux_amd64.zip",
+          "shasum": "2c22fcc720b711a31864b0c4a8c690b033b3a59d9de48d51c2c58c7889276c93"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_linux_arm.zip",
+          "shasum": "a34820d83548ecf446f70ed05a44dc89f1895ae3f06f5638cb2a2a84b0a2dd9d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_linux_arm64.zip",
+          "shasum": "4bb94b185fb42062499389c8fc2285594de45594ef1aff7b101e08c14aff770c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_windows_386.zip",
+          "shasum": "abb1723948a719763cbf8c93cd81996dc7378d83007b3e7aff02d2ffde41d76d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_windows_amd64.zip",
+          "shasum": "f62ab32d3d049a62bc02a039364713eedd0ffb31dcd116af8c09fbf806ee9688"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.1_windows_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.1/terraform-provider-universe_0.1.1_windows_arm.zip",
+          "shasum": "d9c1e6755a95c4f80c14f998cc64435f3d6a0c42660a58258e6d635f7577484f"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_darwin_amd64.zip",
+          "shasum": "13df1e05b0eef9215d956e4909595d47ba0605f81d8a4286b5134512bd287817"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_darwin_arm64.zip",
+          "shasum": "00b73b9dd65600686e4c5b19958cdb2a3368ab25ed44d35416e3842658f0c312"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_freebsd_386.zip",
+          "shasum": "45e0fd3ccc2690acf7068e7050afc8b41e9bd4e3026e70472df91228823a1627"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_freebsd_amd64.zip",
+          "shasum": "87eda6897b611d89e668628d3548275091014f4b1df86b9e4666d500f5a2b43f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_freebsd_arm.zip",
+          "shasum": "951aedff3d348908e82e8760ce67e9eeccd2d478748c62030896f8d5bfb6d60a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_freebsd_arm64.zip",
+          "shasum": "8b064bdb79827aab721c87cdc84655c379b8d5cd4c6aff88e661241940cb5365"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_linux_386.zip",
+          "shasum": "a07937521b42f33865b10ce0bcaa1805fd9ab252f154df56920a1d69c1c09d1d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_linux_amd64.zip",
+          "shasum": "02053890ff73e549e75944d9e113f3372c78b78ac0f9853690ca1a30ab8eb0c6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_linux_arm.zip",
+          "shasum": "78f9630871a6af0b051c3a91e2c3cc4bc5d455d2fabd681a56b3c7759ec3e8e3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-universe_0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_linux_arm64.zip",
+          "shasum": "2fb9089a39f8ae267c668c2d70f5eb5c41940513a913a89243630418fc0bee21"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-universe_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_windows_386.zip",
+          "shasum": "3839b6cbca36b8979c37c94c9f2e94dfb2d2541156d6fed23095d21689c58365"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-universe_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_windows_amd64.zip",
+          "shasum": "ebc333d9c485a79ab6045b7367c5c26315a92320563ab2eb981d6ca339fe41df"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-universe_0.1.0_windows_arm.zip",
+          "download_url": "https://github.com/operatorequals/terraform-provider-universe/releases/download/v0.1.0/terraform-provider-universe_0.1.0_windows_arm.zip",
+          "shasum": "19afc7366b6b04e2efb8f2b0aabb2dc1442619ce6aecdfef8f87a77505e7bd1f"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/p/p2k3m/infoblox.json
+++ b/providers/p/p2k3m/infoblox.json
@@ -1,0 +1,84 @@
+{
+  "versions": [
+    {
+      "version": "2.1.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_2.1.7_darwin_amd64.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_darwin_amd64.zip",
+          "shasum": "faab4a4ac4b3ffc61b3c7f0794a93fae268f3916da380068578d9d55372d21e5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_2.1.7_freebsd_386.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_freebsd_386.zip",
+          "shasum": "699fb7199adca1ba8ff378e8566774b987afa62376d94c8d425ec8a221ce36d8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_2.1.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_freebsd_amd64.zip",
+          "shasum": "f684fad42771f7f3cb5a3e1343fb652c7950ead0d22812d44c75152de132a188"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-infoblox_2.1.7_freebsd_arm.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_freebsd_arm.zip",
+          "shasum": "31a89d319e1a9f2a80f05f85ef23978c35cabcb77dbbc9f65c489fa37ec3ee07"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_2.1.7_linux_386.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_linux_386.zip",
+          "shasum": "a0d1b840aaf984b6ed70b6ba80e36eed82d3ca8e6004ee7586296490a032f11a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_2.1.7_linux_amd64.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_linux_amd64.zip",
+          "shasum": "8f1c2e101d43d86337f00640dfa9297404f35adde5ca682904e16be938fce442"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-infoblox_2.1.7_linux_arm.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_linux_arm.zip",
+          "shasum": "8136c10237a57335c46ca0e5f0324aec4f632d2415ae302d4ce2b539e8f6c5d2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_2.1.7_windows_386.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_windows_386.zip",
+          "shasum": "3324d098dd80ab8a00fe47514729473b152aaefc94d51626e09c1c1c0396d9f1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_2.1.7_windows_amd64.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_windows_amd64.zip",
+          "shasum": "9f667b4d4ef1dbfe842194e4d48ce933e77ca72f59898e44f6e71be1a8304bed"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-infoblox_2.1.7_windows_arm.zip",
+          "download_url": "https://github.com/p2k3m/terraform-provider-infoblox/releases/download/v2.1.7/terraform-provider-infoblox_2.1.7_windows_arm.zip",
+          "shasum": "b9c4f124f073fc3367a0c937ef9dbe133b9730c3d93c7efa48401e9d8561f39b"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/s/SvenHamers/apollostudio.json
+++ b/providers/s/SvenHamers/apollostudio.json
@@ -1,0 +1,380 @@
+{
+  "versions": [
+    {
+      "version": "0.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_darwin_amd64.zip",
+          "shasum": "422f8bf9549488fdaada83e394b466460a01442feb2fdb046d255b6d3a0e92a1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.2.1_freebsd_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_freebsd_386.zip",
+          "shasum": "d8dcada602bffeb3564c632f820cedc6c2610160df6ae6c6db9a7a7b22f80586"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_freebsd_amd64.zip",
+          "shasum": "56f40590cfd70111cb771597a9e43b73765aa4b5a4b388a59f7342ff161f06ae"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.2.1_freebsd_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_freebsd_arm.zip",
+          "shasum": "8c8bc435d7e5fc3c3b32a51bf9e323f668e209a47416371417bcc9d43591fbeb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.2.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_freebsd_arm64.zip",
+          "shasum": "9340ae1c179e281ccfb0c75bc75bafa8f819d4b4d47743708bbc1ae7430d8fba"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.2.1_linux_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_linux_386.zip",
+          "shasum": "9e21b9fa65e662773bd94e8d39e42deb5dc81ff911eedc3b506466c00bb0fdea"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_linux_amd64.zip",
+          "shasum": "c8624fbf8d7a422e338439e8f2c5a80397a9e03499b78c4ef6344e1404ab08bd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.2.1_linux_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_linux_arm.zip",
+          "shasum": "d739827937ef12944d2f5828270409e32a0c20d3248677b72a8eee0cc68f7494"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.2.1_linux_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_linux_arm64.zip",
+          "shasum": "3c4cf5112cb1db179b49a0ea910f372e09f12a270ba62363e024bdd31d4c70f2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.2.1_windows_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_windows_386.zip",
+          "shasum": "9883e1bf83b2383e4e295710c2fc270e06059cf77f1ab3e3a16d16e3f654678c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_windows_amd64.zip",
+          "shasum": "c40bc4463321d31fd49a8eff04f69e8cb91bc41024e62e388ce2a1476234b800"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.2.1_windows_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.1/terraform-provider-apollostudio_0.2.1_windows_arm.zip",
+          "shasum": "96af0861d4e4762cea56ca8d4c4cb7067991602c05fe617d544605ff3c6130ce"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_darwin_amd64.zip",
+          "shasum": "08a390d169fbf635ee2926a5b38ff40c99cbce304021c194932ace12b7b8c7a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_freebsd_386.zip",
+          "shasum": "4487fcfde2bff2b5f2c74f54ce28989632e6ae99600e353ec47405da30bfab18"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_freebsd_amd64.zip",
+          "shasum": "b23de061acd04e70ae1853eb76b2d5d29a80219fc299304860f4ecab81867c3a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_freebsd_arm.zip",
+          "shasum": "214b0c1930f7f226ace087b50de90008d44a7b7675b1d0980d9fd6203340f469"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_freebsd_arm64.zip",
+          "shasum": "2608234a2baf7903f3c8f7b491c0f995c33a2e378e777aea34088ea2edddb63b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_linux_386.zip",
+          "shasum": "9c9e11bbd6a4dfe9e8b05099db24123c7592abb5a0b08d4a338a0dbed1858b4a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_linux_amd64.zip",
+          "shasum": "5e0e7e7c2b598df79d0267671cdca027d584df327d32d4d42e238e3850b71fb2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.2.0_linux_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_linux_arm.zip",
+          "shasum": "90d6d2894b789c9ad267cac8d69466512a3cbea9abf6e85cc1eac30dab12b45d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_linux_arm64.zip",
+          "shasum": "d630dd67a39447ac120e818c0dc726f128b0caeaae751a86c2b97e798071b443"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_windows_386.zip",
+          "shasum": "3a909d987aaf9a305ed1690934cc8f253527fc5e9c941dec71cc0a45f065b018"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_windows_amd64.zip",
+          "shasum": "a26e91f978c92444f3211d3a0f15cdf89850c1dd1df5af4d81286d95a3bb5320"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.2.0_windows_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.2.0/terraform-provider-apollostudio_0.2.0_windows_arm.zip",
+          "shasum": "86f2adf7fc4d728f7c4766e89caf66609934c7511bb32b123e3429eb5fdc3b6a"
+        }
+      ]
+    },
+    {
+      "version": "0.1.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.2_darwin_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_darwin_amd64.zip",
+          "shasum": "7d6ae3960e5a7a6f39f4e0640efc7f81d04b29fe5edb4252d34600778d15020f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.1.2_freebsd_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_freebsd_386.zip",
+          "shasum": "0535d0363c969c684b9a1156fa7cb3e1ad5fdefc27cfc968a3845aab62615af2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_freebsd_amd64.zip",
+          "shasum": "dca1f4f70ae9dc880550b4320b9291299736d056b9fbd7c896217b13ee8d23e5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.1.2_freebsd_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_freebsd_arm.zip",
+          "shasum": "31af199733fc66995b269841b8e09194e184baa7e9da3a926b5c3db456eaeed0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.1.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_freebsd_arm64.zip",
+          "shasum": "705be9bae208a134fbdc565bb8125b6bc2365f7ef126a8891f5ffe98c21e4ad0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.1.2_linux_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_linux_386.zip",
+          "shasum": "9e337f811f648d448dfb0a7a7327bb079334532c633f0cd4c965dbbfc099a9b9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.2_linux_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_linux_amd64.zip",
+          "shasum": "89102fe2034148b806cfeb1d255f6cf9586ec4361c5e2f4cee4638294b60dbbb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.1.2_linux_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_linux_arm.zip",
+          "shasum": "88ef0f44ba2d3f939a6b939c1e1bcf54a163157c71162b8bf7a48b0d0c6e4b39"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.1.2_linux_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_linux_arm64.zip",
+          "shasum": "7ad52d61d779b1dde5ac1cdcf1b92c107d5288b8f8f5529b18484830ff8849ed"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.1.2_windows_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_windows_386.zip",
+          "shasum": "671fd20dd9b432b6a04bfcddec4f6edb3bde77479b554aa65be5e119ce606189"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.2_windows_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_windows_amd64.zip",
+          "shasum": "f8976214ce9fa02eacad326b5c9b0036c542f9f21e7e9e59761bf5018056b256"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.1.2_windows_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.2/terraform-provider-apollostudio_0.1.2_windows_arm.zip",
+          "shasum": "f51d3757fa16843da66559993fe052a38a2bc3defcd4e21cb2cec1bc64956dc7"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_darwin_amd64.zip",
+          "shasum": "7e23b4c68418f459502900fd4867eeec842ffc3699adc0e6434219746934cb75"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_freebsd_386.zip",
+          "shasum": "39c88c2e55f58c6e28ed96dba2956b09af281aa176d8a23a7142d586423dc9bd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_freebsd_amd64.zip",
+          "shasum": "89fd143c01c85532d6db09f4731e3b1669dccc170b4f950f821846fedf7c5edc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_freebsd_arm.zip",
+          "shasum": "0fcbce3bdc336967beb1b21c7b5eb858fb9677fd40a203531a0f8ce9772cc54a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_freebsd_arm64.zip",
+          "shasum": "138c753ead9d857028d527ff0460d168adface62f2898fd62af3529c93391361"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_linux_386.zip",
+          "shasum": "b30ee006c9fc07c588bd7b7ad6e5ce4fcd1285842f887573a6ce7221c4840934"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_linux_amd64.zip",
+          "shasum": "1c4654a17bc00ad8dc78911592707c524d113937bc8776c347d182c6273c8fd0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_linux_arm.zip",
+          "shasum": "63ddfd8a213314111ef8d0ccf301613c8b77eaff3a191bf42bef46d11c4a43b0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-apollostudio_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_linux_arm64.zip",
+          "shasum": "7a915a7c125cc6f8162c6163818f38d7cf924c6747edb02a398e09f0a5337171"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-apollostudio_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_windows_386.zip",
+          "shasum": "51b00329c1a074b3f132d3d4f2c400943e8b215645c9bab1d1449ca3bc9db63c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-apollostudio_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_windows_amd64.zip",
+          "shasum": "78b523abaf9128d25d9890716ac5b7a6ae24f327b7b674ed0aa1f757b06f9f86"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-apollostudio_0.1.1_windows_arm.zip",
+          "download_url": "https://github.com/SvenHamers/terraform-provider-apollostudio/releases/download/v0.1.1/terraform-provider-apollostudio_0.1.1_windows_arm.zip",
+          "shasum": "765da53aa83289e83e7792886a7e76ab566f4aacc2a661c8b5d04c72935b911f"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/s/samber/stripe.json
+++ b/providers/s/samber/stripe.json
@@ -1,0 +1,98 @@
+{
+  "versions": [
+    {
+      "version": "1.14.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-stripe_1.14.0_darwin_amd64.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_darwin_amd64.zip",
+          "shasum": "26da72acb1487074bb8912d2ad7806e187f2df64d7380359f90ddd6a08c4b76e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-stripe_1.14.0_freebsd_386.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_freebsd_386.zip",
+          "shasum": "419b490a08809bd25936f4d24483fd602b93adb4751a3026bba9d9c88690c381"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-stripe_1.14.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_freebsd_amd64.zip",
+          "shasum": "8770dc028342828fe58d362411b9bdad445218435559e847d7bb9410479a69e9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-stripe_1.14.0_freebsd_arm.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_freebsd_arm.zip",
+          "shasum": "c5422ba1cf7ece15061eaf36968027843e48e01baacb6230eb59c2e0ae19bb8d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-stripe_1.14.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_freebsd_arm64.zip",
+          "shasum": "35338f62daf91d78a12130521285858e3404581c5311dd1bbc07ff498b8e807c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-stripe_1.14.0_linux_386.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_linux_386.zip",
+          "shasum": "512124c37e9b5402b298dbe267056c2da594f9a00c0900bbd0278d74201c2cc3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-stripe_1.14.0_linux_amd64.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_linux_amd64.zip",
+          "shasum": "04296ca86aeb7eb2d3c22793a3be545082848530dc941dd64525ad3c49a9df88"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-stripe_1.14.0_linux_arm.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_linux_arm.zip",
+          "shasum": "a24b001a30287e054967b10d7d14a4b0061d5304d09bedcae13a71b997db92f7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-stripe_1.14.0_linux_arm64.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_linux_arm64.zip",
+          "shasum": "79fa6a9fb51a29aec642eabac1fc7690d52e25030120c88ca7bd90268b36df0b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-stripe_1.14.0_windows_386.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_windows_386.zip",
+          "shasum": "fc8a6c9d16321abb1503a193717bdda791b49d112236405d493af825881afdb9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-stripe_1.14.0_windows_amd64.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_windows_amd64.zip",
+          "shasum": "553cbc6f5fe9ec25265a5d5464b90a45332eb11d5456befe06ef036a25f2e315"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-stripe_1.14.0_windows_arm.zip",
+          "download_url": "https://github.com/samber/terraform-provider-stripe/releases/download/v1.14.0/terraform-provider-stripe_1.14.0_windows_arm.zip",
+          "shasum": "0b7df92f1b1ae903f256304ad5a3e96aef14278a6a6e7fb076af2af296788a14"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/s/smundhe-a10/thunder.json
+++ b/providers/s/smundhe-a10/thunder.json
@@ -1,0 +1,35 @@
+{
+  "versions": [
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/smundhe-a10/terraform-provider-thunder/releases/download/v1.1.0/terraform-provider-thunder_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/smundhe-a10/terraform-provider-thunder/releases/download/v1.1.0/terraform-provider-thunder_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-thunder_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/smundhe-a10/terraform-provider-thunder/releases/download/v1.1.0/terraform-provider-thunder_1.1.0_darwin_amd64.zip",
+          "shasum": "da8b98778a1d77b4bca0e2dce35d8603f655a44c26c45a52be00693af40ba085"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-thunder_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/smundhe-a10/terraform-provider-thunder/releases/download/v1.1.0/terraform-provider-thunder_1.1.0_linux_amd64.zip",
+          "shasum": "3e66d96fc7d8e76d07b40791b528d35e32fb8e6a3c3f9688061cf13a5d1398d3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-thunder_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/smundhe-a10/terraform-provider-thunder/releases/download/v1.1.0/terraform-provider-thunder_1.1.0_windows_amd64.zip",
+          "shasum": "a92eb040d8e6787037eef5375247ed19d48214cfc1fb49ef2cec7929c5dac498"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/t/tbaledent/kafka-connect.json
+++ b/providers/t/tbaledent/kafka-connect.json
@@ -1,0 +1,352 @@
+{
+  "versions": [
+    {
+      "version": "2.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_darwin_amd64.zip",
+          "shasum": "4607b085fa4b8a08b8c554561f8d3a815b336440cf1d56240de19f675e2a503e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_freebsd_386.zip",
+          "shasum": "01529b0af0605af79f62ab1ce36c2c9886ac79431a9091af5b1b3c9713b0e180"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_freebsd_amd64.zip",
+          "shasum": "6ff3de7b084058b001bd5d9be9d859b342e8300c62236ad9a8e3186af397a995"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_freebsd_arm.zip",
+          "shasum": "af46080ef1dd1c0695a775a720ba61035ede9bf19f323644cd6c3dac1d143b60"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.2.0_linux_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_linux_386.zip",
+          "shasum": "f4ab24b893b64ec778a0104f55d1a965a844de230ae4c33564e0eb9d328f8ea6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_linux_amd64.zip",
+          "shasum": "d8f1653650c9baa4a043c9b747525845b3f651e0d254f01884be9907c69d1a9a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.2.0_linux_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_linux_arm.zip",
+          "shasum": "209af28a559f40fd8541c2988e892d9ffbf15a3be54dffe8d5c28b869b184f92"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kafka-connect_2.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_linux_arm64.zip",
+          "shasum": "ce963807a5ba9fc355b14b951ff92906bebcd35dd9ab9beb69ed2b0093424f1f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.2.0_windows_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_windows_386.zip",
+          "shasum": "71dcd1b58ad43c2b0801b0d00556906273677b15a3d0e2e5dfbf9287797f9500"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_windows_amd64.zip",
+          "shasum": "e7956a9ade34698a6a881677b0aaa8a9170fbe692c115683b181e12ec3365616"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.2.0_windows_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.2.0/terraform-provider-kafka-connect_2.2.0_windows_arm.zip",
+          "shasum": "10891ec2bedb06ac407961c41e3292b15bb9d7856aa16224b999b09e672eca58"
+        }
+      ]
+    },
+    {
+      "version": "2.1.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.8_darwin_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_darwin_amd64.zip",
+          "shasum": "ffb295b431c8482dfd8177b842a4b511809365450d18c9f2efae1503a043d8ef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.8_freebsd_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_freebsd_386.zip",
+          "shasum": "263c395fa0ae45cc6e1f39377b3d9040714331ff64b2a254e1fe90969f7ebcb4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_freebsd_amd64.zip",
+          "shasum": "c2c8d83a8a302cf1a44604af4818feb2fa8be945aaafea086beff513b3ce918c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.8_freebsd_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_freebsd_arm.zip",
+          "shasum": "663a676e5312f889334e39ce067e6a824c30a13627ec811c612e27af30394bbb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.8_linux_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_linux_386.zip",
+          "shasum": "a0d4736711936fd7e00544ef0807594b00cfec4e448348dce8ed1879aeb1e2ef"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.8_linux_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_linux_amd64.zip",
+          "shasum": "95474d096129a7ea8cf373314cf2408df6fda8c89de8f310d669aaa5a3d1c874"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.8_linux_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_linux_arm.zip",
+          "shasum": "1c653575fb96423cdec8ffba0fb99b2efe78bb6907c29c55e8955bac6b258fb9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kafka-connect_2.1.8_linux_arm64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_linux_arm64.zip",
+          "shasum": "6e6995d34f102e6d67c7a92f260ea31e0368ede972213fb3013112ae26f7b459"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.8_windows_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_windows_386.zip",
+          "shasum": "81a94fe4a07cf037ab164a347fd6b32e924f2c6452df89a999d268dbd22ef29f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.8_windows_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_windows_amd64.zip",
+          "shasum": "6442a84ddc548406b05fd85f841a0999280fc6f87bf7ff6df72ed2c6b87cf7cc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.8_windows_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.8/terraform-provider-kafka-connect_2.1.8_windows_arm.zip",
+          "shasum": "2aef7b31f4b0e1794162ded57a222c0788526f5ae2c64928952b7c5ddc8c6a7f"
+        }
+      ]
+    },
+    {
+      "version": "2.1.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.7_darwin_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_darwin_amd64.zip",
+          "shasum": "00c22f63097148feb826ab140b878275e6949d4f4052a617ed55e508a5e329a3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.7_freebsd_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_freebsd_386.zip",
+          "shasum": "008859886f4adf18b6a5a8329310c193c38cf45dfea7a081a4762b2a2e881f3b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_freebsd_amd64.zip",
+          "shasum": "84624243238c8a188d138c7db9baff322cd70453a64582f3546149178ec261ed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.7_freebsd_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_freebsd_arm.zip",
+          "shasum": "3fd1ce54aa5e84c0dc6f2f7027c29b2a8263f47ddbf20f14ce194cc4aef1191b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.7_linux_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_linux_386.zip",
+          "shasum": "2952876f57b94d682aa298b976660f246f8932b451b157484ea5b58e1dce831c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.7_linux_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_linux_amd64.zip",
+          "shasum": "8866dc4be7c5210db0c6295389860c030dec70fdd578f64631d3ea918a679797"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.7_linux_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_linux_arm.zip",
+          "shasum": "c9aa27fc1923348507e3954ba86a37ec112d0661d5d73525e0ccc83e616ad13f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kafka-connect_2.1.7_linux_arm64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_linux_arm64.zip",
+          "shasum": "31804a48dc5ccc5b4d958862a97d1cda26f9ca8067a365fa246ce19d5bbb48f6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.7_windows_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_windows_386.zip",
+          "shasum": "0c449fe9fd3b118f8f8aa15f690018aec3cb48b6614700c451bf6ecfab686931"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.7_windows_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_windows_amd64.zip",
+          "shasum": "20512c13c548c5ba612bc1330e79aa1c736dc86b49fd297bd9b18a2599b148be"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.7_windows_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.7/terraform-provider-kafka-connect_2.1.7_windows_arm.zip",
+          "shasum": "bee1844c94ce1ac69a122260ff3718c30452461fb3659d5f46dc6cd9a5485561"
+        }
+      ]
+    },
+    {
+      "version": "2.1.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.6_darwin_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_darwin_amd64.zip",
+          "shasum": "4b2419ae6777b55b94c23a5b1216a9420b4db0ad02400eed99d1eaba62f41d1e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.6_freebsd_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_freebsd_386.zip",
+          "shasum": "6b5164eb27e3145e9f555e82c320f46a7a877275075d12ac9f342e6327c261a7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_freebsd_amd64.zip",
+          "shasum": "9ac37f2442d93b3d8c516338b817c086c9c6f42f0cfb906539dbc75470cfc264"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.6_freebsd_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_freebsd_arm.zip",
+          "shasum": "6d36ce08e3c8ade2ec76c689e4b3753636f403f920ebe61557d9ccd35866a22b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.6_linux_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_linux_386.zip",
+          "shasum": "6564c05649eaf3b742fd833ec115c2d783c23f9a3d1752438dbd2e10f2a369e4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.6_linux_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_linux_amd64.zip",
+          "shasum": "c0d5eddfb846e05c6b9bd69d0f4dde442c81a7882003b63c3ad67afb652c6cf6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.6_linux_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_linux_arm.zip",
+          "shasum": "309f978497be642df75ff934f6014eecf479a4549c9f089305e9edadb3e1dd6e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-kafka-connect_2.1.6_linux_arm64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_linux_arm64.zip",
+          "shasum": "65c830a1e83c9897fa659c8f1fe922a646642da8bfd1ab1c937e302c9714f9b5"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-kafka-connect_2.1.6_windows_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_windows_386.zip",
+          "shasum": "2575884c3b8749b4d0fa7fc16d4a2c94f352a99e0e3b2912d99746dab4900d3f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-kafka-connect_2.1.6_windows_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_windows_amd64.zip",
+          "shasum": "13684c0776971d923ffaa1b7cf8d35d2cfcc1bc24c1e872b2682d3ecc5b7d920"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-kafka-connect_2.1.6_windows_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-kafka-connect/releases/download/v2.1.6/terraform-provider-kafka-connect_2.1.6_windows_arm.zip",
+          "shasum": "3165fd47f16dd8f40cbe6761c2d737b7178fa414a853a8d657eceb637c6bae68"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/t/tbaledent/postgresreplication.json
+++ b/providers/t/tbaledent/postgresreplication.json
@@ -1,0 +1,178 @@
+{
+  "versions": [
+    {
+      "version": "0.8.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.7_darwin_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_darwin_amd64.zip",
+          "shasum": "57db330b7b73c7491f5e3c3a145d7c70ee93be477e7da2ec4cd72b920596d394"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-postgresreplication_0.8.7_freebsd_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_freebsd_386.zip",
+          "shasum": "4cabfd74cea72689eb8e89a7b80701712489d3ca64288d31886d368dd2bbef43"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.7_freebsd_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_freebsd_amd64.zip",
+          "shasum": "ab9162e5db1539d28548355b387ef0fa1d557d7c28267f7c78490d3b996e66d5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-postgresreplication_0.8.7_freebsd_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_freebsd_arm.zip",
+          "shasum": "ba7caf3fc443bc3eda0d16951781342b48d64807fdfacbddf3edb6cea898f05a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-postgresreplication_0.8.7_linux_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_linux_386.zip",
+          "shasum": "681247f215cdc8950a5c4b76c4732582ed7675b8aea2ba69bef9a52824a86499"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.7_linux_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_linux_amd64.zip",
+          "shasum": "01708b008fba6d1ba2035e35e710a81f9ae4742997c502915d9d5ffc4659c19e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-postgresreplication_0.8.7_linux_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_linux_arm.zip",
+          "shasum": "89e71eb0e2e5fa9e3c1849e8ca2a9a8481dbcfe72196888245f1f7d1547e4236"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-postgresreplication_0.8.7_linux_arm64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_linux_arm64.zip",
+          "shasum": "9c7069d187d3164f40865894ca2f041dfbf4008d4bafc49925e7ad491353fd59"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-postgresreplication_0.8.7_windows_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_windows_386.zip",
+          "shasum": "144a909767688380c395a7fea4e67070a40b758502d33f2dc733da9492c2d41c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.7_windows_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_windows_amd64.zip",
+          "shasum": "c0164abe86f8d94bcb23d900250588b814bbd8a2317c9393217c6604774613ad"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-postgresreplication_0.8.7_windows_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.7/terraform-provider-postgresreplication_0.8.7_windows_arm.zip",
+          "shasum": "41af9db45d80b1998e104988d69c368f90cd238982dca329c7a1773534a1ec70"
+        }
+      ]
+    },
+    {
+      "version": "0.8.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.6_darwin_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_darwin_amd64.zip",
+          "shasum": "ec740ae2a6769277c013565d088627f2835913c539e9c722522a12b6a4bfaf5a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-postgresreplication_0.8.6_freebsd_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_freebsd_386.zip",
+          "shasum": "fd8472d0746d45068d29be5aeff90998305439effc31db057d7fd9a8fac9d271"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_freebsd_amd64.zip",
+          "shasum": "59fc432763aba8e4c3d8ef01bf63d46c6e0eedb07399ccb6fd98921994d2e751"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-postgresreplication_0.8.6_freebsd_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_freebsd_arm.zip",
+          "shasum": "16685df5420093105d3e9232f096b812cfae58b0d47ea5da46265de3ccb8364a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-postgresreplication_0.8.6_linux_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_linux_386.zip",
+          "shasum": "083527bbd98af6aa3254ba69608fd0040c6876fc6a9d7c90c37b4b87472959a2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.6_linux_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_linux_amd64.zip",
+          "shasum": "d3700f5cc7c59c6746a874e2c902b15fe251b6def80a57b3254cd45c658644c5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-postgresreplication_0.8.6_linux_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_linux_arm.zip",
+          "shasum": "38490fcc09fa2913584fefca0601c0f5daedb11a0646132e6edc4c0eb74b2c51"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-postgresreplication_0.8.6_linux_arm64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_linux_arm64.zip",
+          "shasum": "5288c2315693762acede9d976b6ce83344d6f5a382b7f43499ad4bc4fdc6c6ac"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-postgresreplication_0.8.6_windows_386.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_windows_386.zip",
+          "shasum": "9b671fe6455365bb41603c677611dc47c58c34f9cc1fb797957090fd360a338c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-postgresreplication_0.8.6_windows_amd64.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_windows_amd64.zip",
+          "shasum": "4e2a0c6debf8990a20fa8034f41b10135d8bff251a4a81253cab09a58798c6f4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-postgresreplication_0.8.6_windows_arm.zip",
+          "download_url": "https://github.com/tbaledent/terraform-provider-postgresreplication/releases/download/v0.8.6/terraform-provider-postgresreplication_0.8.6_windows_arm.zip",
+          "shasum": "081c770c8f4f8c36e8c62a0e99562923ce6603846efb08aa0c4eaaf35e356d22"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/u/ultradns/ultradns.json
+++ b/providers/u/ultradns/ultradns.json
@@ -1,0 +1,1948 @@
+{
+  "versions": [
+    {
+      "version": "1.9.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.9.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_darwin_amd64.zip",
+          "shasum": "19990583886d3f93ad106b68ee42eb10937915c66c8cab4c9a2f6563eab3271e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.9.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_darwin_arm64.zip",
+          "shasum": "dea9ac5c71e1f9e2a7fb37f38d8fff99d7e507d7b292ff82dfaa477178a2f9ec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.9.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_freebsd_386.zip",
+          "shasum": "a64b97084c64643685d1d419d10bce82d495cfc48d3ba50f0bdacb38197d065b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.9.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_freebsd_amd64.zip",
+          "shasum": "83699284a5b53e4775104be9896c841d63b22f61ad72c513ba83c5528567dca6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.9.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_freebsd_arm.zip",
+          "shasum": "300ff5ea4b498b3c4a7199ef7114a6e6b1c60ba56b6f23037568ef4ab2aae2ed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.9.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_freebsd_arm64.zip",
+          "shasum": "a23a00b680f5bbcdd82e08f030c67dac8b6d78036663231666b0076223b7493f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.9.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_linux_386.zip",
+          "shasum": "b50cd150dd4dfa941cdb41ddff8a5c54c57ef616fe47e6bc2da4a4f3f4be8477"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.9.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_linux_amd64.zip",
+          "shasum": "469997a7e5f0025c7622e9702327aa8a2a9289a4cc524a5c846ac56422cde4d6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.9.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_linux_arm.zip",
+          "shasum": "7bff3e6666398662582482278e33ea2db59bcd1c5f34674ddf41f3e03a4bd4a7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.9.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_linux_arm64.zip",
+          "shasum": "b5dc1dc900cd63bdde96735148e6a195b1419c66f340b8ce7ab4de769b47049c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.9.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_windows_386.zip",
+          "shasum": "deaf619907291aaeec9a87b4476357f3f170264d4121ca0e9db46fed02f9e3ee"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.9.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_windows_amd64.zip",
+          "shasum": "d317c28386309688848b39117f73c4a8ec46757fb1245523932fe07b3b725811"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.9.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_windows_arm.zip",
+          "shasum": "b00ce8193b0ac4f14f4a46d4f1af6259648d9793907b7b747959bac85be015c6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.9.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.9.0/terraform-provider-ultradns_1.9.0_windows_arm64.zip",
+          "shasum": "403ac4a6e63996bbdacf1df32e836b67dd0e1dcb9430821d33f75437008f25ac"
+        }
+      ]
+    },
+    {
+      "version": "1.8.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_darwin_amd64.zip",
+          "shasum": "24dbbc7cc9f3459409594ec7317b46c8de5fe2073c55abe50257c8759ae9ea87"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_darwin_arm64.zip",
+          "shasum": "3e99d7fbb9d6d9f997a82eb78fcfdda1ef269f7708d27299a242265cc722ee4d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.8.1_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_freebsd_386.zip",
+          "shasum": "f7181293203e130936cbeab85ef1f50831064dff009c8de4aef66ed9338afb7d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_freebsd_amd64.zip",
+          "shasum": "4cba4c12b2c5397339977dd983d01911ca4a5651a37ec5916f87c5f66a5859fe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.8.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_freebsd_arm.zip",
+          "shasum": "f06d832d397954089fa4dc8222b13b01c987fdded8e028c877e4d14d0d5c2c39"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_freebsd_arm64.zip",
+          "shasum": "9860abf1da9b5af8bf0d4a41d0c813d43e142bc9b06f1e495b32958c0af25e2d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.8.1_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_linux_386.zip",
+          "shasum": "60eebb00548356c83e35f6f4be7061bfb40d73d369495269a0037aaec1eda27b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.1_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_linux_amd64.zip",
+          "shasum": "889977543a97bc1265bf56c5f9d775effb4c15ecc6af2bf32e196228584edcf2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.8.1_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_linux_arm.zip",
+          "shasum": "67f4cebb5b39eea05479516eb31b05b594fd2500f94bc4adcd02f0deae161146"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.1_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_linux_arm64.zip",
+          "shasum": "faeb4b8226e6eb63bf7ce4cebdde988e31917fd9d0657c11546e82bc8df69c75"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.8.1_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_windows_386.zip",
+          "shasum": "b225e987f9724489d6f870dd16ae864ea1120e3752a980c4283b1c25a5a38e78"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.1_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_windows_amd64.zip",
+          "shasum": "c6fc3da342a7e6bffd5c0a3cfc3495bbc91337496164765f12fba076350c6f83"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.8.1_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_windows_arm.zip",
+          "shasum": "549cc3612626d2f851de51c2df2e3f812f3ded187392fd34fc95719d4ae04b8b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.1_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.1/terraform-provider-ultradns_1.8.1_windows_arm64.zip",
+          "shasum": "79bec066004df6351953f343c6dabf00094b73602cdc16a1d919b4d4d1659cc1"
+        }
+      ]
+    },
+    {
+      "version": "1.8.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_darwin_amd64.zip",
+          "shasum": "f8b2181daea49a02865f711399898236a721c334fede1b0376c7439b310c789d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_darwin_arm64.zip",
+          "shasum": "63b1a42975620037b9bd795f43bfa502ccf3fb5c5e57dc8951d49a924d97bd78"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.8.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_freebsd_386.zip",
+          "shasum": "543b7b8219364c02dd3defca4e48feebc6b848b7ccd21fd06e62ceb52b3a4b32"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_freebsd_amd64.zip",
+          "shasum": "9eb616b368c789b5b023beb9606a54dccae6441fba1e1ddeaae11132932f2248"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.8.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_freebsd_arm.zip",
+          "shasum": "365c7571a9377f8a9fabcecec0e55620754c89305e1aa7016544fce240f522c4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_freebsd_arm64.zip",
+          "shasum": "8c8b7bc1eebf291c14a7be9ee14a3d1b1c0465587bb420644e5ac184d869ad0d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.8.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_linux_386.zip",
+          "shasum": "aa0dede9890c7821bf759bcda1e10fa5abdc2772eb5a3a87c3a8e1146ad21d8d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_linux_amd64.zip",
+          "shasum": "bc27d29c0cd0a0cd6e95ee6f14314b6fb4eb0f6159b998fdfb91b0c2c8565e35"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.8.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_linux_arm.zip",
+          "shasum": "99c82a941ad9da7c8ab69f4e4b717932e32b61f12ea68b133e40f2945f5a3506"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_linux_arm64.zip",
+          "shasum": "8e92fad758621389b434a29dfa5d9f5c4f5dcc4a79fa8d54a43dda50f1a9693a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.8.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_windows_386.zip",
+          "shasum": "85dfb9727064b4fbbc219477cfa402d0ca36a5d675bfc45248d0b9e96bbb12ce"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.8.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_windows_amd64.zip",
+          "shasum": "e71eec70043adf7d780d459d4a03c3ead98b05ce312bf710085fe75ea365e97e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.8.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_windows_arm.zip",
+          "shasum": "989bc83ab7a96203620633a98120a8cc2029eac41f31eac2ff24023bf204493e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.8.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.8.0/terraform-provider-ultradns_1.8.0_windows_arm64.zip",
+          "shasum": "bef9932e638155a59bc4926ebbb9e1fc7f498bf0e603ad306198c036988b6af4"
+        }
+      ]
+    },
+    {
+      "version": "1.7.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.7.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_darwin_amd64.zip",
+          "shasum": "5e3f01fed69f1c7066ff58a03d1c46124bd384d6f86e831f30030f6a8b66a33b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.7.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_darwin_arm64.zip",
+          "shasum": "b7f19d812eb23fc4c17b7876ea9705bcbdc612f8f32ce5b0a13d9db3a6004c69"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.7.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_freebsd_386.zip",
+          "shasum": "f320fce74208fee3ced3de998e56c4be0551bef88925e3b4611130f1eb50664e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.7.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_freebsd_amd64.zip",
+          "shasum": "4265d91b793593ab0f834298878402c833f9d47495960f37a5cb3ab430af254d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.7.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_freebsd_arm.zip",
+          "shasum": "ba0af41e7103afa1ded3f89d6a671d072ccbfcb0085b90ff3a15fabbacb9d636"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.7.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_freebsd_arm64.zip",
+          "shasum": "0ed142e261557ec8d2bde1e339bb48244562ee44fc7c4222c831cb7020d71d17"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.7.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_linux_386.zip",
+          "shasum": "ecf8284b90f254c76d8719158a5ac9e59f855ce66229404c94cf9ff530f72c87"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.7.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_linux_amd64.zip",
+          "shasum": "025a8ee1ba95604a5f04fccb5d25dd329adcbfbbd0160682d34b53d1f2a88055"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.7.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_linux_arm.zip",
+          "shasum": "cdadf8483d694ddda3e55637e548924fb294bd0f876dd54bc0cd344d96e267cb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.7.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_linux_arm64.zip",
+          "shasum": "f3655da7cfe5386460e04552c6e3aac40eb05cf122f531a78f347f37f1a642a9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.7.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_windows_386.zip",
+          "shasum": "766f88b39b14732174fb8339cfd0d6b828c2c37747498180ac85cf6479c0cbcb"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.7.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_windows_amd64.zip",
+          "shasum": "84d1f63de7318d5f9e0372a73258056cf40da6162ab3a35cd9c7839d5b307c29"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.7.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_windows_arm.zip",
+          "shasum": "7b6576a09cd9c3878b3aef4aed52521099d95e881f0b3875f3012235a8934d1d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.7.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.7.0/terraform-provider-ultradns_1.7.0_windows_arm64.zip",
+          "shasum": "412de6cc8a9e5a52901503b999de25eb58847d5ab0a0c92f218313bc7a3e9f15"
+        }
+      ]
+    },
+    {
+      "version": "1.6.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.5_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_darwin_amd64.zip",
+          "shasum": "b6fbbddee1ee0d2e248efb79737a26663b9998b69598672cdf63a4157295c65d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.5_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_darwin_arm64.zip",
+          "shasum": "546615219bf30fd05a5395759afb9b68daba0d79f9f6f46600ff9dbc5acb0073"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.5_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_freebsd_386.zip",
+          "shasum": "04a0934a064d96e13a45e94e15015f08c61d517c9f0968a401b087b779be7fb9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_freebsd_amd64.zip",
+          "shasum": "f11504aaac688cc5331d8e11e8a2d4e366ca67abc49b80052b504be3384dd4ad"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.5_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_freebsd_arm.zip",
+          "shasum": "95a1dd57a85beb7bbd9126a541c5553e718e42e8bbf5e74a96d95da39515ab4f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_freebsd_arm64.zip",
+          "shasum": "d2f0ba854d5e413ddd1e241bdeba3121a00188cc2c6a72212df4755316cdaf76"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.5_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_linux_386.zip",
+          "shasum": "18d2af2d7c326e5a65e7f4e27746fa7cb18377ef2f33f8b7cd3dcbc506ba121f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.5_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_linux_amd64.zip",
+          "shasum": "7f4c7efc10a41cedf46e45afe91474a75dfca34408dc470e420f68cfba982f8b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.5_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_linux_arm.zip",
+          "shasum": "42fd4c4c9449717c3cf2a55ff3ee946d722d6af092a270d7882283fa3383ca61"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.5_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_linux_arm64.zip",
+          "shasum": "b45682c3e1eb3422eff998474ca37c9e7fd1059699d6f343f1f02dd02380fa0a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.5_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_windows_386.zip",
+          "shasum": "87b9a09adb7d9f6a110e91089777e8b09c512c74ebe7e2e9ce87609cd0402589"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.5_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_windows_amd64.zip",
+          "shasum": "04df3cceed9389d799afa6028b5b04ba904fecd45dd646a8452e0c8a0c45e5ef"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.5_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_windows_arm.zip",
+          "shasum": "20c602469a7fea4deae331552c41a6aa7b6c00f4f46007bd056e001526172d66"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.5_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.5/terraform-provider-ultradns_1.6.5_windows_arm64.zip",
+          "shasum": "2119a7e6dea82402f5f2a9c106f33edac2072d9238eaae076801228af9adb979"
+        }
+      ]
+    },
+    {
+      "version": "1.6.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_darwin_amd64.zip",
+          "shasum": "a2523e1b209a469d2b95fb0b59ad9d0b86c8a60dd58e0192553255992c4e0c98"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_darwin_arm64.zip",
+          "shasum": "028a08a90364a5198f7788acaedb9e6f19a6bbb41fb83f026c0d22add969f022"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.4_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_freebsd_386.zip",
+          "shasum": "1067b72c967f2a182985c9c8938ef03a2c7d65987c8ddf36a19bc36f3019e5a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_freebsd_amd64.zip",
+          "shasum": "18742ce827421a0ccfb1146e4f3986856e74b7cdb5be145849680e201daa2343"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.4_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_freebsd_arm.zip",
+          "shasum": "887be22db96f3c6fafe76734fb8c3ce51492b866db3f3abfbf133329f94d8432"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_freebsd_arm64.zip",
+          "shasum": "3eda1be0a7b678309b933ae71259bd9dc74fbe083f8b82be5711ded746bf38d4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.4_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_linux_386.zip",
+          "shasum": "8eedb965dc283cc55b3ac5c22612fa0aea36b8e0c15f6a640f4a2812958ca196"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.4_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_linux_amd64.zip",
+          "shasum": "06ae9e1fe112ed43e59d7c79b6855f50327a7cabd676180138fc4f49cf4a13eb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.4_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_linux_arm.zip",
+          "shasum": "2d6cb864b287590319c4b71d78dc99629712205f2058de73e85b04624d470d20"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.4_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_linux_arm64.zip",
+          "shasum": "2bef3942ed3eb3fe35a6aedc7b7d1ef99e3b6a63122d47b4c8ac27308c616a63"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.4_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_windows_386.zip",
+          "shasum": "27765caa1f2e583accab757e1eaddb6b5d6fe8ec77aee4090e849b16bb2eb18e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.4_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_windows_amd64.zip",
+          "shasum": "77de113b62439db83f3858a46799e3c11a9aed3c016f9f95edf8a2dddb03a3a3"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.4_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_windows_arm.zip",
+          "shasum": "ee5cce1a89af054b0ed4ab9de710fc445942887d26f831573920bee98a322003"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.4_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.4/terraform-provider-ultradns_1.6.4_windows_arm64.zip",
+          "shasum": "08ffe5382052a5f245cfdbb5b0d1130fa195679d47120c3d437a147cb16853d4"
+        }
+      ]
+    },
+    {
+      "version": "1.6.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.3_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_darwin_amd64.zip",
+          "shasum": "65728cd3d0ed8617b85083acfc10c008004d79fb5ebcf0ab5a5e1f6fd4cdaf2c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.3_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_darwin_arm64.zip",
+          "shasum": "78139eddb8eafedb351053c105a0eec557f9974f9ff9c7be205a66dc03d5227e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.3_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_freebsd_386.zip",
+          "shasum": "b10df1b4981f3b911157ed990688e14dce895f054aa3b630e77248f2ae47a87d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_freebsd_amd64.zip",
+          "shasum": "e5c035ace4b995a27ad61899eecf3c7df472e57f86b0a4f3e902c4af59a93d44"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.3_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_freebsd_arm.zip",
+          "shasum": "2c1f8f0321a1040711850aee78cfc9bed8ea1c2f619ebc580b6f97b7c22d707e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_freebsd_arm64.zip",
+          "shasum": "cbd788d011146ac7e80fe33d2e226b1ff492eb0e95333820a9960d18c326d879"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.3_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_linux_386.zip",
+          "shasum": "7fb1d54e451a6b7e0675aab4131002b5805bc0d4346819166ea13f7479effb25"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.3_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_linux_amd64.zip",
+          "shasum": "8014cdd7d81c78b06b0338430748efa783e4622652871381814625390f635d98"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.3_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_linux_arm.zip",
+          "shasum": "535a3cbe23275194d426300c2111449d5b48bdab4bf3977b6b48af37776a42eb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.3_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_linux_arm64.zip",
+          "shasum": "0479208f8edde5861e0d4d6bbcaa99b68f61fb742007e72a010723f1b36a3bf7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.3_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_windows_386.zip",
+          "shasum": "f534e64e8fd2573314a6cb8d078ddcaa28bfea4a2b6ff912a7de5d3ab27b3c7a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.3_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_windows_amd64.zip",
+          "shasum": "1c78d4e575c5467d530d6fb8a0970efe58405696d1094fa58328ed156bc9536a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.3_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_windows_arm.zip",
+          "shasum": "cd4690ba4cb554186a3532a21ecdab6eae4a7176796a7966d0d69a21a71ffb7d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.3_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.3/terraform-provider-ultradns_1.6.3_windows_arm64.zip",
+          "shasum": "888d7065b0d968a3d1aae0da3f2e5fed67f21b658e3f287bee24450f7c3fd6d5"
+        }
+      ]
+    },
+    {
+      "version": "1.6.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.2_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_darwin_amd64.zip",
+          "shasum": "256346f51950b867ccfed7c616b7a25cbc221b5cbb552de2e0d98ff613f8a6db"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.2_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_darwin_arm64.zip",
+          "shasum": "74024fcb9b43a972978df5d2869f3cd3e713e0995dcfd9cae62084d390ac5137"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.2_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_freebsd_386.zip",
+          "shasum": "fee14deeed959b14d4123be0d1dba5b8081828fae3aaeabde3de74b141b8bb19"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_freebsd_amd64.zip",
+          "shasum": "d0ca8ed967a8c0d34b27fc20e08b67766a65d49e7dd36a3fc783d5b9f6d559ec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.2_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_freebsd_arm.zip",
+          "shasum": "99245a6a0f50585dd709dabb0402b58184bd003c2e01818030822d2b5c1f156d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_freebsd_arm64.zip",
+          "shasum": "e6c0f2d61d473c1e3c5d4d3d4c6e3aff5bf29a64a40477739a46aecd864548f9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.2_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_linux_386.zip",
+          "shasum": "59299040f2852533ec257833a13c4c89802c2ec31e1b1585ca1d2552c06c5bd3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.2_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_linux_amd64.zip",
+          "shasum": "65480825116cb3483ec56c24e09f05d5be7eb5eccdab140eaa35803237d37537"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.2_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_linux_arm.zip",
+          "shasum": "9274bceb94c53aa4e03c1a685fc9afa30ed3e42c8e44ad1173312ae360a46209"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.2_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_linux_arm64.zip",
+          "shasum": "164e4d5f31f2dd21213eeb837b9adf489c1ba008bd63f29676e508fcca7c5df2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.2_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_windows_386.zip",
+          "shasum": "0e75caa440e29e630f498d0df98bbe18093a869d96f437bfa19c4ed413c4c62c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.2_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_windows_amd64.zip",
+          "shasum": "2cea06160e4bf307e343481e315228e6a19042520b644b266f0cbda710b45888"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.2_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_windows_arm.zip",
+          "shasum": "fbc30fc8a60538007f4a03aa201335d040215fa603323327210bcd1a9c11d942"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.2_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.2/terraform-provider-ultradns_1.6.2_windows_arm64.zip",
+          "shasum": "5ff280b793ee3c24633a5b9665376df056a71c3176250ee4598891a3e4fb1920"
+        }
+      ]
+    },
+    {
+      "version": "1.6.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_darwin_amd64.zip",
+          "shasum": "7f0469b4d9b74da4075590dbf3fe701029cc064277e5c17fbf2792501379dd79"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_darwin_arm64.zip",
+          "shasum": "ef9d20537baf5954310c38041838e30e590eb75d4eb63182269def5b346aec45"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.1_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_freebsd_386.zip",
+          "shasum": "ddcdf39d2121496e27b849c4aa026b51dbd6e1ebbf3a0704690e18bf8a812ed8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_freebsd_amd64.zip",
+          "shasum": "662de3b3b91c0ef91022882050855b879fe7003f1c627c9c419ebb28809ecda0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_freebsd_arm.zip",
+          "shasum": "27e32b9c56cd719dd1dec1b0e8013a84e7b8b5303a15be809343c5a2442c6bc8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_freebsd_arm64.zip",
+          "shasum": "922909bec55d448fba9fa40ddc465cac90f77db09127a96a477a648d6b0d6e51"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.1_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_linux_386.zip",
+          "shasum": "fcf1b83480ff1eef79d4131206dd12cb2f8d76f95cdbac6c85afbbdb1be28aa7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.1_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_linux_amd64.zip",
+          "shasum": "7c785014c72899ca8f2452803274291d3229bb5f5e921b0673b86d3cec5d959f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.1_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_linux_arm.zip",
+          "shasum": "683018b229aecb05921e6b905806a577b92b57e2011f8f62043e86454b161f36"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.1_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_linux_arm64.zip",
+          "shasum": "d31285e42e26a082e85098124441f589a63671dfd2f2230d3398a2b89ca8f301"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.1_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_windows_386.zip",
+          "shasum": "ce8cd614cf01eef060564e6707a382bd73b8a27488f0316a5aa261c4d38288bd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.1_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_windows_amd64.zip",
+          "shasum": "18d92c2d96eab7837dacc87345ad8dc67640e88bf4648058d3c3d01d66da5d28"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.1_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_windows_arm.zip",
+          "shasum": "dc5afff200c9baf9f1eaad6a520a6e3323417f148d4ead614ed409d63177f2d6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.1_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.1/terraform-provider-ultradns_1.6.1_windows_arm64.zip",
+          "shasum": "66b29ab820e3d7885bbadaaf298cb9f8368039e1082ebc12cab2d89b3bc6412d"
+        }
+      ]
+    },
+    {
+      "version": "1.6.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_darwin_amd64.zip",
+          "shasum": "4b7092faa57df48f93b6ad393ae87d0536e39fde41641d65a806730dad804b03"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_darwin_arm64.zip",
+          "shasum": "689d1662637f5c732e2a4b358f623ff274498ff496e2ec1e61dd50c9577be952"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_freebsd_386.zip",
+          "shasum": "9817d39d1090ac45e9a1223784a0c7dcdb9b8671ea7897bf2ffadd1ee4e061fc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_freebsd_amd64.zip",
+          "shasum": "3f2e9e5ae059dc5530a7f4cd069fefa6f2a2d8ad55fc904ad3901992c1435294"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_freebsd_arm.zip",
+          "shasum": "cedf687dddec6f6ce3f8a4805943813e16f5e209c9ee108e369d28a8c6bcad98"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_freebsd_arm64.zip",
+          "shasum": "10b34a68411c434aa2e81baad076061c77bfc1889a4bc9bb7e1ebcaa973e7322"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_linux_386.zip",
+          "shasum": "586e09d955b98d11653c791c5959ee792b2525f46431d9ff5be39c7314f7251b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_linux_amd64.zip",
+          "shasum": "8dd84a179fdefc9425ccbb947f5901eb4539b189bb948b5e933119a0dd3f5a07"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_linux_arm.zip",
+          "shasum": "44fd26b9ba50beb53cfbed7bdb86892b3973167ca4eeeafdbae8512c3de5a877"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_linux_arm64.zip",
+          "shasum": "227bf751a2d3cb8bd2fa45e9feb6f9afe526758430a08c068e0480194c9a0e04"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.6.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_windows_386.zip",
+          "shasum": "e6838ad1d8fedbcd880abd07214acb05e0a5d32c23badbdb592bb2c1521d6e88"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.6.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_windows_amd64.zip",
+          "shasum": "b5266592b6e959d5cd03dfbc9b6cf75133a5ab98c2b8534345cc6d40a27be46c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.6.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_windows_arm.zip",
+          "shasum": "180bd770a7dee903c1e853793778f5d6f835f921861e6623de6048d5afe63017"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.6.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.6.0/terraform-provider-ultradns_1.6.0_windows_arm64.zip",
+          "shasum": "203a8ec592dd509cd12de3c661776ccb35e067a9fa64359285ecff15afd9a89d"
+        }
+      ]
+    },
+    {
+      "version": "1.5.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.1_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_darwin_amd64.zip",
+          "shasum": "eab9fe47e41b92deb648af781ee9f411f087e065e9ab158d47ac937f69e239b1"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.1_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_darwin_arm64.zip",
+          "shasum": "3b4b92dde61b302a7b4f5b8a30b9a028aba2292b11c2d009e5332b9885e96bc5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.5.1_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_freebsd_386.zip",
+          "shasum": "f94fa9696e7c74b9205514f074532cc657f48ec2e67be8c01114a59fc1d65482"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_freebsd_amd64.zip",
+          "shasum": "51a7693f784647bb930caa729fb2e413283b0994c9cbd058751f64f010d11fa0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.5.1_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_freebsd_arm.zip",
+          "shasum": "c8ae158e170025b3d2ed989372eaa91bf1bbb5b4e39f7e222591da81ba453183"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_freebsd_arm64.zip",
+          "shasum": "89a77c3154809308e895e1ee7972e807160eaad712e0232f845e7242d9edd8cc"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.5.1_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_linux_386.zip",
+          "shasum": "d046a1a3ee4c483cbe9fe6ee85e5aacd194511bae448abc73dd79b8f18a36aa4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.1_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_linux_amd64.zip",
+          "shasum": "eb1dc7772ce24a13edcbffa8534e0d6cda36061f7a84be701f838758bdbd56dd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.5.1_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_linux_arm.zip",
+          "shasum": "ec5c58ce0ee72c6dea745e345a5591eda9f12509dd811ab836bb66f4b9a25db7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.1_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_linux_arm64.zip",
+          "shasum": "f673869e7e76000a2f194dcf6b7fe6c99de1e6fa6cc95b309acd41e48d710d54"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.5.1_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_windows_386.zip",
+          "shasum": "3a801f69f86628f46535136de9478650ea8a31fe6328917f492e6bddba9bb753"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.1_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_windows_amd64.zip",
+          "shasum": "7715e085e5b31f34e6d6d0d4b0b79686edafb63c4914041eb27fdd3dfc48f823"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.5.1_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_windows_arm.zip",
+          "shasum": "7be958225acb035f241a4da86e494bacc546a759b7a7ed01071d412052e05918"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.1_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.1/terraform-provider-ultradns_1.5.1_windows_arm64.zip",
+          "shasum": "c4a57a4676c7aeb629644bad017085da1f8116abcf764de660382ac9e8b00db6"
+        }
+      ]
+    },
+    {
+      "version": "1.5.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_darwin_amd64.zip",
+          "shasum": "663cef8e0999a59fbbfc5daada7db40aad3fc020ccad478d7cafe104f5a16990"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_darwin_arm64.zip",
+          "shasum": "bc91072e55ff292033a6859d8df2f9c23fabdead8f56688239a6f6108b8bee17"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.5.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_freebsd_386.zip",
+          "shasum": "7f72e29fe9296f5a8dc7eb7ee88191cb2207b1c2fc6acfb6f964c5a88f7f83c0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_freebsd_amd64.zip",
+          "shasum": "e81850ea34b6fad22c749775bc9586fef78deaaa8c16fbccc5f4e4ff7183fe64"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.5.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_freebsd_arm.zip",
+          "shasum": "63080e2a46cd50017aab0c0d64622cab9b933f120186eee30429a4298a6f649f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_freebsd_arm64.zip",
+          "shasum": "9f9c850f29e1ee44198886f8c44816506bc38d084172f01af1bd343ec2af43d6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.5.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_linux_386.zip",
+          "shasum": "ca3ae17c329d34853b43569db97dac8645e8afb5d7b2e20fc433e98c339c7845"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_linux_amd64.zip",
+          "shasum": "10e2ac98c2fcb7cd3400e38a461d0978d9abb2b62d945ed59400bcbcb7061eda"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.5.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_linux_arm.zip",
+          "shasum": "0c4408eb6c1ebe05a49e66e51af784252a160f58af9e800828e39baa0fe3304c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_linux_arm64.zip",
+          "shasum": "c99b5a03279cb9eccf5ca92ef7eb5295baa645f6204e6a0e1734c21655696966"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.5.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_windows_386.zip",
+          "shasum": "4ac2db198ded9fb50c140b2402a976781192f4437f50c400d9bc9b5740acbcb3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_windows_amd64.zip",
+          "shasum": "0c169a09f016b64e8b1f3a6213a0c4bd08b7a16f4b09d82db1567c69167b6404"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.5.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_windows_arm.zip",
+          "shasum": "a829609b5016ee8a58f817a10b7addf963522cbe40e283b66283707794ac949a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.5.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.5.0/terraform-provider-ultradns_1.5.0_windows_arm64.zip",
+          "shasum": "ec39d09fd1b01d2defc15fe611dd1fed6f17568f8871c58abb926f2d837b6976"
+        }
+      ]
+    },
+    {
+      "version": "1.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_darwin_amd64.zip",
+          "shasum": "6d3c26243863036462ee7dd9a0043a3717145c77169d6c56a0fa6d408f144fd1"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.4.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_darwin_arm64.zip",
+          "shasum": "99f3b93367f701c84e3d9f04539d283827afefa014f8e27b35ccd29096b2caf2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.4.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_freebsd_386.zip",
+          "shasum": "ee9ec0c5dcbbb4ddd50a618e3fc911e180019d6bc9beed48d2b213262b488a01"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.4.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_freebsd_amd64.zip",
+          "shasum": "9589323bea68057ec71502faf6a7376adb6690cefd123f2830e5ac93fca62136"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.4.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_freebsd_arm.zip",
+          "shasum": "21a2d34a3b7acfd5be87d07b1de3c903685c4ac405f2a3bed46140131be9421d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.4.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_freebsd_arm64.zip",
+          "shasum": "08d6972175012bc914188f26fb42da87f2e9a83bb2b045c934c100871da291ff"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.4.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_linux_386.zip",
+          "shasum": "7b84b8fb3ddbe440c68b05148c8ce840d91d2868134a26bc2df35757ee24ebd6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_linux_amd64.zip",
+          "shasum": "274ac84b176ad9022e03529d1e7481908efc73301c71613bee54e728b313cd76"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.4.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_linux_arm.zip",
+          "shasum": "ddac18287ca21725e6609f56a2960f2e5f069f9b0ab1ee2e5bfff74b66d27aec"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.4.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_linux_arm64.zip",
+          "shasum": "16c80b034b25708ca3e771047f67b01d2a86b779b6bafa2cf8a14090113e8dea"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.4.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_windows_386.zip",
+          "shasum": "27387ce152cc3186b6379a6c8b9a60432857efe5b3107091a2bcffe32a8b5bfe"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_windows_amd64.zip",
+          "shasum": "d71aff2d3ca96661e08b82db6486d134cd170f65eb4f336fc40d38fdac80dcc2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.4.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_windows_arm.zip",
+          "shasum": "ec08491ead1ecfea5c51145add1d933003ec5424ffa2d9114ae4187ece53593b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.4.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.4.0/terraform-provider-ultradns_1.4.0_windows_arm64.zip",
+          "shasum": "44feb61287c5a3f7d737e4f8a7a6b0d053f1ac114a185ea0e7c72973ed460e04"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_darwin_amd64.zip",
+          "shasum": "c66fb95beb7fb33974f26ac9d4dcb8b4112fb4c5183ae59ef1a903a4111ec92c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.3.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_darwin_arm64.zip",
+          "shasum": "ffc6c97ade8d4708142b31d284612922baf7a4ce743359d80d276be848e11cc9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_freebsd_386.zip",
+          "shasum": "55faf09c9a73654f3e8b7afb85d3c20e2714fdea2fb50305f38b33e1ccf82811"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_freebsd_amd64.zip",
+          "shasum": "540982945548863e7b3f69b07851c1624201ddadd461d977454c265c5c5ce96e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_freebsd_arm.zip",
+          "shasum": "395ee9bc84c35520e9a2e636ede41b336b93121d96a2c83a476d94d2cc1709d2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_freebsd_arm64.zip",
+          "shasum": "74082fdb5be68fb9ad73d08bde716797d1636d7ee8e0d4f646aafa3f59bf38a5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_linux_386.zip",
+          "shasum": "25d0863c2134a67657e5889a974514a06aa16ed29c47e3f4176a49fce718031b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_linux_amd64.zip",
+          "shasum": "856c1daa11edb4a69184a4141d8f4d4642b4fa9a817ade59d27ffc5c7a30ac0b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.3.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_linux_arm.zip",
+          "shasum": "2f2cad52359f091b19522b2a9f45e29d59f53bbbc63d3cdf2f3eeac00e7bc529"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_linux_arm64.zip",
+          "shasum": "2d7ab860826aedecac46729562edacb73e41a6987109af31b3e98526d8544df5"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_windows_386.zip",
+          "shasum": "d9c2ac99ae0838ae538d2e67c5ecd07ed676b5f79cbbd354958c7152606829a7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_windows_amd64.zip",
+          "shasum": "709f5651541da90f8877873a4df48f51ca54cfd9c14579906d2af70602b8ef8d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.3.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_windows_arm.zip",
+          "shasum": "aaaf06daaf199037d0df60a7a4ebe069b2c07cfbe8ea3eb5ce95deb1fc37ce18"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.3.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.3.0/terraform-provider-ultradns_1.3.0_windows_arm64.zip",
+          "shasum": "1c0b11f7edaa3dc2a6654e102ac397dcba971c4c66074396a80cdd576f0d0044"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_darwin_amd64.zip",
+          "shasum": "bf4315ac6fc2c5df99bb4087c2d8367aac83e3e5b223528ea9a30b0b053700a3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_darwin_arm64.zip",
+          "shasum": "7deeb33044a4adeec4e009b923b9f14e18390cc8756d54b6cddeb667151f6e12"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_freebsd_386.zip",
+          "shasum": "b0ed421c18d3c906fca4f1e791a38a334fd8f9e296852b1e85f35f71c8c05e71"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_freebsd_amd64.zip",
+          "shasum": "a5879deb5dcfd99ec4701be2118c7b16b251732c109ceae22cbb3e2457f7eee2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_freebsd_arm.zip",
+          "shasum": "ece7b71c5c467a5280aef6f96250fe261d9d7e343d741b541de3eace64aba07e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_freebsd_arm64.zip",
+          "shasum": "7f78f16699519fe4023d97e45ecfaa60b0b325f2c34aeeaff3e50db45e95ad89"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_linux_386.zip",
+          "shasum": "00e295419479de871535b52c9d2aafacfdd1df754522285f31ae5042913325dc"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_linux_amd64.zip",
+          "shasum": "16e22ee323a2be272182e5f0391b69055201930dd49a6c469efa338503389f71"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.2.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_linux_arm.zip",
+          "shasum": "dc8d00b821d8caf7143b36e308c13f2c4408fd6d4d512436acc1f39c698bccb9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_linux_arm64.zip",
+          "shasum": "def6192f1c78ad0aa4760e1338a80422d1d49c0f613667f77f10703f536355d9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_windows_386.zip",
+          "shasum": "0aba2feae1c303162d276252ddf4dfde01e1f2fa42715f9824b9a633a754e723"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_windows_amd64.zip",
+          "shasum": "e7c1f7848fe6be15a4dffa3a9e6fbe9352ffbafde5422c1aeedd79ff221e0a40"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.2.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_windows_arm.zip",
+          "shasum": "304c6cd069eaf096d5aca62a35cb424ad2254f26d30bdaa5f1fdfa351da06020"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.2.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.2.0/terraform-provider-ultradns_1.2.0_windows_arm64.zip",
+          "shasum": "8436360c9586e859bf6567af096e4960a579a4adad594089aeb200e854a2e927"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_darwin_amd64.zip",
+          "shasum": "f50ab7413512f75edead2e7ad0261728e622bf4f819b744ac852b803ade39e40"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_darwin_arm64.zip",
+          "shasum": "17bebf77bf71977b24b3f77969c2444b0a5d75ab821e19deb3dc888f19e5fabf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_freebsd_386.zip",
+          "shasum": "f3d4626b064c26abd01b20ea37fe2606a9e9a13c59a25e3ef7c4a3b6968fc481"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_freebsd_amd64.zip",
+          "shasum": "c915afd12ed98f8aebd119dc43d93b0a5263ae6cf3e14a84dbf842a99558db14"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_freebsd_arm.zip",
+          "shasum": "2fb134e321c0366c3c779229adb5eb824e7a87ce848a3ab7e2e2679426710a2c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_freebsd_arm64.zip",
+          "shasum": "e04f93edd33ca9cb86d185528ff71911c91f449d72d26cb7fcb4fe97a092b3b1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_linux_386.zip",
+          "shasum": "17401be93c0b605f5d186a95303006051cb45d4cac4e26e283cd80b11f6a92cf"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_linux_amd64.zip",
+          "shasum": "aac8da4a3b1af28e901748089a4481baf38d6c686dc05e60b2ab5e322dca8d4f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.1.0_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_linux_arm.zip",
+          "shasum": "32e6619367f4682fe1cee04b681c18751a4c2ab5922101a2bc9c4e12273c0404"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_linux_arm64.zip",
+          "shasum": "09d90a5e5810d91dfa58620fbd48ff5a3193b74e9a0f86f303467e1a5491fe14"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_windows_386.zip",
+          "shasum": "506e5b0412504efd88b381b012d05962a99217762313fb3492946395c6d5e074"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_windows_amd64.zip",
+          "shasum": "c4a980b8543682635a05079630823396fdf8564c162665e7d675f12cd022b5bb"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.1.0_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_windows_arm.zip",
+          "shasum": "cbdb018b0d532e6cc6496e52e980aa71fc5eac5389f83561ebd93953483d3cfd"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.1.0_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.1.0/terraform-provider-ultradns_1.1.0_windows_arm64.zip",
+          "shasum": "f439746dbd4b46b38549c0b26f2f00a21977f257f012b96075dd70bfb6a8ec75"
+        }
+      ]
+    },
+    {
+      "version": "1.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_darwin_amd64.zip",
+          "shasum": "95186222024e0fa2fa18119f9d9ec13a5c958d3a366601224f2de7b1cb75e66a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.4_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_darwin_arm64.zip",
+          "shasum": "644e9cc481048d2e3b1830a13cd1f700848b5d9dc53a47f2c46df95162f2ded3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_freebsd_386.zip",
+          "shasum": "4103d84f2f2d47dcfcabc7b9725cedd31677b96458f397cb76da9639695cd03a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_freebsd_amd64.zip",
+          "shasum": "f5e9b26eaf42cf10498d3e50c6a0e8f80a1ea7495213addec34f2aa9eb7f3484"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_freebsd_arm.zip",
+          "shasum": "1f27290f498a4f1beae85028b58aa0ca9dddb1f61efba5bcecfed9081ae69a15"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_freebsd_arm64.zip",
+          "shasum": "9ab79675a7f85d2fd454280541d25eccc1008e42d8b8f87d9ecc9a91244e9632"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.0.4_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_linux_386.zip",
+          "shasum": "c435e9c89f3b1b21bc788d09d9b9e227b06fedc3c125412eae0fa64a1a10b864"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_linux_amd64.zip",
+          "shasum": "63a20833cb8bb304bc6c1f56b8ee576edcbf52cfe54ecb503c4a9a91173ec929"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.0.4_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_linux_arm.zip",
+          "shasum": "7f662e26366c84b4c6bc14da9fd6bad2b8d3485aa66e8c95a6a793e1d8e283d2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_linux_arm64.zip",
+          "shasum": "1307c35a2cd4a7829784b9ece42cbaeca224b8000586185bcdd108bd59e24e8f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.0.4_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_windows_386.zip",
+          "shasum": "376cad988a8ec0e497e7d4fd13375f7c1f1008a555b311a524eb72340cce7cf7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_windows_amd64.zip",
+          "shasum": "759aa1f74b9826792e4cb7f9b50c8b57e164d9c1c19b03c4977d33d8ee1d1efe"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.0.4_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_windows_arm.zip",
+          "shasum": "51c0036761313336cf58126f5602b7dc4a52763e4e8340b4e415923a4ca1dd22"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.4_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.4/terraform-provider-ultradns_1.0.4_windows_arm64.zip",
+          "shasum": "5ab015cb32471917988577ae856724dcb8bfee3e6044fb42f3ce53657e22c24f"
+        }
+      ]
+    },
+    {
+      "version": "1.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_darwin_amd64.zip",
+          "shasum": "273d9a0cef2c09355b3bf30ab74e4b9e3572ba79ced1817f5bba7dcd97f1f659"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.3_darwin_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_darwin_arm64.zip",
+          "shasum": "c24df1d4a0a45ce909238267a55de33f10ca4c980291ff6c91572fbb9081aea7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.0.3_freebsd_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_freebsd_386.zip",
+          "shasum": "79de484dcd098565b948cde956ea62505abec2deb9779f4c91822b90da15597d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_freebsd_amd64.zip",
+          "shasum": "8fd57bc1aadbe21a5a75392c547bb0161464b770bd4d64d59dac2d2628a43b69"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.0.3_freebsd_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_freebsd_arm.zip",
+          "shasum": "5fb399d2e24fcd0268b4e27844053b4c3d1909f9d36d1c9249bed3f17ca53589"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_freebsd_arm64.zip",
+          "shasum": "5cf16e1075b8db9e6dcc188a5fe306cfd66607c5505aeb2a07e57446be97f911"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.0.3_linux_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_linux_386.zip",
+          "shasum": "56392031d4ebf4e40d990c447c9cf4462e67f6a19d946095d089330e3c9b9351"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_linux_amd64.zip",
+          "shasum": "8306c647b41200267540d9b9f3959464d0c04d1db5b8fe4ee7055279446dfc81"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.0.3_linux_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_linux_arm.zip",
+          "shasum": "df41fb1ba385dea8d0c1b642b8fb04edd92491be2c00fd57dc8afe9a7fa75a3b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_linux_arm64.zip",
+          "shasum": "bf6817a3b4e47f7021c3abc9069193a3f66ce55b8c2fcfe79bc8a07d6f5e6b58"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_1.0.3_windows_386.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_windows_386.zip",
+          "shasum": "3652a897acd1562867319f7d2aef42b289e63db403b99fc7d9aee4c7725d0e6a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_1.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_windows_amd64.zip",
+          "shasum": "cb9563aef161c67f82d6619d80dda040b4f7b2159fec1944e67d6c7a7bcd8b7c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-ultradns_1.0.3_windows_arm.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_windows_arm.zip",
+          "shasum": "5286021917ed84b404f628b8d9d31f8070d7b2c4229703e2ea74bc03aac96be5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ultradns_1.0.3_windows_arm64.zip",
+          "download_url": "https://github.com/ultradns/terraform-provider-ultradns/releases/download/v1.0.3/terraform-provider-ultradns_1.0.3_windows_arm64.zip",
+          "shasum": "c3a729c67f4d4bbf13a778472d7e7ec65aa9583cbda5c7f07985791d0ce345f9"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/v/viktorradnai/bcrypt.json
+++ b/providers/v/viktorradnai/bcrypt.json
@@ -1,0 +1,328 @@
+{
+  "versions": [
+    {
+      "version": "0.1.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.2_darwin_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_darwin_amd64.zip",
+          "shasum": "997164a77cfeebefa68f5289087682ccae53d3307c4e97e6df6f00ba304e8b28"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.2_darwin_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_darwin_arm64.zip",
+          "shasum": "db6e33503c357aabc108479f24ee4d920c130242992a7caae8b75ed5164e8742"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.2_freebsd_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_freebsd_386.zip",
+          "shasum": "dd449aa77d587af22fa68328f404c2b19ac198909e2256f7b00ea2e9006e64ee"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_freebsd_amd64.zip",
+          "shasum": "22c2ec30603f55e8e3c4f54ad22da2cc77a98e7988ec16bc06c652fb3a7e3dc3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.2_freebsd_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_freebsd_arm.zip",
+          "shasum": "6264f5bd71afcc6c77f46e052a71a8a50fc623cd263860172d0ea0886a588cbe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_freebsd_arm64.zip",
+          "shasum": "135e99d3d36a49dcec9e6898de0070a6b7c01e3c0eaefeaaedf7336f71d590ff"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.2_linux_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_linux_386.zip",
+          "shasum": "a725b80499e15f3cab9ee40e698b203cd9a231a2dfa83937b3458f8115f4f087"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.2_linux_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_linux_amd64.zip",
+          "shasum": "c6266a93cebd6a1f62d8bb9ab898b448c78217d63528870ca7af9eccdd7402c4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.2_linux_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_linux_arm.zip",
+          "shasum": "6f2bd49ac4499d4734c107554ae88974b1247739cd10c3001918307646937e32"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.2_linux_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_linux_arm64.zip",
+          "shasum": "9875db898a51c223f56a08d5231190b6c9271bb3ae445921c83b7bbca58169e6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.2_windows_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_windows_386.zip",
+          "shasum": "62faa449ed4b526b23ddf732db72490c3eac8c9433fc17a15f4edf31b6928906"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.2_windows_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_windows_amd64.zip",
+          "shasum": "43263378cd4604ef4d1e902668338695260a5bd93301879b2456e155f5936c9f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.2_windows_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_windows_arm.zip",
+          "shasum": "f1808d00755d73f2929142e3a767d21a4d232a533b2ab5d346a294e7d227bc57"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.2_windows_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.2/terraform-provider-bcrypt_0.1.2_windows_arm64.zip",
+          "shasum": "383943b05e2821ae91ec288a716011c5bfe60da97e37767e25e71d629b44917f"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_darwin_amd64.zip",
+          "shasum": "f2981f4b4fae6aa101b9aa972f8cb50d98cbede92f258e559215f7252fd0b68e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_darwin_arm64.zip",
+          "shasum": "18ece39fa8759a7974f1040da088ab28d6fe5d0b7d35a3ad996c38a5b082864d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_freebsd_386.zip",
+          "shasum": "51727ef22aabc926d52bf1bb5bd8fc0cf08681ac78773dd7267c3bd5df70aef0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_freebsd_amd64.zip",
+          "shasum": "b582fff34b5edea0205bb4aaf6ce044515ec915469f45af3008f1454229decc4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_freebsd_arm.zip",
+          "shasum": "c666d89fdb37e982f125455f0826674d04b0c26cf284008b1284d8ff9287cabf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_freebsd_arm64.zip",
+          "shasum": "a7f0571b938fccd90a3097e5df0fce85f3e3e29951079463068e18f874f69e26"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_linux_386.zip",
+          "shasum": "1e44a434e29ed687eef2326d0d62306efb507b686cc41008488b0d6e59c659f8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_linux_amd64.zip",
+          "shasum": "3569b94eb0e3884be3c065caa5c13f17aacc7450a12f02781e085fc827c80d0b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_linux_arm.zip",
+          "shasum": "bc2347550476546d4615d4327463660bec74b0fd62a7a3c3d8652f012b7dffcd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_linux_arm64.zip",
+          "shasum": "291912265518bc9885d57407b6e77b7836cb70730452c1d7401729a11f40c461"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_windows_386.zip",
+          "shasum": "9483b48b59ced577297e239d39833592753f90a6bc12f160af67249e5da331cc"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_windows_amd64.zip",
+          "shasum": "902fa1d6d841b62597987b563d0efffe2a4fde39333954e6b904983b64b21b9a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.1_windows_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_windows_arm.zip",
+          "shasum": "e86df80b22c309049c879b991aac0b40faa6ed2c8140938180f3b9b4ab6ab284"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.1_windows_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.1/terraform-provider-bcrypt_0.1.1_windows_arm64.zip",
+          "shasum": "12c2782cf3d7bbc90a6aefa818dcbd5c3f713b33e921d69e95b1b9ce2ccf8a16"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_darwin_amd64.zip",
+          "shasum": "ea692e8a454801c4fcebdbdbe49f35efe607893d43cea683d0900a3e96726066"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_darwin_arm64.zip",
+          "shasum": "87ab39beab35fd350d786095930c0223ae797a481e85fbcf6c4d4513cf180ea6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_freebsd_386.zip",
+          "shasum": "bfeed4d97c8b290a9e0abc4164d8ad0587f7d881dbcc990614b1f0e92fe3568c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_freebsd_amd64.zip",
+          "shasum": "0e771a2e5cfaa87a59aa14879113c7bd01d819a4065d4802c279fcf6a4156a41"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_freebsd_arm.zip",
+          "shasum": "3c1a20d502942e3d669783d8d8f192f364ac714d1c141dad1876c4e11a725356"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_freebsd_arm64.zip",
+          "shasum": "1de8dc9ed3e83362c3fe533daaa452b7f76a9b2dd362b904cb0f5d1189d1135f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_linux_386.zip",
+          "shasum": "09d4f274906fc5de2e79434e102b3b364d625cc614775f1ee3cf432757f70252"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_linux_amd64.zip",
+          "shasum": "f718b514ec7d01af60dd8dff371715ffa358cee2a5ce95fa0cdbe56e00ed8790"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_linux_arm.zip",
+          "shasum": "37c45dc4366827b1ec1f91eb452a83d59c7db6373bffdbd54ebdbef19ce0eb9d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_linux_arm64.zip",
+          "shasum": "666a2cd6516cb85e9cfdfbd9eec2d4fd6214f866f549cc552e16b69656e6f42a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bcrypt_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_windows_386.zip",
+          "shasum": "8d09db78f5647dcd3f24557768f2ab698b68a42beaeadafd336ecd24e74a6bd8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bcrypt_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_windows_amd64.zip",
+          "shasum": "c4d5362fb250f3885d0662d43291734199e2f6146c40b22a3fa2b0ebda6337ac"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-bcrypt_0.1.0_windows_arm.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_windows_arm.zip",
+          "shasum": "6eee50f9096e88b1e4a868920ad08e99e764f6e16d21b1901569973b80fc89f1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-bcrypt_0.1.0_windows_arm64.zip",
+          "download_url": "https://github.com/viktorradnai/terraform-provider-bcrypt/releases/download/v0.1.0/terraform-provider-bcrypt_0.1.0_windows_arm64.zip",
+          "shasum": "18e4f994a01114812f8654127874f6423c419b85442d061715b2e7cdca78a1d3"
+        }
+      ]
+    }
+  ]
+}

--- a/src/internal/provider/protocols.go
+++ b/src/internal/provider/protocols.go
@@ -23,7 +23,7 @@ func (p Provider) GetProtocols(manifestDownloadUrl string) ([]string, error) {
 
 	manifest, err := parseManifestContents(contents)
 	if err != nil {
-		return nil, err
+		return nil, nil
 	}
 
 	return manifest.Metadata.ProtocolVersions, nil

--- a/src/internal/provider/protocols.go
+++ b/src/internal/provider/protocols.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 )
 
 type Manifest struct {
@@ -23,6 +24,7 @@ func (p Provider) GetProtocols(manifestDownloadUrl string) ([]string, error) {
 
 	manifest, err := parseManifestContents(contents)
 	if err != nil {
+		p.Logger.Warn("Manifest file invalid, ignoring...", slog.String("url", manifestDownloadUrl), slog.Any("err", err))
 		return nil, nil
 	}
 


### PR DESCRIPTION
- Change the code not to fail if we've failed to parse the manifest JSON file - simply assume that the protocol is `5.0` in such a case
- Upload providers that failed the hydration process as part of https://github.com/opentofu/registry-stable/pull/46 due to manifest parsing errors
  - `coxedge` providers were manually set to 6.0, as that's the expected protocol there, even though the manifest files are broken (have trailing `,`)