### PR TITLE
Ensure that providers use lowercase pathing in the v1 api

### DIFF
--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"github.com/opentofu/registry-stable/internal/files"
 	"github.com/opentofu/registry-stable/internal/provider"
@@ -34,12 +35,14 @@ func NewProviderGenerator(p provider.Provider, destination string) (ProviderGene
 
 // VersionListingPath returns the path to the provider version listing file.
 func (p ProviderGenerator) VersionListingPath() string {
-	return filepath.Join(p.Destination, "v1", "providers", p.Provider.Namespace, p.Provider.ProviderName, "versions")
+	listingPath := filepath.Join(p.Destination, "v1", "providers", p.Provider.Namespace, p.Provider.ProviderName, "versions")
+	return strings.ToLower(listingPath)
 }
 
 // VersionDownloadPath returns the path to the provider version download file.
 func (p ProviderGenerator) VersionDownloadPath(ver provider.Version, details ProviderVersionDetails) string {
-	return filepath.Join(p.Destination, "v1", "providers", p.Provider.Namespace, p.Provider.ProviderName, ver.Version, "download", details.OS, details.Arch)
+	downloadPath := filepath.Join(p.Destination, "v1", "providers", p.Provider.Namespace, p.Provider.ProviderName, ver.Version, "download", details.OS, details.Arch)
+	return strings.ToLower(downloadPath)
 }
 
 // VersionListing will take the provider metadata and generate the responses for the provider version listing API endpoints.

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -35,14 +35,16 @@ func NewProviderGenerator(p provider.Provider, destination string) (ProviderGene
 
 // VersionListingPath returns the path to the provider version listing file.
 func (p ProviderGenerator) VersionListingPath() string {
-	listingPath := filepath.Join(p.Destination, "v1", "providers", p.Provider.Namespace, p.Provider.ProviderName, "versions")
-	return strings.ToLower(listingPath)
+	namespacePath := strings.ToLower(p.Provider.Namespace)
+	providerNamePath := strings.ToLower(p.Provider.ProviderName)
+	return filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, "versions")
 }
 
 // VersionDownloadPath returns the path to the provider version download file.
 func (p ProviderGenerator) VersionDownloadPath(ver provider.Version, details ProviderVersionDetails) string {
-	downloadPath := filepath.Join(p.Destination, "v1", "providers", p.Provider.Namespace, p.Provider.ProviderName, ver.Version, "download", details.OS, details.Arch)
-	return strings.ToLower(downloadPath)
+	namespacePath := strings.ToLower(p.Provider.Namespace)
+	providerNamePath := strings.ToLower(p.Provider.ProviderName)
+	return filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, ver.Version, "download", details.OS, details.Arch)
 }
 
 // VersionListing will take the provider metadata and generate the responses for the provider version listing API endpoints.


### PR DESCRIPTION
This is to ensure that we serve things up in the same way that the clients expect.

Fixes #57 