### PR TITLE
Add basic providers from github (second pass)

### DIFF
--- a/providers/1/1Password/onepassword.json
+++ b/providers/1/1Password/onepassword.json
@@ -1,6 +1,114 @@
 {
   "versions": [
     {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-onepassword_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_darwin_amd64.zip",
+          "shasum": "6552e74457325b5bdef4376bcf0509599934f95b0ecb02b34f406482e3d8c0fd"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-onepassword_1.3.0_darwin_arm64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_darwin_arm64.zip",
+          "shasum": "f53a50555c607b73609db7a912b32a36724770372d56bdc4be278b60e50a06f7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-onepassword_1.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_freebsd_386.zip",
+          "shasum": "5c3f73f02fcec1e2c80027a459c8fb9ad4c16843fae0b9fc722263f4d803d3d8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-onepassword_1.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_freebsd_amd64.zip",
+          "shasum": "419e1d159d60ad13ea3f409b6205d89e308d81fd3918391e0c62eac025ed6e76"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-onepassword_1.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_freebsd_arm.zip",
+          "shasum": "a0fa0b5acdf040d9211d2e4b98d6675222f2cba4d1d40e4e8fbc74cfec46e653"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-onepassword_1.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_freebsd_arm64.zip",
+          "shasum": "6419d64c9b6329f159f902a3a12958a4675cdabc7a80938377b5ab31974b7edc"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-onepassword_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_linux_386.zip",
+          "shasum": "408cff888c21edf174d1499f00f8396a8e473b986a0d797cf6bcb45e6bf2d791"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-onepassword_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_linux_amd64.zip",
+          "shasum": "7fc5425e1679710c8062c35f57d97296e0c26b0eb09af5b0f92530669915953f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-onepassword_1.3.0_linux_arm.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_linux_arm.zip",
+          "shasum": "9dbbb2f76cf3fd33578a084780c3745fcb4cc635777046b7935c7db0abb273d6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-onepassword_1.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_linux_arm64.zip",
+          "shasum": "5c14ce90201966b26bcae9443ac5d4863848fb8d843f521da3e94706dd9efa0f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-onepassword_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_windows_386.zip",
+          "shasum": "667de204e54ee598b0c3cec6c320d9bd9d5b1873c1cb0cc36f5a1c7d467bed28"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-onepassword_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_windows_amd64.zip",
+          "shasum": "4e72b7985812bf3f17f8e541d4bc327cfec2b288fcd745562b7105d9ed9045fe"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-onepassword_1.3.0_windows_arm.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_windows_arm.zip",
+          "shasum": "a67acf88560db4e4b27c71f10ec910275ee56f4a4a4b5754b5ee458b0d1b0f90"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-onepassword_1.3.0_windows_arm64.zip",
+          "download_url": "https://github.com/1Password/terraform-provider-onepassword/releases/download/v1.3.0/terraform-provider-onepassword_1.3.0_windows_arm64.zip",
+          "shasum": "6b6f4b4e6b43687f0a86eeac40e74b87182675b618530b5e56ae408657baffda"
+        }
+      ]
+    },
+    {
       "version": "1.2.1",
       "protocols": [
         "5.0"

--- a/providers/d/daniepett/qlik.json
+++ b/providers/d/daniepett/qlik.json
@@ -1,0 +1,112 @@
+{
+  "versions": [
+    {
+      "version": "0.1.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-qlik_0.1.2_darwin_amd64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_darwin_amd64.zip",
+          "shasum": "525627236385f2bc8ca42ea274dbdd27a7fcd7dcbf74918104370a3047d73706"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-qlik_0.1.2_darwin_arm64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_darwin_arm64.zip",
+          "shasum": "3cca9cd23073b6b7b168cc0c1a7da95b0d7889daefd35f43d1ff95d9f49c6d5e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-qlik_0.1.2_freebsd_386.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_freebsd_386.zip",
+          "shasum": "21b3456dabc2b13dbcd63adb7d829d1eab8e79b50af67c30efa9ac7d3faf1a99"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-qlik_0.1.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_freebsd_amd64.zip",
+          "shasum": "262b8f8b8164cc5d240022dfefa37d55ec554aae8a38f76ee2c463680d40f5fc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-qlik_0.1.2_freebsd_arm.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_freebsd_arm.zip",
+          "shasum": "dd590d2df11fde26e479180aaa32ad4e2ef5b0c839258982abe8b00cc99e90e7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-qlik_0.1.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_freebsd_arm64.zip",
+          "shasum": "c32fe273ca8f4d0345082edede72399a46d2125c640e5024779da64950516d39"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-qlik_0.1.2_linux_386.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_linux_386.zip",
+          "shasum": "f170695ee8557564be6ad56e992e4ac421ec0a3f4ea6dad49c42a610c58a103a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-qlik_0.1.2_linux_amd64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_linux_amd64.zip",
+          "shasum": "822d001958aca65fa7c9c4ef024568e64804a95dfc7c619a38e7a81d431239a5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-qlik_0.1.2_linux_arm.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_linux_arm.zip",
+          "shasum": "f74cf1fa09f0b4e6cd6a933de9da6754ba8299434b3af29b98d350956ef2e675"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-qlik_0.1.2_linux_arm64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_linux_arm64.zip",
+          "shasum": "ab1d60f316700aba19d9abcf74c89217b607e94258ad8d8028e271172f44f663"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-qlik_0.1.2_windows_386.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_windows_386.zip",
+          "shasum": "0fae953b8f43a89f7d3f7b8b707029b040ce74d513336d90401abe3629a238d9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-qlik_0.1.2_windows_amd64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_windows_amd64.zip",
+          "shasum": "bf8b6006d402a72fceb1149c85c6ae7a04928b0b8bb4966f9e535ce973975a09"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-qlik_0.1.2_windows_arm.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_windows_arm.zip",
+          "shasum": "0b16b1bbea2bdfe0a5776e5305362b7e0e9b3a7f622b856367de9b0ffd974e7d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-qlik_0.1.2_windows_arm64.zip",
+          "download_url": "https://github.com/daniepett/terraform-provider-qlik/releases/download/v0.1.2/terraform-provider-qlik_0.1.2_windows_arm64.zip",
+          "shasum": "a00f55a8a41b95ff90aee079dcf3985697baeb37e8ecaaabc55aba067c75a820"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/d/darkedges/fram.json
+++ b/providers/d/darkedges/fram.json
@@ -1,0 +1,98 @@
+{
+  "versions": [
+    {
+      "version": "0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-fram_0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_darwin_amd64.zip",
+          "shasum": "dfa8dc8869a99e036dda640e3cd1703ba32b19b9202336dc1a60ec97a6fe430c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-fram_0.1_freebsd_386.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_freebsd_386.zip",
+          "shasum": "90b0f5c09c18fb266d785c2efb7daa3603d24401c1185641aa2d00ed01028bb2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-fram_0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_freebsd_amd64.zip",
+          "shasum": "88c787b4a74024c9ae8e8cc16e3305f4f43f1d2f6e5caca5814145e7b3ab7fab"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-fram_0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_freebsd_arm.zip",
+          "shasum": "3da09424f8fd9a453caa4cd21950a80d6ca6ada760e35be4bc2d14bcad493542"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-fram_0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_freebsd_arm64.zip",
+          "shasum": "75e3b5f6de2c520e7b6f191f95d0f49dc6a769421add319fd524fa7ab494afb8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-fram_0.1_linux_386.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_linux_386.zip",
+          "shasum": "d32f588663aec5b0e54176cd174d45436f1aa88add7295d8d3485837b49908f5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-fram_0.1_linux_amd64.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_linux_amd64.zip",
+          "shasum": "615e09a49ddf226c8324b28b7c281bd131277edee907081d59a9b63fda5c6224"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-fram_0.1_linux_arm.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_linux_arm.zip",
+          "shasum": "31e5c9c3c4a84b76dd154983c95b4aaa4a23209c39e897692b6a6c6e52ec89ea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-fram_0.1_linux_arm64.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_linux_arm64.zip",
+          "shasum": "84aa83b1e3a4c75fcfde42faa78ce3bce34ff3039f0c5f3f1c293c8e7c432058"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-fram_0.1_windows_386.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_windows_386.zip",
+          "shasum": "54bd6fcb8c1725af4f1b4b2a4a1f64f2285586e606093fdfb33385de1df33a51"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-fram_0.1_windows_amd64.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_windows_amd64.zip",
+          "shasum": "2cb30674b2513076c2f89271a95e3368c8df29516c7b61953b40b83842838895"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-fram_0.1_windows_arm.zip",
+          "download_url": "https://github.com/darkedges/terraform-provider-fram/releases/download/v0.1/terraform-provider-fram_0.1_windows_arm.zip",
+          "shasum": "1344692eb7418b8c2ff35e8c00951da594a413da13b48492d932b7b3996c3d21"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/d/deploymenttheory/jamfpro.json
+++ b/providers/d/deploymenttheory/jamfpro.json
@@ -1,0 +1,112 @@
+{
+  "versions": [
+    {
+      "version": "0.0.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-jamfpro_0.0.8_darwin_amd64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_darwin_amd64.zip",
+          "shasum": "3ff1a9a24b416751a4b47f39a0274bbf3ae050d661c51ed5291f0442bfb00919"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-jamfpro_0.0.8_darwin_arm64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_darwin_arm64.zip",
+          "shasum": "a63c333d346468536aafb5e86ea2b4bb317aaf06799fad6780467d08205c3326"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-jamfpro_0.0.8_freebsd_386.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_freebsd_386.zip",
+          "shasum": "4aed769bb1bcbd8e97777f8ecf1041bceda8102e8ac42518e33bd19dbd63bf93"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-jamfpro_0.0.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_freebsd_amd64.zip",
+          "shasum": "09f8e22f3e7b42e45785a2ae9f30a443e4b8fe92c4d06e9d5a7c3e3876552610"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-jamfpro_0.0.8_freebsd_arm.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_freebsd_arm.zip",
+          "shasum": "19519d6cfad1f60817191973c23b646cc654620811f7a4fa74708d8886fc07eb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-jamfpro_0.0.8_freebsd_arm64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_freebsd_arm64.zip",
+          "shasum": "12c8debf825302a85c8d07dd31b070015640bf597315c05265bb15d4cde2d100"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-jamfpro_0.0.8_linux_386.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_linux_386.zip",
+          "shasum": "159cbf76f98f9e68828ad39828809b0216709da7d491e9499e89a8136ceb3232"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-jamfpro_0.0.8_linux_amd64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_linux_amd64.zip",
+          "shasum": "9302df044251fc2800e1d0882c3216c3c1739cb47bd883e0d795343516ce8f95"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-jamfpro_0.0.8_linux_arm.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_linux_arm.zip",
+          "shasum": "547bf7acfb0cbf7c6ca22c1302a38f54b80b7cb3ffd0baa195f862bca3a266ab"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-jamfpro_0.0.8_linux_arm64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_linux_arm64.zip",
+          "shasum": "e065b0b2aa57e745fed00382cff2bb28d55e3e650a112a6fbd907def4af2e22f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-jamfpro_0.0.8_windows_386.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_windows_386.zip",
+          "shasum": "934065d7bc032d7d7e03460a9a2b1313ab4cefe62323e3059162ed39faaa5d86"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-jamfpro_0.0.8_windows_amd64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_windows_amd64.zip",
+          "shasum": "565c7f0a235067d1886017765ba14895c5da54e1f121abc37e47de362904774f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-jamfpro_0.0.8_windows_arm.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_windows_arm.zip",
+          "shasum": "01e7dbd56523b9aa849ab0503ec6721cf0ff304c8abc12b7196d99f5831d29be"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-jamfpro_0.0.8_windows_arm64.zip",
+          "download_url": "https://github.com/deploymenttheory/terraform-provider-jamfpro/releases/download/v0.0.8/terraform-provider-jamfpro_0.0.8_windows_arm64.zip",
+          "shasum": "62ceb5ba14fde62dc438c13876847cf24b41dc7b7883154e7283f1c69a515afb"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/e/enriquebelarte/ocm-test.json
+++ b/providers/e/enriquebelarte/ocm-test.json
@@ -1,0 +1,56 @@
+{
+  "versions": [
+    {
+      "version": "1.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ocm-test_1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_darwin_amd64.zip",
+          "shasum": "b1e0dc30e5c8a19585c645a07a326ef07ad2c725a47e5de44ba09a7801ccf7b6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-ocm-test_1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_darwin_arm64.zip",
+          "shasum": "b282652d00b15d08dceb11957df6c6e78800705219ceea48b3f7582306e25328"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ocm-test_1.1_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_linux_amd64.zip",
+          "shasum": "f5249ae69beefe357eb46adb23479bc8cf81b873258a9e6c4827d6dc31bdefee"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-ocm-test_1.1_linux_arm64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_linux_arm64.zip",
+          "shasum": "c8113b4c1df75c316ee5e98219cd7545c8cfd76a08f50ce4f0950a6d7122489a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ocm-test_1.1_windows_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_windows_amd64.zip",
+          "shasum": "972e7478afb979a191f5ed2fba3d0e7ee6beade9feb1391fee2b48dd070248cd"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-ocm-test_1.1_windows_arm64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-ocm-test/releases/download/v1.1/terraform-provider-ocm-test_1.1_windows_arm64.zip",
+          "shasum": "b18baf34dea25d8bade2474761a85bce2994e90a85029f136277591271ee0535"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/e/enriquebelarte/rhcs.json
+++ b/providers/e/enriquebelarte/rhcs.json
@@ -1,0 +1,157 @@
+{
+  "versions": [
+    {
+      "version": "5.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v5.1/terraform-provider-rhcs_5.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v5.1/terraform-provider-rhcs_5.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_5.1_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v5.1/terraform-provider-rhcs_5.1_linux_amd64.zip",
+          "shasum": "2725525a78a82491cc4b0c5d9d2f0431fadddfbfe30b5cd5391f4672affa63cf"
+        }
+      ]
+    },
+    {
+      "version": "4.86",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v4.86/terraform-provider-rhcs_4.86_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v4.86/terraform-provider-rhcs_4.86_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_4.86_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v4.86/terraform-provider-rhcs_4.86_linux_amd64.zip",
+          "shasum": "960770d31d159cfd29628438bf792e9e56541dc5acf612f8ca010aa2adcd6a10"
+        }
+      ]
+    },
+    {
+      "version": "3.8",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.8/terraform-provider-rhcs_3.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.8/terraform-provider-rhcs_3.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.8_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.8/terraform-provider-rhcs_3.8_linux_amd64.zip",
+          "shasum": "8e5e0d120464e8b62c68fa30fa70139babc4a22b281b15bf585cd987675ec71d"
+        }
+      ]
+    },
+    {
+      "version": "3.7",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.7/terraform-provider-rhcs_3.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.7/terraform-provider-rhcs_3.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.7_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.7/terraform-provider-rhcs_3.7_linux_amd64.zip",
+          "shasum": "acd345a67f0aa815a75579f85d6f11f1c75435742c7cd9674c6759ea2c0ed80f"
+        }
+      ]
+    },
+    {
+      "version": "3.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.6/terraform-provider-rhcs_3.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.6/terraform-provider-rhcs_3.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.6_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.6/terraform-provider-rhcs_3.6_linux_amd64.zip",
+          "shasum": "947edf81bffee5d4777e286a470ea5e88811f1d1065475f8c1fca5a09410b822"
+        }
+      ]
+    },
+    {
+      "version": "3.5",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.5/terraform-provider-rhcs_3.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.5/terraform-provider-rhcs_3.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.5_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.5/terraform-provider-rhcs_3.5_linux_amd64.zip",
+          "shasum": "3e0c929c3a12caef6577126816849aa575225a6aed4cc1a0e35399f0df80ea1b"
+        }
+      ]
+    },
+    {
+      "version": "3.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.4/terraform-provider-rhcs_3.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.4/terraform-provider-rhcs_3.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.4_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.4/terraform-provider-rhcs_3.4_linux_amd64.zip",
+          "shasum": "23a104b86b856190ce862c887f7a63c733b9a3912a0d50ade001c32a7bb10b9c"
+        }
+      ]
+    },
+    {
+      "version": "3.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.3/terraform-provider-rhcs_3.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.3/terraform-provider-rhcs_3.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.3_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.3/terraform-provider-rhcs_3.3_linux_amd64.zip",
+          "shasum": "e38ed842f5f89951df088c754dc8fe09cafb641558f8c022a7153f5b3c5c5403"
+        }
+      ]
+    },
+    {
+      "version": "3.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.1/terraform-provider-rhcs_3.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.1/terraform-provider-rhcs_3.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rhcs_3.1_linux_amd64.zip",
+          "download_url": "https://github.com/enriquebelarte/terraform-provider-rhcs/releases/download/v3.1/terraform-provider-rhcs_3.1_linux_amd64.zip",
+          "shasum": "91ce614d5ebc2899906957c183a41b4637326230b702c0b0778b976ee58d54e3"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/g/G-Core/gcore.json
+++ b/providers/g/G-Core/gcore.json
@@ -1,6 +1,86 @@
 {
   "versions": [
     {
+      "version": "0.3.88",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-gcore_0.3.88_darwin_amd64.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_darwin_amd64.zip",
+          "shasum": "dd5fefe3b38a66bec11c04ccfd52639e11c6e76ebb4c542c270594d9b5e322a3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-gcore_0.3.88_darwin_arm64.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_darwin_arm64.zip",
+          "shasum": "53871bcf8f8b19c735b15726c5b49fd4f6e9e79e21031ff6121fd7edcaffcff2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-gcore_0.3.88_linux_386.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_linux_386.zip",
+          "shasum": "a141a61a0d69ee01effaaa8ad0f2e79a83e158b21d700405a1048de7fafc0351"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-gcore_0.3.88_linux_amd64.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_linux_amd64.zip",
+          "shasum": "2139be338d18c162bd5f4a1774381bcb8cfcb38752770295d98200430aa06b4e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-gcore_0.3.88_linux_arm.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_linux_arm.zip",
+          "shasum": "915c7257125df836819f8535dd093f21244dd36e3782605c9cbc4b131266627e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-gcore_0.3.88_linux_arm64.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_linux_arm64.zip",
+          "shasum": "62f8d9748e0edd3f14999f83dfbeb2caf02f07b5fccf7a4d6e0d8c7032f3d31f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-gcore_0.3.88_windows_386.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_windows_386.zip",
+          "shasum": "4e256d0f654434a4e82226b5ec7ba8ae97688d6e12df35036f276e817f365b8d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-gcore_0.3.88_windows_amd64.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_windows_amd64.zip",
+          "shasum": "bc007ae8726983b6872d9545fabf37d65bfcb1dcbf9e100fd728ab44df13db18"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-gcore_0.3.88_windows_arm.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_windows_arm.zip",
+          "shasum": "89755476c06c2470989f4f9061a882ddbf97f8aa999f888666280c9b53c990fb"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-gcore_0.3.88_windows_arm64.zip",
+          "download_url": "https://github.com/G-Core/terraform-provider-gcore/releases/download/v0.3.88/terraform-provider-gcore_0.3.88_windows_arm64.zip",
+          "shasum": "68b3c0ffd9295633e4f5649c4ea14bdc62c647bc86c41de399566302419a9e2d"
+        }
+      ]
+    },
+    {
       "version": "0.3.87",
       "protocols": [
         "5.0"

--- a/providers/h/hashicorp/arukas.json
+++ b/providers/h/hashicorp/arukas.json
@@ -1,0 +1,139 @@
+{
+  "versions": [
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_darwin_amd64.zip",
+          "shasum": "1bcab1ffceec7c3d92a92faeaae063bb643e15388c72a9318f2ff06acd6ddfbe"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-arukas_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_linux_386.zip",
+          "shasum": "32edb5652b0687b1cee93d8370fdbe801df6ac7f4b1c5edb88abb9eb58af9aea"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_linux_amd64.zip",
+          "shasum": "7cfa4e88dfda659612822247a295df565336c68b88776c0af7bb6435a24b17a9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-arukas_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_windows_386.zip",
+          "shasum": "f8d633fadb46de571ea8505d6ea8ad7cfdef958ca0d9d66eb57fa061893809ae"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.1.0/terraform-provider-arukas_1.1.0_windows_amd64.zip",
+          "shasum": "ce6123e0723e09317d40b4690e5290bea99aff6fbfd360662da7ee1eba6af180"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_darwin_amd64.zip",
+          "shasum": "9b7e2bc17621e6becaf6131ce88a750f99f35f07a7865dd88cdd9d28d94070d9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-arukas_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_linux_386.zip",
+          "shasum": "68a93b65c1d47226769644c88db22ff77e52cd84f2a59000eaf247fe3bed79d6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_linux_amd64.zip",
+          "shasum": "e1c44042be58327762fb470b96b3331d59c2f45f6c6c136b498f7076575e52c4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-arukas_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_windows_386.zip",
+          "shasum": "10cf0a54237936c85f425a42fb94045fe4fdbac36d9bb74d4ca3e6cc583efc7a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v1.0.0/terraform-provider-arukas_1.0.0_windows_amd64.zip",
+          "shasum": "044c5ccd2566ca46cdfa7a43112fadabc4c6f237bbec479eddc9bf5a1f134070"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_darwin_amd64.zip",
+          "shasum": "e2b71e35a7f1c7045cc860cd19f5f618c679254a6c4cf61e1c69f08c8237a152"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-arukas_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_linux_386.zip",
+          "shasum": "23f0926b47a24791087c38ed16c9e202a98e65bf2113f955aaf028fd54796092"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_linux_amd64.zip",
+          "shasum": "594ddeba4e949e247bd12bb81d9af0ff81cd37a375608c32403c01dc6fcf01e4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-arukas_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_windows_386.zip",
+          "shasum": "d91b8d193efb58ad3b46ac9c2cf48b037a64a4f2f28f4a61c1e709d030796280"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-arukas_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-arukas/releases/download/v0.1.0/terraform-provider-arukas_0.1.0_windows_amd64.zip",
+          "shasum": "822eba051f999870f636df582bb4cf2ea66bb6d53986540293520675a2240069"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/azure-classic.json
+++ b/providers/h/hashicorp/azure-classic.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azure-classic_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_darwin_amd64.zip",
+          "shasum": "175e21399aad6896062f5925db1c7cb234262d86db4d3e1d978440d83aeb5ae1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azure-classic_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_linux_386.zip",
+          "shasum": "e031bbf7711b994e5dc0abb14637b2a0ed413e6da79f4eb2f52a4865e225850d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azure-classic_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_linux_amd64.zip",
+          "shasum": "def1a6c90979e90e221c77a4c61ae7d604c5b9f3fc33d17db61509da2cedb3e4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azure-classic_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_windows_386.zip",
+          "shasum": "f99e570fb660d6372f46eece29d23f686e6cfde9be9a22d358baba6cfa8abbd4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azure-classic_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.1/terraform-provider-azure-classic_0.1.1_windows_amd64.zip",
+          "shasum": "b1b8b477fccd2715e720418f837af8d642a0f1abdb957e1d38c89abe70b11369"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azure-classic_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_darwin_amd64.zip",
+          "shasum": "11b74b26ada7c6b33d3b75a75ab9b99dc12dff6e813fa82902f9e3d7844c564e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azure-classic_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_linux_386.zip",
+          "shasum": "67e4725775babfd2f85a2c83ec592400eb2b5ca8aabca27ee15c5ad323635538"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azure-classic_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_linux_amd64.zip",
+          "shasum": "60afb87f8bf68c40a54534c3faf48f93e4894746da80b009b12a22655b369f6a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azure-classic_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_windows_386.zip",
+          "shasum": "b3c796b25ce088f16bf8d69eba41c6e7e83f5a832b1f97876afbcf03e59fa88e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azure-classic_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-azure-classic/releases/download/v0.1.0/terraform-provider-azure-classic_0.1.0_windows_amd64.zip",
+          "shasum": "a0f172491ceeac016152e49a7994cf7f446e578eff3b4f824c0d9f04a9c065f0"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/bitbucket.json
+++ b/providers/h/hashicorp/bitbucket.json
@@ -1,0 +1,184 @@
+{
+  "versions": [
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_darwin_amd64.zip",
+          "shasum": "265dbbe5453dbc86629fdfababf3a2798f8e11eb6b76f25db05c3bd4f6a5a7b3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_linux_386.zip",
+          "shasum": "7f3e9d021a3ec9fe8e7222f8adb989ba03943b08e0896b24dd7edc4a4b8c43bb"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_linux_amd64.zip",
+          "shasum": "927305d083f3fe049194a4791513cd6cdde8f812bc46cba0c9b4bf2f6ea8259f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_windows_386.zip",
+          "shasum": "ea57e13c20ea3466f3f97cbbd0b4443af770fe91d66b4e62ed3e662aaa201744"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.2.0/terraform-provider-bitbucket_1.2.0_windows_amd64.zip",
+          "shasum": "eb656c27e5a69192f6b690a5985eba6211e6567914d2430f678b7575c68a5a6c"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_darwin_amd64.zip",
+          "shasum": "e3100e482224d2c0734fba23cede203ae08ff336758e5f882d417f32c2575f9c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_linux_386.zip",
+          "shasum": "73e688cff851450f753ecf26d747cf46c1f7de5e6a687e9c7af3ccaf20a6b223"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_linux_amd64.zip",
+          "shasum": "1c8f94b4eef51a2d1e4c811cbe576fae95d908e4576cab206d77c337947755fe"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_windows_386.zip",
+          "shasum": "c4fcc7b5e9f3050abd39100f0eba5ebf52757d62f15653187b353892e461370d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.1.0/terraform-provider-bitbucket_1.1.0_windows_amd64.zip",
+          "shasum": "d2f34348b3cf7db217fe1bf9077d0b2c9e548d5f6a293279c37e08b6ba4bfc8e"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_darwin_amd64.zip",
+          "shasum": "d825798148f9a6a6c3fd55f4b9343f1e7415b5b1b553f28cc4af53db1a4934d5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_linux_386.zip",
+          "shasum": "95b8b5b6e2eddf63b939a86e46c61810ec51a3337034b1348a44f65f116cab77"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_linux_amd64.zip",
+          "shasum": "698ddb9871c1d0017d77492b8600444bd4eceae87baa0c0e6f2a56ad4c069f56"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_windows_386.zip",
+          "shasum": "5c8eca423f92317496de5feadfb22e905aaf634248f1036a5ddb836ff76373d4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v1.0.0/terraform-provider-bitbucket_1.0.0_windows_amd64.zip",
+          "shasum": "43a6eb0e9f9557311bdd05f9506d68df6d745c68bd8687c7859148036789cd69"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_darwin_amd64.zip",
+          "shasum": "12771ea09ad01730248a4c2ab918e92a87af684183c30a0ca51826075a28c20d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_linux_386.zip",
+          "shasum": "7f2f8521cd866ecff2ef406ae139b6880f8e19f39cf2f1c1a192879abeb0c2af"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_linux_amd64.zip",
+          "shasum": "864bf29c98e5adbcaa87aa06881857a856b9e5b78c0ff352961d3d0c02c3e9d3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-bitbucket_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_windows_386.zip",
+          "shasum": "c8f607d365a6c48f4265e9bfabd326b889163379106e8c4ec263c2c08a8ab7b4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-bitbucket_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-bitbucket/releases/download/v0.1.0/terraform-provider-bitbucket_0.1.0_windows_amd64.zip",
+          "shasum": "3a1f930bc7c771c425c0855e068ddd781ebad2b7f60d9d015294a74ad6071f5d"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/chef.json
+++ b/providers/h/hashicorp/chef.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-chef_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_darwin_amd64.zip",
+          "shasum": "075a5665f6a9e4b2e6f0c6861a557ff08a85edc72cb9556f7f60c5d13c5dbbc7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-chef_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_linux_386.zip",
+          "shasum": "6ffb4f185eebd2824957fd1569d9c60d2ca9aa4fac370fc690c1522d59a3eb63"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-chef_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_linux_amd64.zip",
+          "shasum": "c33d1caf3e784e84dc441e0c889f40b4cfd300ca7094a3b0526cab0875900bbe"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-chef_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_windows_386.zip",
+          "shasum": "2551dfad61b3bacd60b684d94068a0d7ce1cdfee6307b303a62167eb473e1af1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-chef_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.2.0/terraform-provider-chef_0.2.0_windows_amd64.zip",
+          "shasum": "3fd6bacaebaa81bfec94e0b4a385c99bddb0ce6ecf041ffc5c607aec35206bf7"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-chef_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_darwin_amd64.zip",
+          "shasum": "e57387e912bb532033eadbe3590f9c5a2f91109861ee338145020287404c1171"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-chef_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_linux_386.zip",
+          "shasum": "4a182cdf5cdbf87b2fb4c4a3e277e953ad81c8761f8f912b552e0d88de3dff8c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-chef_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_linux_amd64.zip",
+          "shasum": "3d4b58cf9665802fa344877ac6730cecc900be6958ad0b8f181d97972f0eb620"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-chef_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_windows_386.zip",
+          "shasum": "acc6b0a4bbe61cb4f077b880c5332e14c78574fa6465bdd21432caf020b098f2"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-chef_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-chef/releases/download/v0.1.0/terraform-provider-chef_0.1.0_windows_amd64.zip",
+          "shasum": "88094ab1974be50119ae238c244efe13bf0c305d9e527872cab7c0a382786bc8"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/clc.json
+++ b/providers/h/hashicorp/clc.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-clc_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_darwin_amd64.zip",
+          "shasum": "1f826d5459799d1b56a16c0452e49b79d344238bf9bb7f43d6a9f979a60fa7e3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-clc_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_linux_386.zip",
+          "shasum": "dfc456558b742ae6efd733438466262b22b1e77ce20e0c35985e0706bcad75d7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-clc_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_linux_amd64.zip",
+          "shasum": "ad8b4b0e5e21cff529bd66d927add30791b562f0588db05ce7e5bf1e73b36a2e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-clc_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_windows_386.zip",
+          "shasum": "480678d0a03176618a2e127c5855487d5d8f7b4165bc04a10b4fce8efd13cb22"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-clc_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-clc/releases/download/v0.1.0/terraform-provider-clc_0.1.0_windows_amd64.zip",
+          "shasum": "83cc215f85a3c32483628c030b0bf26e85ec76ea59b5f39dfdb6bd972dfca448"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/cloudamqp.json
+++ b/providers/h/hashicorp/cloudamqp.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "1.8.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudamqp_1.8.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_darwin_amd64.zip",
+          "shasum": "1ed786a5cf79383ab457f6e20767cce175c61767f511d79a74b888629bcccfae"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cloudamqp_1.8.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_linux_386.zip",
+          "shasum": "1fdfbd12070259016d5f863430a3de66d50eef27dadb81b8e2d41827a1c2bf51"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudamqp_1.8.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_linux_amd64.zip",
+          "shasum": "6090ab0bcf5e056810f5da87e002433a8efa2af537ed6fff0e32f128db0aaecc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cloudamqp_1.8.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_windows_386.zip",
+          "shasum": "4fd2e93bd9bdda52cf8254648fbab8551357290ef12ace5fda88aced7e6267e1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudamqp_1.8.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudamqp/releases/download/v1.8.0/terraform-provider-cloudamqp_1.8.0_windows_amd64.zip",
+          "shasum": "ec3c016e8f1f30d71b1f0d7bfab815c6fd89ca8ec54dd8793f938323d12bf30d"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/cloudinit.json
+++ b/providers/h/hashicorp/cloudinit.json
@@ -1,6 +1,86 @@
 {
   "versions": [
     {
+      "version": "2.3.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudinit_2.3.3_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_darwin_amd64.zip",
+          "shasum": "21e7ab6820990f314de03be87af71cb4bae2409fa18007d11cfa60066a7f924c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-cloudinit_2.3.3_darwin_arm64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_darwin_arm64.zip",
+          "shasum": "af20410183201bbbe4e13f7fa69f0a57eea5b925e3092036f1aaa2767f1a7516"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_386.zip",
+          "shasum": "bbb60400a2c17aa31728b348d4f7ba2de8a20b014b0c0658c7ff1f54a4e1f776"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_amd64.zip",
+          "shasum": "5ab08771183c7dd6070ae95be84154540f15c41b34606e55fe87639e0bfddc0c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_arm.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_arm.zip",
+          "shasum": "132f1782bb198a635892ea4b116fd69ffabcf4b6b11f86c57faf53b19575c23d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_arm64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_arm64.zip",
+          "shasum": "e8cd5c617707b5e5f78a2dba45e864b7690930f39aa6c84e9455e9f3943cb83c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_386.zip",
+          "shasum": "2cf69cac676eb20e5f82b1dbb739c30b963fd6010e430e1b0bf3dfedc6554000"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_amd64.zip",
+          "shasum": "f43b99f6b6d581d2745e4f0cfdeb0425f381c113bebf2cc95c08c8f8c2d6506b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_arm.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_arm.zip",
+          "shasum": "3c508f6ef48fc8073d2e4ebd1ea1532b52e4d7ac679908d73891e8f4b451a71d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_arm64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_arm64.zip",
+          "shasum": "2a6a71194f3923ba6136c8a17765f505fa3e20624f4cd1078f36bdb92cafbe00"
+        }
+      ]
+    },
+    {
       "version": "2.3.2",
       "protocols": [
         "5.0"

--- a/providers/h/hashicorp/cobbler.json
+++ b/providers/h/hashicorp/cobbler.json
@@ -1,0 +1,184 @@
+{
+  "versions": [
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_darwin_amd64.zip",
+          "shasum": "f8f13e051c556f0f8eff8de1d1f6d6ec5b6d5535127c029594904253184db53e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_linux_386.zip",
+          "shasum": "7b2b0a1f856f898c84342bc666acb9feb39e65a13ae92a54124231abd1e35546"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_linux_amd64.zip",
+          "shasum": "762ba66dd2b40242a7031d09cb56e112998583152890205582b92f000325c55f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_windows_386.zip",
+          "shasum": "0d8683bdef8ec08b351ef45fadb76337670d4083a1da9d80c3aa337e8da7f561"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.1.0/terraform-provider-cobbler_1.1.0_windows_amd64.zip",
+          "shasum": "e956eb936280615fd95f5034834abd9e2ab667baedfc8919ad580355590185b2"
+        }
+      ]
+    },
+    {
+      "version": "1.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_darwin_amd64.zip",
+          "shasum": "4faaf6cc5283a3579174e99e08c1bf6400838689f52bf42cf2adcceafa8fc157"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_1.0.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_linux_386.zip",
+          "shasum": "8ac0d50fcdd97d689427931398822cb111ffb8f9993c00cd0b879303f8899002"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_linux_amd64.zip",
+          "shasum": "72d55a97f82b8ee397c3a45a72d006aa6c70137b6a86c9650771c852f4bcad60"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_1.0.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_windows_386.zip",
+          "shasum": "f87038f4064877bb9fcca392ac620a891eb61bf27bb1dd7e101b7f0acdddaa0e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.1/terraform-provider-cobbler_1.0.1_windows_amd64.zip",
+          "shasum": "0f73af76a602aeb3236e5a5ca97fdbad09563e2655a3e109cbb5a1b63eb99711"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_darwin_amd64.zip",
+          "shasum": "8ef7329c557d7ea26d6647498803c89abf489da912cad1317afd648396c15a15"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_linux_386.zip",
+          "shasum": "e76a11dcc3a12e033e4114b0a06c5c18aac19dffc0a6d1c48e6aa2b2b0312859"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_linux_amd64.zip",
+          "shasum": "7c8703c8c9f2061e195b8fe509500d55921c62eff7edb0ff30e2a103da6baa2a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_windows_386.zip",
+          "shasum": "6a0bf5519d9350af21b036256c82b048e944c16bdc62fe44ab88ff99e7cc015d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v1.0.0/terraform-provider-cobbler_1.0.0_windows_amd64.zip",
+          "shasum": "8d2cb056ae37348a1472fb9b044a652a951995ecaa99652391bf8c917b2e596e"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_darwin_amd64.zip",
+          "shasum": "2138a0742b007429812787d08a12723d8038f85ec0819af8696734327e3a77ee"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_linux_386.zip",
+          "shasum": "6957c3926ac77e88a17399f46c274287be3d3623f8a40abf8a627690d6edeccc"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_linux_amd64.zip",
+          "shasum": "58f2394846679f20490486208ce5ce4d8e41680451a873b66a086f9cd085eed1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cobbler_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_windows_386.zip",
+          "shasum": "c4c506c1f844bb4b7e11c93175411358b815fe1869ef48454eca2ae3041f6931"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cobbler_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cobbler/releases/download/v0.1.0/terraform-provider-cobbler_0.1.0_windows_amd64.zip",
+          "shasum": "4ba381cd715e03aaf64318bbe5691860f3d5ed58abcb4a90b1d3c4d392d782b5"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/cohesity.json
+++ b/providers/h/hashicorp/cohesity.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cohesity_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_darwin_amd64.zip",
+          "shasum": "f6fa7f376dee531fbb99d2b71dc675e83521d16b59774fd6fd5f684f3e7b6a1b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cohesity_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_linux_386.zip",
+          "shasum": "3fa409a330fd738a6d22573bd11022d5fbfffdde1692743014e869d558ab5e8a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cohesity_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_linux_amd64.zip",
+          "shasum": "c5d6b90e0add9eccf2ce64a19b1265e6b4ecb934d77536c544c7a0717297172c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cohesity_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_windows_386.zip",
+          "shasum": "9a99139775ff73a0660a941b7070cba8108b97c70382b262a9c9e57d808e13b3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cohesity_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v1.0.0/terraform-provider-cohesity_1.0.0_windows_amd64.zip",
+          "shasum": "99b5c848a17cf33427fe69f01008ab2f2a165f1cdbfd2a53f32635772c066360"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cohesity_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_darwin_amd64.zip",
+          "shasum": "3f4afa7918ececbcf1c3111cf8e511b3cc6a19e6e01b17cf9c8786f0112c0ae3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cohesity_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_linux_386.zip",
+          "shasum": "8b0983c8b661d8df61c2e5ce3ffa87c9a5c2b1924765a0203f34265f3a09e465"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cohesity_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_linux_amd64.zip",
+          "shasum": "dca3577a5c1b82bc5adccc99048154dc0630e48aa2ded443875d2127cc06d298"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cohesity_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_windows_386.zip",
+          "shasum": "90f4c28afbd080bb0918cc09d02ebbecf7701e016437672c1d8c5b3864fa5c34"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cohesity_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cohesity/releases/download/v0.1.0/terraform-provider-cohesity_0.1.0_windows_amd64.zip",
+          "shasum": "09acd7cd43739217a07fdb4b13edd1837b90f0ea08de8901e8c53ac579709d45"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/dyn.json
+++ b/providers/h/hashicorp/dyn.json
@@ -1,0 +1,184 @@
+{
+  "versions": [
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_darwin_amd64.zip",
+          "shasum": "21441207d68f205bd853dd92bf95394fbf1c8a4e66f5c9b5530bf4b3a1ff6a32"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_linux_386.zip",
+          "shasum": "02bca86b4c5c2fa3b454358a2b0d81df8ef2facfb909c11d11772b5d8b72e7b1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_linux_amd64.zip",
+          "shasum": "1bc2373efc97df37d1a32caf5b1314ad13f380c95ab64a1b4bf0025f7739930d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_windows_386.zip",
+          "shasum": "f9c34339c10050f5bbf30cf5193a269785083efea2f4b242b331c6e9bd901513"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.2.0/terraform-provider-dyn_1.2.0_windows_amd64.zip",
+          "shasum": "0703d2e594bb8c22aecd2155d67efd290a6c0149704716cdbf1bd993d190cacd"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_darwin_amd64.zip",
+          "shasum": "597aa16ef018f8e029fd57ae698753b780b7288b9427df8830adc170dc2f8c55"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_linux_386.zip",
+          "shasum": "61139520da33c0b7f5522ea09f1cb7f9ef853a215c755161450e6ae67a96f019"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_linux_amd64.zip",
+          "shasum": "7ea9aa7577dc61f532cd054251230343d4abd39790960d0eb1ad463ec24c0bb2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_windows_386.zip",
+          "shasum": "535f33c67096797898171efc48d1c370aae13d252b99ace5565429467f7de8f4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.1.0/terraform-provider-dyn_1.1.0_windows_amd64.zip",
+          "shasum": "7370b68355e8289f9c336eb989be61aa9260db9f8d5fae07c8d2731e16169204"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_darwin_amd64.zip",
+          "shasum": "12bfc9b4bc7db2d55bcebe7c5a18104e6edb505984ad971d25c564e7edce6464"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_linux_386.zip",
+          "shasum": "37796745db4102a0a45df87cd41736fb47ce82f5733ab33348e079c6937b2f2c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_linux_amd64.zip",
+          "shasum": "b4adb4e5125cb63ccb2f288581e27439174a3cb678e8f53b4ba26c861afc52b9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_windows_386.zip",
+          "shasum": "a91d932605bcce8227bc105fa66f9771bdf3c9ef583db63cfd407408d1d0675a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v1.0.0/terraform-provider-dyn_1.0.0_windows_amd64.zip",
+          "shasum": "e1dc0b2f64ee82700e6cc09294d70cf9c7aabe69ff8cd9dc42b9c88d1f10a52f"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_darwin_amd64.zip",
+          "shasum": "4641d84b7f50a090e67673d3b84a78a557d31e12f3b6fd948c48a1e7538c0039"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_linux_386.zip",
+          "shasum": "dc7fe3b046294f73c25304a8eda4557838f9c0a649715e45776ad25c39bf7119"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_linux_amd64.zip",
+          "shasum": "9efd797a6b3010b5bdc0cc53ada0d346c0ce73202c4dc1b7abc6114c4aa35f52"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-dyn_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_windows_386.zip",
+          "shasum": "89527b4b96dab486f7e0eb00b9b08585cc9b42f98646804eaea8c1601643aad3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-dyn_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-dyn/releases/download/v0.1.0/terraform-provider-dyn_0.1.0_windows_amd64.zip",
+          "shasum": "6f509b3f876cf4d01abcd59f655f534833df0847f35639ad15bc531528ffea27"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/hedvig.json
+++ b/providers/h/hashicorp/hedvig.json
@@ -1,0 +1,364 @@
+{
+  "versions": [
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_darwin_amd64.zip",
+          "shasum": "9adc96cb81e182cc0bd4c047eba60500b62df0e39463d72ea474f9f75657f8c5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_linux_386.zip",
+          "shasum": "cdce68f2cbd6e6f4d9dbc7ffa98cd828fca9442ce441772e69f28945218095bd"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_linux_amd64.zip",
+          "shasum": "c9d7fa24ca71f2b3ff48a6e178a3873d21af293cefe4986c880275393b9e4ed9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_windows_386.zip",
+          "shasum": "2449114c20f59015a3b32c6f74e7129540134d9178217743686d1bf6fbd4cb4c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.2.0/terraform-provider-hedvig_1.2.0_windows_amd64.zip",
+          "shasum": "4e829dfbae01a7039b8418c34b727c90b93b8b4d336a05044a47487ccb26ce83"
+        }
+      ]
+    },
+    {
+      "version": "1.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_darwin_amd64.zip",
+          "shasum": "5311faf5d655cb6409b3ad0861d441180fc455eed842c61e84a29d10b0ade656"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.1.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_linux_386.zip",
+          "shasum": "9d5edbe2f20315e3f8fb3dccc4f3472f9bdda82ce1414ca5d08365d64d644b96"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_linux_amd64.zip",
+          "shasum": "78fadac1dde0e691b1c3ff87b2adb35cfa384049e45d74b135ef5f7ce75eb0e6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.1.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_windows_386.zip",
+          "shasum": "162c5cfa8631c2fe8d1b3d33209e94f52aaf6a3107ffd09ddaa3d560268c2f7c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.1/terraform-provider-hedvig_1.1.1_windows_amd64.zip",
+          "shasum": "4b9583209dab8bd69ab86a756d9a6e453ddf7b90c6dd5d07cb83d39570cfce3f"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_darwin_amd64.zip",
+          "shasum": "33925b9ac9f5ea8fb77c9a022b6e3bc52ebe1061b92a234411f6e469ca7ddfd8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_linux_386.zip",
+          "shasum": "3517c00bb35586ff3445146dba9bd99f7907fd6f061c71a82038d599af63ba9b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_linux_amd64.zip",
+          "shasum": "040c96f7c0be2c203a454dd640d630a8ff20772f1800afddccca53d1773a9bf4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_windows_386.zip",
+          "shasum": "29fcfadb8f68a93598ceb1a707402c5e94447fc8d116c56b2f363df877a15fb9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.1.0/terraform-provider-hedvig_1.1.0_windows_amd64.zip",
+          "shasum": "13ea8e88c3bb341de957b10244028c28e6808a56e1e896593acc718752b5cd4f"
+        }
+      ]
+    },
+    {
+      "version": "1.0.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.5_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_darwin_amd64.zip",
+          "shasum": "c741bc403886dc971febb0188112fa3d7ce5286ee305d47184c6b3be52fd3258"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.5_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_linux_386.zip",
+          "shasum": "de4b566195712649ed6499691c06a996870c7ba7e9651dfc8311d99556bfa972"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.5_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_linux_amd64.zip",
+          "shasum": "1e79d914a7e5132fddcd44c497ae6556d3a5ad9b025fa9e060bba3b484bce164"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.5_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_windows_386.zip",
+          "shasum": "7f28c7495686f01fbbe81b99f5636831d2809624a30f9334527cf66ccd602f78"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.5_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.5/terraform-provider-hedvig_1.0.5_windows_amd64.zip",
+          "shasum": "316825c6257b84f4a579e49479e4482f665d453a477691aa67573f5b6d122f06"
+        }
+      ]
+    },
+    {
+      "version": "1.0.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_darwin_amd64.zip",
+          "shasum": "cb13268b0996ab8a275a5bda2993d6700b3a22656b16ddf816dd5984465117e9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.4_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_linux_386.zip",
+          "shasum": "2c7cb9df7847031af657ab19037f40ae1af7270fe1edf4dd7b271dda872b2a9b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_linux_amd64.zip",
+          "shasum": "ca096307f322ef343bb1f27ea3c7c66d6e1906f77b154fefd8b4522cc38862ba"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.4_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_windows_386.zip",
+          "shasum": "2d623220077e17aa4ee9b83437ff11f57135d6aa0fbc4c4bedfef3b84a8001a8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.4/terraform-provider-hedvig_1.0.4_windows_amd64.zip",
+          "shasum": "3810e2a3e69268cbf38248e4fb58e912a793f964761e9ecb3248d82b52c8f648"
+        }
+      ]
+    },
+    {
+      "version": "1.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_darwin_amd64.zip",
+          "shasum": "6148d4c975ec57fc5fbca4739ce502ed7ab34ce55a9f80548a344fa0f4aef147"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.3_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_linux_386.zip",
+          "shasum": "2bbb5ec54e56b1ab81848bfc353161f16abe7f76dbd8a4a953167d51c563ec83"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_linux_amd64.zip",
+          "shasum": "f4ca91ad44df284897544f27ccd292b0c27724ba6dbfb96615da5705d3eb4d36"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.3_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_windows_386.zip",
+          "shasum": "ec9f430a724eeb8a0ef5bcefbbb5ff90716d35c558c476134b86d668e3105951"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.3/terraform-provider-hedvig_1.0.3_windows_amd64.zip",
+          "shasum": "aa4bb236b8ef539e873962167d0d1a5ebc1fe910f5923bc769d4fc7b1fe043c3"
+        }
+      ]
+    },
+    {
+      "version": "1.0.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.2_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_darwin_amd64.zip",
+          "shasum": "b4c0386509fb3f372ea3dbc0e1fd514b1c4cd1ca3bfd0e61bc4d9c6e65f0d1e0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.2_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_linux_386.zip",
+          "shasum": "b7fe1aee3a547ddf49e7e967db228d133fc6487bbae699a7abe721827c562213"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.2_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_linux_amd64.zip",
+          "shasum": "bce4685f1bdc6354c28d54d5096a07186c2ff8e7710b5ebceab98e2cb0db1421"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.2_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_windows_386.zip",
+          "shasum": "d7b976815b2e3f46c725ae82860e716e2ebe56e6c6728be922fa389d79fc514f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.2_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.2/terraform-provider-hedvig_1.0.2_windows_amd64.zip",
+          "shasum": "c485aa6e725cc0ff624d9aac037e993fb86c68e2e5328c4fab65ad78306c3462"
+        }
+      ]
+    },
+    {
+      "version": "1.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_darwin_amd64.zip",
+          "shasum": "36c0f4faf0fe4bb6dc569b0fa6e1c4623fce4e5d5516778086bb0a016457e649"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_linux_386.zip",
+          "shasum": "2b356ce3b7b61750a2a7b92d35b6e67efd253c47404f3705a94714d7e7cf4438"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_linux_amd64.zip",
+          "shasum": "986e9fd94209e1450de65de211b6d317c2c536ce173c6609dce2714c43d7ddf7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hedvig_1.0.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_windows_386.zip",
+          "shasum": "f9b5696c976a6dc5bdf3da8ba2531f6b8555026b091b26f59279435e83114095"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hedvig_1.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-hedvig/releases/download/v1.0.1/terraform-provider-hedvig_1.0.1_windows_amd64.zip",
+          "shasum": "7d1e06ec50d91eb98ef08c1bda626f64e519505b6f61838604ea58e3eec3c85a"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/incapsula.json
+++ b/providers/h/hashicorp/incapsula.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "2.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-incapsula_2.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_darwin_amd64.zip",
+          "shasum": "cd558ae6a1a654c293644452d5728e97a1fecb322603c13d495d9b5ae9acaebe"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-incapsula_2.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_linux_386.zip",
+          "shasum": "c6115ba52b0df912f6be62c82e21428123ba94009156c4bd38f54d20b35fe682"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-incapsula_2.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_linux_amd64.zip",
+          "shasum": "b3ee3970f575eeadf636b9a544374008949ecf815dc66e3e11f4c4be1ae69102"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-incapsula_2.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_windows_386.zip",
+          "shasum": "5c9eda1a07e56385186ec8c6350cb3c318c7c52f94708264c827ca392c62ad05"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-incapsula_2.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-incapsula/releases/download/v2.1.0/terraform-provider-incapsula_2.1.0_windows_amd64.zip",
+          "shasum": "65e6824d493671b41a6065ee6147780ba9378399213439257dd56d95d66f1bb2"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/influxdb.json
+++ b/providers/h/hashicorp/influxdb.json
@@ -1,0 +1,409 @@
+{
+  "versions": [
+    {
+      "version": "1.3.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.3.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_darwin_amd64.zip",
+          "shasum": "84e1739593d9bf8e094777a92dea248eb08919701f51e26fc2793ee936aa416f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.3.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_linux_386.zip",
+          "shasum": "15982c16fe900a3d3285cdb2087f52612406085145236399d9e5ef1c891c11f0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.3.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_linux_amd64.zip",
+          "shasum": "574c4ec8c698233e1c9700420755fd19f75d0321d645f241595cb2eedf57c709"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.3.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_windows_386.zip",
+          "shasum": "be6d476ab2271de7d278f696ccded2b17f5e845f02e93c8be6f7fc5e95ed8bdc"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.3.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.1/terraform-provider-influxdb_1.3.1_windows_amd64.zip",
+          "shasum": "3f037830f18f7afa481c08430c0861b87bbed65a0abbbaf526238093e87ed9d8"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_darwin_amd64.zip",
+          "shasum": "f956687ff11a67f574425ae159263da7dda9b1c6c0da4134dae17982f174c7a6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_linux_386.zip",
+          "shasum": "cda884a69f0afb2765d574cdbcf0d130170319de476d4096d6baf01a5279856f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_linux_amd64.zip",
+          "shasum": "31d3283e8f9e2d01229603f5c33c933cd7d0355eaf10f0c7db998ab214cc0666"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_windows_386.zip",
+          "shasum": "1871aacab879281a00cdea6c3f9e25c46db9b6101f5cdb316d17a3ce680bd0df"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.3.0/terraform-provider-influxdb_1.3.0_windows_amd64.zip",
+          "shasum": "0237d245a09415944441ffbf5163fac3f8e71849ffba05ebd01f352fc111aceb"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_darwin_amd64.zip",
+          "shasum": "59fa6f40486b51d7f9d5dd03de68f87a7d68ecdbc0d30494537b5055c00ea993"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_linux_386.zip",
+          "shasum": "8ce78227fac40a2966f7e8e51e04d243e54300f4acd599c6ae17ceb2716b16a3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_linux_amd64.zip",
+          "shasum": "f5ab68eed26edb97e8bb4daaa7e2d434abcec26732ed2d4a02c29eeba88b9ab4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_windows_386.zip",
+          "shasum": "8941e8342507fe98a4f51b35f12e5e56e60cf5e18832db437fe9d3911f4d6a83"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.2.0/terraform-provider-influxdb_1.2.0_windows_amd64.zip",
+          "shasum": "72de8cfe491f4bd21899d97207e16ec6bcc22a140105f77d88dd8d716be12dbf"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_darwin_amd64.zip",
+          "shasum": "015450aa7409b83e34778b8fe4646e8f82d06b966182c04ed9c3f7b0fa8cdbf8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_linux_386.zip",
+          "shasum": "5ace56ed85e0a3335e232bfd1309be2456027e223884dda129d8d402cc4b0748"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_linux_amd64.zip",
+          "shasum": "5e36866d1dddad6c8759714add135335eadb4e9f971ad2086576115755abe4de"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_windows_386.zip",
+          "shasum": "9bd99519cc9ab99af2079df63e70b0b71a5e912ed6b1a5307862ef5af6b98f07"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.1.0/terraform-provider-influxdb_1.1.0_windows_amd64.zip",
+          "shasum": "ff686fdae59fa75a24573be97f5449270e50544f74600885a190a637661d0ab6"
+        }
+      ]
+    },
+    {
+      "version": "1.0.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_darwin_amd64.zip",
+          "shasum": "fb887806ccfdb380d567f607d2d34fe9df5db0cee034fa2432fd5d1a88a7973a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.3_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_linux_386.zip",
+          "shasum": "453f48d23dce673ab10d1d071665dfe0f8d28a41725783517c57ad6125e2b384"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_linux_amd64.zip",
+          "shasum": "3b28dd8aed08f697347929278f8de1719472826d0e1e65b3ee6b6a7c34dddd5e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.3_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_windows_386.zip",
+          "shasum": "65c0e0b995e48ff01961b7d3326d940bccb19ed905b38005a60b1acdc73e6711"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.3/terraform-provider-influxdb_1.0.3_windows_amd64.zip",
+          "shasum": "93387cc53e80ff8181ba1135e15da6420cc41ed3ae7f87d0c0edcd7b4d1a0e65"
+        }
+      ]
+    },
+    {
+      "version": "1.0.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.2_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_darwin_amd64.zip",
+          "shasum": "3955cf8e6d73c9a2e4b6b42e0fa6239136a9bbbd326b9a6864c5a3eefe075fe6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.2_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_linux_386.zip",
+          "shasum": "892fdfbf468e6f49a84b7840e4dd2d278f8bc29c72640db9edbc5f60679903c2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.2_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_linux_amd64.zip",
+          "shasum": "f88bcffba0d4774c3ff2f9f6d9a83688de236a69301d6565174a96c1087ae2a0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.2_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_windows_386.zip",
+          "shasum": "4cd84fa3d808213ae4296ee25366582db5cb846ff55e2fe9cbb40a9f1329061d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.2_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.2/terraform-provider-influxdb_1.0.2_windows_amd64.zip",
+          "shasum": "99a7b5d5fc4ae9eb17bebe0207e9895993a2726087920404d7b8ef77d73e0026"
+        }
+      ]
+    },
+    {
+      "version": "1.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_darwin_amd64.zip",
+          "shasum": "afb2ad99764779955b2b10d2ab18ca7dc465eba4c1135efc7b39fd4a494c297b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_linux_386.zip",
+          "shasum": "ced949edaeee9e358d2de20595f56ee18e84fe7fe861fa2a68076e03b9e7848c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_linux_amd64.zip",
+          "shasum": "5bd44b4ba19786442d6e53983ceb22f096c7586b75bf477bb8e1984d146edc04"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_windows_386.zip",
+          "shasum": "89a64572fd70835607d8e4b64d67138133db1e5efdd9f0bb9b151c06a7fd2b63"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.1/terraform-provider-influxdb_1.0.1_windows_amd64.zip",
+          "shasum": "d7102857cf8ff98d59227284c11bec856c9e3d7ee17d572ad14c5ad8fa70532e"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_darwin_amd64.zip",
+          "shasum": "bc1b7fafc8bf3f8d06039863713dfc6f7ba581925a6088d91e0ee2ef33e4ad6f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_linux_386.zip",
+          "shasum": "94b9534edc45527195c05a11bd8a471fee4a2cf53962bde92560c5f85883395f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_linux_amd64.zip",
+          "shasum": "49563be0be781041d20abbdaeaf39ef294e9709b71630ffe167a576081fff7eb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_windows_386.zip",
+          "shasum": "4d714b861a06cfb63ec460014988415df6e9a3018cf01a67cbd7c032730ebdba"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v1.0.0/terraform-provider-influxdb_1.0.0_windows_amd64.zip",
+          "shasum": "e301f3aadf16d3795846774e4b5bb55a3b6fe5c749a349429ff4ca1e2269b63b"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_darwin_amd64.zip",
+          "shasum": "b3f27e6d942dc4bff31c15f3fb2fc811195901c0e934600e1c737f97d7d7b906"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_linux_386.zip",
+          "shasum": "57f74c5af154a39e28597738ad61d90dc9264cf24bd2603286e7490120409b3c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_linux_amd64.zip",
+          "shasum": "e272c44bc90fd920fa207360da0ac847bb188d1adbf3325ac92c6bf941cbc213"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-influxdb_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_windows_386.zip",
+          "shasum": "6412f36f3c4e0a11a33da19728fa0ab0792373b3ff7f9981864099055933193e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-influxdb_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-influxdb/releases/download/v0.1.0/terraform-provider-influxdb_0.1.0_windows_amd64.zip",
+          "shasum": "1b8e2ab90670d02d370b53c1c7e08dd168ca66878f236f0de5b583c89c42d2f8"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/infoblox.json
+++ b/providers/h/hashicorp/infoblox.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_darwin_amd64.zip",
+          "shasum": "3595944388eb05b8e18b73f6c415f058ba50915f49968f5c3750e84ada670c85"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_linux_386.zip",
+          "shasum": "d8cd51ae1f6318299076a08f4679f2fde0d0f575a705f74d5ea888131c2a07bb"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_linux_amd64.zip",
+          "shasum": "52e26ee32800f6c8501b81da61fd3ec0c6605358349c12d11da4df883f782632"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_windows_386.zip",
+          "shasum": "13a044b9793b0c3f2786450874ba2a524dca3c5b64e859c633fdeeb8a3485555"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.1.0/terraform-provider-infoblox_1.1.0_windows_amd64.zip",
+          "shasum": "be1b2534f20adfe29a75f8006d3089d0f172ba4ae2aa3e0f922d6b00ef66936c"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_darwin_amd64.zip",
+          "shasum": "2462078f89bd0ec5529fbdbc041fa4e21598149f7046d66edeec9bb4a917c73e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_linux_386.zip",
+          "shasum": "06e9d29981a3b7074376e48e3d2ff01751eca59a519a6deddffc4552a28f9edc"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_linux_amd64.zip",
+          "shasum": "7f9d37f3ebfc370a160165c42281dcde68dfb3dc7a46b0e0fe29463b61676cca"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-infoblox_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_windows_386.zip",
+          "shasum": "20b3d031821cec689504fd56230d6b41cae169ada84d5cbf96463aa7cb09451e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-infoblox_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-infoblox/releases/download/v1.0.0/terraform-provider-infoblox_1.0.0_windows_amd64.zip",
+          "shasum": "af77eb677baefe870ab12b8849e1a3a8fd51ca36bfd393d47c9e81359d9a951c"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/jdcloud.json
+++ b/providers/h/hashicorp/jdcloud.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-jdcloud_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_darwin_amd64.zip",
+          "shasum": "01aa9026ddee2cf0d736e0ab7a35cdc27fb2380d0ca7376cf4f06368a308435e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-jdcloud_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_linux_386.zip",
+          "shasum": "959d0fc8bdb72e6718627a6c06ecb2e075f45fbce2335997df1a72d692660f07"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-jdcloud_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_linux_amd64.zip",
+          "shasum": "5fe2a11591b08f8d8aad4cd9bcf4358ebc228174f35fcee50fa8b33f9bbf0f4f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-jdcloud_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_windows_386.zip",
+          "shasum": "cd0b8333b0e158d481adff0d6d7ce5ad2e7a29f4e59d5b8c72fd57dc68823ba6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-jdcloud_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v1.1.0/terraform-provider-jdcloud_1.1.0_windows_amd64.zip",
+          "shasum": "ef0cf3ea2913b51817ee83757b6e654844078ffee940cee9b71bf51c074e5340"
+        }
+      ]
+    },
+    {
+      "version": "0.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-jdcloud_0.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_darwin_amd64.zip",
+          "shasum": "1077d845d299e306c006ed2253777f14a23dc2b665e7fc6dce8fb6c22b9e2330"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-jdcloud_0.0.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_linux_386.zip",
+          "shasum": "91f4953ffbdc53d65111829c9c9a356200a051f7a044d74961896083735d489a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-jdcloud_0.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_linux_amd64.zip",
+          "shasum": "e02c67cb59bda8c4d36310bb9f442e66cd98416983f3e0a681cc44d55575cc58"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-jdcloud_0.0.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_windows_386.zip",
+          "shasum": "e43fd6e95c7e3f4e96879574fe68504f4d5e1596ac9f10f7e4d7acc4cfac915b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-jdcloud_0.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-jdcloud/releases/download/v0.0.1/terraform-provider-jdcloud_0.0.1_windows_amd64.zip",
+          "shasum": "ec30a1846055900c39e9e0f928016967e5800204fe1bc50e461c424421a35bd5"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/ksyun.json
+++ b/providers/h/hashicorp/ksyun.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "1.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ksyun_1.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_darwin_amd64.zip",
+          "shasum": "3acac857d21d0119c79b67b77b5b63c265654d920e9d3c853ad1c774a360c705"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ksyun_1.0.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_linux_386.zip",
+          "shasum": "89ce76f9e164a9daa318850ace70e2565d5ea6f5dba9e17e5654bc32871efad7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ksyun_1.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_linux_amd64.zip",
+          "shasum": "fbe611324b8bfa4ae5c44835d01f852d6445f4a83ab6e1066d5efde95518e3f5"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ksyun_1.0.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_windows_386.zip",
+          "shasum": "840e7a39dc538b72ae056fbcfbf3a9e1c50675119fc05ba37733525b1f878744"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ksyun_1.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.1/terraform-provider-ksyun_1.0.1_windows_amd64.zip",
+          "shasum": "08e973b544bdf3be617fd773f2a687f87f77d3bff2b9b622dc570b275c54c50f"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ksyun_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_darwin_amd64.zip",
+          "shasum": "ea351f1e8cc422c163f982f3ff130aa2d2b1e059ee9235bf11a96f76230eecc4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ksyun_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_linux_386.zip",
+          "shasum": "cfeb79460b48db78e4ccde51845020662c6950d16fb60550c99d656496db9f7d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ksyun_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_linux_amd64.zip",
+          "shasum": "ccf5d9c4159f7965fa621d01ceafa8678044936ddea5a36ef9667a62e2a1a2b5"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ksyun_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_windows_386.zip",
+          "shasum": "e4ec787e5244724c465b919ed1fa05e0ff322761028497c06b7bccba85852d09"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ksyun_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ksyun/releases/download/v1.0.0/terraform-provider-ksyun_1.0.0_windows_amd64.zip",
+          "shasum": "e94a0b488019c9f96deddf7da9249b90ff4c4e4652e110f381258641a0314f3e"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/lacework.json
+++ b/providers/h/hashicorp/lacework.json
@@ -1,0 +1,319 @@
+{
+  "versions": [
+    {
+      "version": "0.2.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.4_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_darwin_amd64.zip",
+          "shasum": "d897dfd6e0c2976e2f49d73a8954d4ce5f99dd4aa0fb58b71b7c839efd2d150d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.4_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_linux_386.zip",
+          "shasum": "a03eb0a83334c5f385391dd1cf5ef1d4bbaa6e0c3fac5c4f99d777a8fb46dc7f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.4_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_linux_amd64.zip",
+          "shasum": "18657a75bdc2edfed20571436a9857f44e9b89cf7697d5f5e628eeac9072c867"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.4_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_windows_386.zip",
+          "shasum": "686915c0cda4eca597abf8555f2ce23b7b026e98b9ccc8fa7c7ca2a343f427bd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.4_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.4/terraform-provider-lacework_0.2.4_windows_amd64.zip",
+          "shasum": "8ac5cfc006d35b42a05e95b69bb6484e74dfa60187cbbdd216fbe86ad069ec4f"
+        }
+      ]
+    },
+    {
+      "version": "0.2.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.3_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_darwin_amd64.zip",
+          "shasum": "969e6de611467327efc012fd2397c4c79b23c4c83d35560254105dc3fab79c98"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.3_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_linux_386.zip",
+          "shasum": "3653610e654b914144a1c45cf028db7d902e95e6a9458bf9a6a1a3e84e819cf1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.3_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_linux_amd64.zip",
+          "shasum": "9f58354b5796278b6c200e400b23af936477950e96cfa3507f3b57f3f5f396f3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.3_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_windows_386.zip",
+          "shasum": "10c1ea779dec34a92296994b38805343506986770bda43599db89c8bf6c8f22d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.3_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.3/terraform-provider-lacework_0.2.3_windows_amd64.zip",
+          "shasum": "627091ddce9382bbcc65dded1317f0c8a169fec1234b2b9cc49030f7ec374d8b"
+        }
+      ]
+    },
+    {
+      "version": "0.2.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.2_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_darwin_amd64.zip",
+          "shasum": "ba0cd68623e048acf83900014c31c93f1a6fad76a15595b05641dbd3b8ccf912"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.2_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_linux_386.zip",
+          "shasum": "c648ced9d725969839ebbdbe287b03ed63cf423f1c4ac0a204888c7f65e47a04"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.2_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_linux_amd64.zip",
+          "shasum": "7877e95337f1f502868ffd2e1106281fa5f7e3f5e9fb9210c7252cbccd21e9f7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.2_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_windows_386.zip",
+          "shasum": "85663940d61b2ce76570bd2ea26be41186a785c782018730833c1c8e31030e4d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.2_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.2/terraform-provider-lacework_0.2.2_windows_amd64.zip",
+          "shasum": "5d5f419625bd5e5f21f08797cffc903ce6a4272f245c42b914f660554993e86d"
+        }
+      ]
+    },
+    {
+      "version": "0.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_darwin_amd64.zip",
+          "shasum": "4156ba8654d98afceb22fde94366676a26a3ee85161bb191eaa219434edfd235"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_linux_386.zip",
+          "shasum": "f83c749a8eb27110fd20cb21ed6b0348669155e53ad31140299a5c284fabb720"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_linux_amd64.zip",
+          "shasum": "65a78e53b4646610cb545cfb5d9712393a9b503bd37540f917851eddf090cfc0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_windows_386.zip",
+          "shasum": "e3da27ea9af4d0bf520303f6ef81e220f06cb02e759d9c97b445496a986590bf"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.1/terraform-provider-lacework_0.2.1_windows_amd64.zip",
+          "shasum": "b107f96d781cbf91d2310854954041505d19be8d05dbe40b513e9aea77848854"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_darwin_amd64.zip",
+          "shasum": "24987bc8553ddbb6250d146acd1bdc9b75d28fdde0bf169df94934bee3fe1f97"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_linux_386.zip",
+          "shasum": "389741301ebf300358fa8293379605a244277806b6f14f67efb4578c3451e0e7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_linux_amd64.zip",
+          "shasum": "ccb609b82ae3894587ad5e886e34eb1d070b1df132bee13439592f646972fb6f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_windows_386.zip",
+          "shasum": "3153be35743b9b56e8dcb3a13b4e237ff3f3e9f088ac21c3aa8b1d2e0ff26458"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.2.0/terraform-provider-lacework_0.2.0_windows_amd64.zip",
+          "shasum": "7ccc3f752ee4bd61275529ccaa2630cd36800291e164b046cea5990fd41bb46a"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_darwin_amd64.zip",
+          "shasum": "46a2a337f7fed56d2b8ca45774a510e1be2540d0654f77c4f148b658b71604dd"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_linux_386.zip",
+          "shasum": "2c0c456b197369a017cdda03f533d2e80e5988db6aed0ce590a88bdfa72bfd53"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_linux_amd64.zip",
+          "shasum": "36d335878c37ae5ab095ec1f5bd66df97bc17398386c73b4bc70ddb0c2238f96"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_windows_386.zip",
+          "shasum": "90199ce12ed0e7b98880cb3c8bd2bc439aae16a2c4ddcaeea8544bd3783d99a0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.1/terraform-provider-lacework_0.1.1_windows_amd64.zip",
+          "shasum": "f8a3f0823f433e904e9cd28425e17619c5d3d7cae092589106f2a449a6db56af"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_darwin_amd64.zip",
+          "shasum": "58059babc988f1b35259fed5504154b07fca77f23ebab090855106d84454e721"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_linux_386.zip",
+          "shasum": "69c8d5ea58bc96ef037a39d2dd461539662ca1d8dd766608566c9f677dd99024"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_linux_amd64.zip",
+          "shasum": "744f56e4fa8d7ba106800982979235ecfdf5b8e196162014f77e82f03daec0d7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lacework_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_windows_386.zip",
+          "shasum": "2354739f58854a65d68495742071093b1d19b17631f4c1b88f897e7ec8976c3e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lacework_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-lacework/releases/download/v0.1.0/terraform-provider-lacework_0.1.0_windows_amd64.zip",
+          "shasum": "d529830ac60ceafcacccc623c4c85f6ea3fae487c721ae3135a5448a2f918f31"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/librato.json
+++ b/providers/h/hashicorp/librato.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-librato_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_darwin_amd64.zip",
+          "shasum": "e914a15d3906d6eed22a97b0fdb33c252458da95a7bfa3b051d7629002bd75ac"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-librato_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_linux_386.zip",
+          "shasum": "dde07e4e14102c6aeb07eb24df150cba8213d98791893e31703f868b82d41d6d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-librato_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_linux_amd64.zip",
+          "shasum": "309d43be760eb667a9bed7975eb1a4697c281275411032dcf03aad75fea928e1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-librato_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_windows_386.zip",
+          "shasum": "287aeaf9eedc36d2637e3da3cee91aec1e353ea06955dde817b73dd1b178497e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-librato_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-librato/releases/download/v0.1.0/terraform-provider-librato_0.1.0_windows_amd64.zip",
+          "shasum": "c763d2df67ca33e579cbd9b0aa45b9a93e0e0e4a5cea4eb3ef941baefd90f6c1"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/logentries.json
+++ b/providers/h/hashicorp/logentries.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-logentries_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_darwin_amd64.zip",
+          "shasum": "a3d926d069d5d369c2e41794c063902c0612841b3816c68e9b965bf9f2b739ab"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-logentries_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_linux_386.zip",
+          "shasum": "46b9d8bf485231cec8c83d44fc0438685fa53e1ba4ac21924c81bff3329b174f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-logentries_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_linux_amd64.zip",
+          "shasum": "be58c36173d4a0af0147eb162bc7ac5768f005077ad3b5aac163d216c45cbe9c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-logentries_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_windows_386.zip",
+          "shasum": "365c584909318712f776bd3c58e722062bdcc285cd896b639d992f0e10fbb271"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-logentries_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v1.0.0/terraform-provider-logentries_1.0.0_windows_amd64.zip",
+          "shasum": "4735bd8d6fff362f3f084e1d5e4102402d6fd76180e2cd25cd2a1c6a90fb5767"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-logentries_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_darwin_amd64.zip",
+          "shasum": "d60f3871f5e9646998552712954b4bbdf570e3f5f7802ea53facadbe4bf7c606"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-logentries_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_linux_386.zip",
+          "shasum": "8294dd45697a1083a6f39009015f46dbcee29e64298a9239d48a206dc7e5fd3e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-logentries_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_linux_amd64.zip",
+          "shasum": "82dec75bed58fa244341db08fd16dcde9b3289c23e18e665aca1f8f1aea38be0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-logentries_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_windows_386.zip",
+          "shasum": "09dcef35825e4325ed13c6416cb297f8f8e3f8080a9ba77b43c10fdc15794668"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-logentries_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-logentries/releases/download/v0.1.0/terraform-provider-logentries_0.1.0_windows_amd64.zip",
+          "shasum": "a689443b689b963d96f0a134cff0928c1b79756e9271570af3ca9c937e833bf1"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/mailgun.json
+++ b/providers/h/hashicorp/mailgun.json
@@ -1,0 +1,319 @@
+{
+  "versions": [
+    {
+      "version": "0.4.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.3_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_darwin_amd64.zip",
+          "shasum": "9da08b9821902efd0cbcd681125a8465c00fc45ab2852f6d84b90da8435f3dad"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.3_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_linux_386.zip",
+          "shasum": "b99e23ddaa5d4eb04e06d97865a45ec71b7b6ea4c0766a019a867cb14aca0805"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.3_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_linux_amd64.zip",
+          "shasum": "71f4098225f930056217715886a93093fad2afd03522c30c96b37c8eee033711"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.3_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_windows_386.zip",
+          "shasum": "e8bdedda57bcf512eb107ee31ed43323c6609948cf970580cc851fa5686b7ecd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.3_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.3/terraform-provider-mailgun_0.4.3_windows_amd64.zip",
+          "shasum": "92e1bfd517474a9aadd22e106a8dfa6d9f417eab0e87eb86ab4cc46f4adf200b"
+        }
+      ]
+    },
+    {
+      "version": "0.4.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.2_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_darwin_amd64.zip",
+          "shasum": "139e5cfd2645cf80a2aeed5f85d5087f631aa3360facb8cb39209e6dec8e35dc"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.2_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_linux_386.zip",
+          "shasum": "f283be69711f7b205cea78ed8b96abcd510c13587221dc66e5843c55daa06e8c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.2_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_linux_amd64.zip",
+          "shasum": "66808a276f1823753c5c18c2c88ecc23034c29d96e4928f8ee21fdd98a6e02b6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.2_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_windows_386.zip",
+          "shasum": "1b1af713b826692951a86dc84bf67e785ae6653b645662411b73711ee13d86d1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.2_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.2/terraform-provider-mailgun_0.4.2_windows_amd64.zip",
+          "shasum": "759af3a58dd38a64a4903c7fc17aeef87ea84594339841cb664d286acd7f77bc"
+        }
+      ]
+    },
+    {
+      "version": "0.4.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_darwin_amd64.zip",
+          "shasum": "6f74ae2316fd505129c7ccec07c8e658099e675b773b2d531b7529bc9cde8105"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_linux_386.zip",
+          "shasum": "3e5c896d52fd9448699ac10c29d46f641620712591125d35a87b61fb7ac69735"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_linux_amd64.zip",
+          "shasum": "e9d7c546e996b49f1413554bfba6edcf6417653d78a24ee72a4f6a318d734e89"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_windows_386.zip",
+          "shasum": "bfcac610136efef9a5e7a997ec93c18504be54ff854b2abda8f40c545b0d0b55"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.1/terraform-provider-mailgun_0.4.1_windows_amd64.zip",
+          "shasum": "4b038b8be9919a73ce96db9fcde46bfeea5b5ded81bdbeaad3da0f50e78e7ba6"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_darwin_amd64.zip",
+          "shasum": "984d139c03ccbf3830760af51a24fd9e523dcb87e9d99f7344ff11b22f2780f3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_linux_386.zip",
+          "shasum": "e6148881f0d701f0fb0f50b141593cd72e2a0a88d818b0cfbc716f544ba4f9d4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_linux_amd64.zip",
+          "shasum": "d9b7aef00cd4fd6de69aee71efbba99ab48efc8cb472cbacac127d36a944b0f8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.4.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_windows_386.zip",
+          "shasum": "72c4dd6d9a25a59d8d7634f7f6e27600e245a2658fb24ef5ef32879ed55dbe06"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.4.0/terraform-provider-mailgun_0.4.0_windows_amd64.zip",
+          "shasum": "bab3ecd260a04a671da0bbdd960999644aa583bda0c25453204c054112388722"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_darwin_amd64.zip",
+          "shasum": "303b1af7a316289272f2c7067668239f59ad8b41141042526cb9ccfc58469a77"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_linux_386.zip",
+          "shasum": "3ba002a71110012c136eb6413e5aa91640adf58688e41ac5e424c258f21e0d36"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_linux_amd64.zip",
+          "shasum": "79f2f39441a2ff8d2e0de1a1a167336cc2377a4a40c675c0f229a0e751ee95f4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_windows_386.zip",
+          "shasum": "f79737a188ff1f10ef12c7db83ff28a4d0576a50a0e7dcf03dab3cc2773544ae"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.3.0/terraform-provider-mailgun_0.3.0_windows_amd64.zip",
+          "shasum": "4c43fda8639f4f07372eb8cfd0695e35a9d543df41f16cb94cb1becc9dc7e624"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_darwin_amd64.zip",
+          "shasum": "386d8332f60129bbfb74f69af3fe7df9542567888a2d4aa39f10e1229fd88efb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_linux_386.zip",
+          "shasum": "71ce53e0916747bff0b55e104c25b266544487208f243036d9bd267f666ca656"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_linux_amd64.zip",
+          "shasum": "db075c72a948ae997129780ef7590a7078cd265a95a6b71dbc7e72d084cd4e7a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_windows_386.zip",
+          "shasum": "e3ea7b2e275de50946f4a382e7ded0883d530caff3165bd6f3788186a36010ea"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.2.0/terraform-provider-mailgun_0.2.0_windows_amd64.zip",
+          "shasum": "cc91ce7c25d6d182c2e5bf02b7eaa63a2c0017635e7237d6073e969ceda7d305"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_darwin_amd64.zip",
+          "shasum": "75158e2767df07510baf3acb14a1dfccdd849cbbdac16aefb1d6642af557357f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_linux_386.zip",
+          "shasum": "efbf2ae550140f5d5332765d6a839a6d1b7605ec9e414ae6dc550e7b450897ea"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_linux_amd64.zip",
+          "shasum": "1fa57bc8cc44bebb037c6d475cf2b987a177744875702ac8f4c708447ff9f4f0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-mailgun_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_windows_386.zip",
+          "shasum": "67152203670cce13f9674782b3aef882c042ee9ec44571d63d67e5d304c20263"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-mailgun_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-mailgun/releases/download/v0.1.0/terraform-provider-mailgun_0.1.0_windows_amd64.zip",
+          "shasum": "6e02cb68e779d9a67d850f84ae2e1a655bc7468498933f6862035923cd73a37e"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/metalcloud.json
+++ b/providers/h/hashicorp/metalcloud.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "2.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-metalcloud_2.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_darwin_amd64.zip",
+          "shasum": "836852a2fa6c81953a945696f69254329dd3f082efcfce220d4faca6f7ad0310"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-metalcloud_2.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_linux_386.zip",
+          "shasum": "a2b822f8fc71406c7eddc424d33cd84010d36ba45ae4cb6bf7168c4c9f4df7d0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-metalcloud_2.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_linux_amd64.zip",
+          "shasum": "3063fd3d520b98cb1871b8517d8ee65f8b6817c59a9e8202e2eb12359b9b9913"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-metalcloud_2.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_windows_386.zip",
+          "shasum": "7cdeb515460cfa6a4ef9bb5acc484e8aa77dff077044c06aa7f2b8100fe2f30d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-metalcloud_2.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-metalcloud/releases/download/v2.2.0/terraform-provider-metalcloud_2.2.0_windows_amd64.zip",
+          "shasum": "699f49cd3274616b9184c4ec7159362bf07aab1021d165ca42347cfb11918d2b"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/netlify.json
+++ b/providers/h/hashicorp/netlify.json
@@ -1,0 +1,184 @@
+{
+  "versions": [
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_darwin_amd64.zip",
+          "shasum": "12efe296f8aeda0d76600f37bea6442e5632dda9d8f8ef4120369adff01b34c6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.4.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_linux_386.zip",
+          "shasum": "1cb1f51f468cc10159f1da279cad3e0d164f48c7c8f69a1b3a9d275abc70fb02"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_linux_amd64.zip",
+          "shasum": "0c084b24e3e19dcc2acffe03579429959f8f0973eca6e7dab8df30caaabc0177"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.4.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_windows_386.zip",
+          "shasum": "a8899252671042243b8dad8718b5b34a52ddc195efcab81e61595b3bbf445ec0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.4.0/terraform-provider-netlify_0.4.0_windows_amd64.zip",
+          "shasum": "50e83e8f244cf1dcbc5ddcb5b364d565d8c3177a7cf6c1450df016d37880cad1"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_darwin_amd64.zip",
+          "shasum": "253b8876a2f73f998a07709177601e59b7cab0356e1f97ee1e9164e61c13f275"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_linux_386.zip",
+          "shasum": "ed59226db74bbb18d09edffacd841a9b0fdb97b973f821b893753257d1ec7ff7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_linux_amd64.zip",
+          "shasum": "44e31b70bdffe106494c120dcfe3fab517315984d64179c09c8d7aecbcb1c899"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_windows_386.zip",
+          "shasum": "09340a06fd84b9f89f4a773724f33b85dbee73118859cec412e2fa6f0ba872bc"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.3.0/terraform-provider-netlify_0.3.0_windows_amd64.zip",
+          "shasum": "4d266309d5efc5905a2e0453e97e201d82828f486dbecf9eb99a4680c8ffc4c7"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_darwin_amd64.zip",
+          "shasum": "33753ab993e457e972593051caefa86a83e44560e82d3510f936cd53072c6970"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_linux_386.zip",
+          "shasum": "4f2d4411bb47b7828c6844f0d1dce12f838aee0c1d2675b41a7b0299bc2c4c41"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_linux_amd64.zip",
+          "shasum": "94441d5e3818a9ea4f98ff627a4b34b7921ab6808f5ad1b024777f4584d9ebbb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_windows_386.zip",
+          "shasum": "b986f1a9fab74bf15fcd4f5458a37028c59c97482955a692701d9b647d96c42c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.2.0/terraform-provider-netlify_0.2.0_windows_amd64.zip",
+          "shasum": "f38ae399978de5505aafa2f7525c6caf8d06a56728234afaea370777555d6ab7"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_darwin_amd64.zip",
+          "shasum": "2cf4d1560e0d29dfea14d0397e9bfd8009bb0fa704f8c216037a1341409ca53a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_linux_386.zip",
+          "shasum": "046e4dbb0a96e72f426f1280a821cc6e97c604336446652823a12c00897013ef"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_linux_amd64.zip",
+          "shasum": "614187fc9c333a404a0343f87d773bd577c518e4d9735fbfac339f8452c9489f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-netlify_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_windows_386.zip",
+          "shasum": "3ba7b2623dd4ea2d52a0c69a25d6e0b247310e1c78c5f84a752dddc906d5728d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-netlify_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-netlify/releases/download/v0.1.0/terraform-provider-netlify_0.1.0_windows_amd64.zip",
+          "shasum": "a16d9df3493d514d3c2a7cdbc529d94161b55d61679ab539d0415c5c2a879a5a"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/oneandone.json
+++ b/providers/h/hashicorp/oneandone.json
@@ -1,0 +1,229 @@
+{
+  "versions": [
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_darwin_amd64.zip",
+          "shasum": "9bc3e7978b03432e092971f07885c1f33dbf55b7f78bbc28fcc160023a5c8a59"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_linux_386.zip",
+          "shasum": "d1f32e0b115799903ef068557bbb0511c62a667e669c93d04b32a41d21db9a86"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_linux_amd64.zip",
+          "shasum": "34c613871c879c0f11733d7d7711f53f30b07f9543ae199dd3930e8d740a1e08"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_windows_386.zip",
+          "shasum": "6aa1b9f08026495d6aee539600cdbe2c799b037172e6674928d9323ee96d1029"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.3.0/terraform-provider-oneandone_1.3.0_windows_amd64.zip",
+          "shasum": "e4eaaca6bbd0abbc733e158c7248607c43f31cc1d7d66b9123791bc828022da9"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_darwin_amd64.zip",
+          "shasum": "35ab77b399edf509f3b415113ffd581f5c56b7b0b787cbf3409c5919247be4ec"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_linux_386.zip",
+          "shasum": "fa6a19d9b096178c968edbe5a55fd61c2ad6fde2bd40fc7363ab091e0e9c5fd3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_linux_amd64.zip",
+          "shasum": "a8f8b1b4c6aed32a07a6e70460effec43616475e15f7adfcf0bd9e9a5ead5d82"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_windows_386.zip",
+          "shasum": "18c65537c65f5f3eb88f609e36b8b5ebb6f1a341c1fca461dbea8f1755f85cd1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.2.0/terraform-provider-oneandone_1.2.0_windows_amd64.zip",
+          "shasum": "e17ad37a9fa4fa798c5ef9d9388cdb0803908786f19de10214ced7024b30e882"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_darwin_amd64.zip",
+          "shasum": "a81059a600eebe164b5bedd9a54bfaa46e99b128638b3602d657dfdd96839f86"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_linux_386.zip",
+          "shasum": "ee819e449bdc7292c0d0a1add8faa1d5b62b696be0357aefbeb8382fa5aa87b0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_linux_amd64.zip",
+          "shasum": "8371cefeaf88f0345d1eb1631fcfdc0e4c00e96f095f9222c24b9ec5e5309a25"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_windows_386.zip",
+          "shasum": "cc3ed1bb237a6218074c19d393d9c9aa6f15ec4a53e9e1122145321dbd119bd6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.1.0/terraform-provider-oneandone_1.1.0_windows_amd64.zip",
+          "shasum": "830a5e52b70e7394b1376647222640c6d1191d079e615e993c6c53d874f9f569"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_darwin_amd64.zip",
+          "shasum": "a10e489094c84a9d66f92d1dd703f6a6311f3d8d7db208d3476cfffe40df22f7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_linux_386.zip",
+          "shasum": "6f2c49b368e234d618dd8750e1bb8233059a5afc3d3fb4273f3d599d94228441"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_linux_amd64.zip",
+          "shasum": "3370df24061cd84f87b4a7338c9ac7409d4fe82277508f377ddd815761890535"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_windows_386.zip",
+          "shasum": "e81d728ca3923fa4f7a6c7252cae50bf65bb46fd9a5b1ec7d86cf1d3b7a50aa8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v1.0.0/terraform-provider-oneandone_1.0.0_windows_amd64.zip",
+          "shasum": "09e7d0174b3dd0718ccb73bad82a25876b40e8b548093a6acae176878b6a5684"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_darwin_amd64.zip",
+          "shasum": "3cc69ecdac8edf03b36bd62e548e592b101e6aee2033a725f5f7e8616624bdbd"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_linux_386.zip",
+          "shasum": "4d34321c789ebc52a3ef4ab292b32b512d9b8af24857ff6f7c056e74b7ac79ae"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_linux_amd64.zip",
+          "shasum": "23b85cdf323e7be59904f83761ede50b1ee7e825881883db505102f5ada49d61"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-oneandone_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_windows_386.zip",
+          "shasum": "4a41f052f657fb18025e976657d120265159af3cf0bab3bd9bcc64989ca685bd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-oneandone_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-oneandone/releases/download/v0.1.0/terraform-provider-oneandone_0.1.0_windows_amd64.zip",
+          "shasum": "16ebb8dd7cd8fb65b206d49b75c586d54ab80e21b5d95c20962958c0e93e9014"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/pureport.json
+++ b/providers/h/hashicorp/pureport.json
@@ -1,0 +1,319 @@
+{
+  "versions": [
+    {
+      "version": "1.1.9",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.9_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_darwin_amd64.zip",
+          "shasum": "d3a64b9c88c2ad4227feab538add8e24c072d089f3731e83ffb4a825d0ce67e4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.9_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_linux_386.zip",
+          "shasum": "28e4e1050bdb9920ea67295d366f628659dfe5fd523f790748d3d0eb9d24ad5d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.9_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_linux_amd64.zip",
+          "shasum": "acf4e7e5b97ff170668d6eb060a7479878b592c314cfff955ecb67ff65ad28d0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.9_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_windows_386.zip",
+          "shasum": "90b01f8e51c4cd0b111b7976660a4882a4a52b00dc624631b526dee8458b3da5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.9_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.9/terraform-provider-pureport_1.1.9_windows_amd64.zip",
+          "shasum": "df4163e80774e7829310fea6495978021ac286f140e4fed677275bafd9dc6daa"
+        }
+      ]
+    },
+    {
+      "version": "1.1.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.8_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_darwin_amd64.zip",
+          "shasum": "4d72c77033db6035f76fddf84a08dab517460020a42b6f587be8db1896479ba2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.8_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_linux_386.zip",
+          "shasum": "b9c853f6616edeb7daa9afdc758ab62d92819ae9912ff56ada16ef9897584f09"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.8_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_linux_amd64.zip",
+          "shasum": "c559f693c393689672153a868d6f3e567c526591946b3b3085902ca50b7252bf"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.8_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_windows_386.zip",
+          "shasum": "ce0abb2d9d97891f03b1a0aacdb35c97aea7864a3b3c2fc7123c6d088e35c7d1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.8_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.8/terraform-provider-pureport_1.1.8_windows_amd64.zip",
+          "shasum": "8ee5be37e602e336e3c526857bef7e753c2ab528fe38fcc5d3010df2d2da2b21"
+        }
+      ]
+    },
+    {
+      "version": "1.1.7",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.7_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_darwin_amd64.zip",
+          "shasum": "1d149284ca1acbf1478515046907a2b04ce7e2e35c965ce0ce7c0bdbbaa917ba"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.7_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_linux_386.zip",
+          "shasum": "30b4e1fa415730c15ea6cfa0a78daa5154ca8ed1a95912dec5cee8697231f6a7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.7_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_linux_amd64.zip",
+          "shasum": "e305fcf66694857577ee7a79d3cb6e8f200e2fb00f7f8b6893e7a025284fdaa1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.7_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_windows_386.zip",
+          "shasum": "96bb202def6225e631165a5e399e1909b539faffeaf6b43724ff74eebf7dbd30"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.7_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.7/terraform-provider-pureport_1.1.7_windows_amd64.zip",
+          "shasum": "0f37d838e64f6649ba018d0bd17d6eb5948731d655768d53e8eb4e72a81b8697"
+        }
+      ]
+    },
+    {
+      "version": "1.1.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.6_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_darwin_amd64.zip",
+          "shasum": "f7c7628222d3bedc0db132f608b34fa1c8be4c0f4bde4e260b594c7dfcd0b5a5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.6_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_linux_386.zip",
+          "shasum": "dbe695326ddb84ebea458e2403ab83598fee715a1011af53a94f976b325a8f50"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.6_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_linux_amd64.zip",
+          "shasum": "fe481159e79f45ed73f864a97bd150ad99d3850a4e065d966a4956b9c20cd0eb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.6_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_windows_386.zip",
+          "shasum": "d5018846e4bd3e8624da4d30387a5a67462d993b2b22f6bb5789b21be73638b5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.6_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.6/terraform-provider-pureport_1.1.6_windows_amd64.zip",
+          "shasum": "24073089b343331d302b50fd09d6de59c93d2e494f1c38f0c39a03ed0e1413ce"
+        }
+      ]
+    },
+    {
+      "version": "1.1.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.5_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_darwin_amd64.zip",
+          "shasum": "ef5d536b4babf9b0c78d737f5377085b2b048a3f11e90e162c104e3995fac1a3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.5_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_linux_386.zip",
+          "shasum": "5334d341eb7703de6fd38ed54388ab8191352f25ff80d576936beabcbcb1e0b2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.5_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_linux_amd64.zip",
+          "shasum": "1df5f80939691806c0290e777a55a928d78cb0a56caa9fdf8bb35ac2c4991d64"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.5_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_windows_386.zip",
+          "shasum": "bca4ff92b4df9ffe5d1b54eb27f6f4dc45c723cfa5fc0ab50f1ad7b67cc78b4c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.5_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.5/terraform-provider-pureport_1.1.5_windows_amd64.zip",
+          "shasum": "6c7302578782a0b352ecf1fb268cf85fa2540e7cc5192f1415500a80e48ee710"
+        }
+      ]
+    },
+    {
+      "version": "1.1.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.4_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_darwin_amd64.zip",
+          "shasum": "24a62f38735697827401793b704255df3842111d20fdc8d87659736c83c2989d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.4_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_linux_386.zip",
+          "shasum": "d35a7198d5849fabd4f2a17c0886d5b6f4900beea2edd8f3f832b970a2a28bf5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.4_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_linux_amd64.zip",
+          "shasum": "a2b111f7e92bea5fb2ee328d748b3547e7a9cb88b2fd1a9e34dcf08a413076d3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_1.1.4_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_windows_386.zip",
+          "shasum": "e1805c24a33c4b18b147a0cb77b1f6306986a1b22e97eae2bfc8169ce22481e0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_1.1.4_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v1.1.4/terraform-provider-pureport_1.1.4_windows_amd64.zip",
+          "shasum": "43c61d0287eb46f679fd463b2c1348f2aa272bf1985cd26a82233c6d3739e11b"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_darwin_amd64.zip",
+          "shasum": "adda4a8be1c8027a185867522d924eefabc2db3a9f188dd4eda4bbbd013263a9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_linux_386.zip",
+          "shasum": "acb799a110d0d647ed631d15f24113da34f41fa5ae06743e3e769d9f2bcde721"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_linux_amd64.zip",
+          "shasum": "2cf9c7a73a9354a4b7e84e80cefbe5b71a3df0eca7ef2f43a943e8e63762ef54"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pureport_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_windows_386.zip",
+          "shasum": "1fa34f7bda4ea11f3ad8d417fcb7e942f296af7b56ca8ad4ec198cbb2a2edfc7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pureport_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-pureport/releases/download/v0.1.0/terraform-provider-pureport_0.1.0_windows_amd64.zip",
+          "shasum": "2e5dbc35312924ebd62d554e269a3eae362d6df33705e46a6497a692ceed2248"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/rabbitmq.json
+++ b/providers/h/hashicorp/rabbitmq.json
@@ -1,0 +1,319 @@
+{
+  "versions": [
+    {
+      "version": "1.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_darwin_amd64.zip",
+          "shasum": "791c2d1e2bf911c2e52c7f7f66bd36d9d617fc2de95204ba75fe34e12befb150"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.4.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_linux_386.zip",
+          "shasum": "b56eb0c4373cfc2ed89c3446e19f23eb4a6133798551e1d035c6a73c2026981f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_linux_amd64.zip",
+          "shasum": "8c708b813d7fa2bd0fe7eb07b6e6d3da9bfffe10e26aa0f903a11f51cb654178"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.4.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_windows_386.zip",
+          "shasum": "cf90f7a4aba5ce973ea0d529cc2f3f1bca3a721817ee9d9d77879b7fe2f2fc42"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.4.0/terraform-provider-rabbitmq_1.4.0_windows_amd64.zip",
+          "shasum": "eddf328ed86fa10c1429536bebddce4526b2511a394f9f83febad8d1df3ddc66"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_darwin_amd64.zip",
+          "shasum": "29c586078d509b348b31ff5ff9240fb031434a332b65a1603405bd3279ef5438"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_linux_386.zip",
+          "shasum": "0124f3cac76cb74371a2be5ae71730f0de287ae999e04b56be5dd2b34755400c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_linux_amd64.zip",
+          "shasum": "6e02da481c084f3a6eb81a9ad48a49028303c0a1cfe3a7ae599837a2753f4de4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_windows_386.zip",
+          "shasum": "3b35b6f8acee94941964555cbac287ea38d86d3f6327489ad6f22b369cbc83a4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.3.0/terraform-provider-rabbitmq_1.3.0_windows_amd64.zip",
+          "shasum": "0d936a32630a78a046da125b739ceedb331faff3a98bc820d18b86e88b274a13"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_darwin_amd64.zip",
+          "shasum": "e5fc9813fbb4d9907bba152a5ad72cc1ded0ebd2d8fe1a72a197858a926aef53"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_linux_386.zip",
+          "shasum": "0443d1112948f106662144aa6471a71aca5c897d6bf4a375319cdc66a82429ba"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_linux_amd64.zip",
+          "shasum": "5f4919335aaf9a3c7355dcd503c630325c00659e5bc2d30e9570bebea873634b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_windows_386.zip",
+          "shasum": "131ebaf7102a12ee33c48601c42ba9043861c4e52507e0e32958421df06be7db"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.2.0/terraform-provider-rabbitmq_1.2.0_windows_amd64.zip",
+          "shasum": "1e36363da11ff4f44dba181691a65be1ed135858dd6131f01eba91bad94a6e80"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_darwin_amd64.zip",
+          "shasum": "5bb8afd6c515681e4b99b53a7e923d5d9cd51131d79f50b85f7644e1ddd56f74"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_linux_386.zip",
+          "shasum": "cf5ae4a22ce9a3c92b13af8b446ee1aa7905c8ebd71acf520b389d250b74abee"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_linux_amd64.zip",
+          "shasum": "ff47dc09d62f5e99ffa6e7d2e0f54103953e477b025fbe5bdad94d93261e4881"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_windows_386.zip",
+          "shasum": "61ef1dbee145921f7417e2eccc07a194b65ade5a991fa3a3e0527c2039920acd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.1.0/terraform-provider-rabbitmq_1.1.0_windows_amd64.zip",
+          "shasum": "067b264f73c5fc51c03566fa4977c7577f29532c0fc2e81ed25146f09bce6f97"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_darwin_amd64.zip",
+          "shasum": "5359030dda16491ecb402b59c335fe24e984754aff082d494e27ec4c69f1e8af"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_linux_386.zip",
+          "shasum": "8499e5de85f2103e74693df9dfd45e9ba74fe2203c3c5be7e89524b1d16ba75a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_linux_amd64.zip",
+          "shasum": "5e1a8d246a38e14c4c9544bcbd407156f58e52df3fbadd16fea221ea42b8495b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_windows_386.zip",
+          "shasum": "5aeee204bc58847651294e44fee538d034388edc8feec7e45fab3c152349e717"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v1.0.0/terraform-provider-rabbitmq_1.0.0_windows_amd64.zip",
+          "shasum": "3edacdfb0c327be4cdfecc5a9891316a3ad8172674c318950deedc3be84e6163"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_darwin_amd64.zip",
+          "shasum": "59323a787fad76fd6fd3c99554c753e4ae8d6faee7b42fefb4d501d5f56393f5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_linux_386.zip",
+          "shasum": "41a6b8deffb5601740906e9ceb877ba8099d386519a3f729c097d3784297ad7f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_linux_amd64.zip",
+          "shasum": "e17a171842278bd91632b41e0d2e3c3b6b1a5d782e129f55fe525348c1199cae"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_windows_386.zip",
+          "shasum": "9e9e9bccc33ee269169973126b59db08b69554c13d074420d4d883d244581ca7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.2.0/terraform-provider-rabbitmq_0.2.0_windows_amd64.zip",
+          "shasum": "c3e731c6645109d0fe7923601c113f3dc49bbcf480614834a8528b8eea0888e1"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_darwin_amd64.zip",
+          "shasum": "5b1c5cb361c90cc736e82be09cd49d267d8489ef3e25c477f4c553e116e4c6c5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_linux_386.zip",
+          "shasum": "53bc6231e9842477268d9fffeeceafbb0fc513d4b64c1dec235be4f90cf3dd2b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_linux_amd64.zip",
+          "shasum": "6dd55af620e482699e1ed562fbf912a215efcfbf374ceab9218860d14f2f496c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rabbitmq_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_windows_386.zip",
+          "shasum": "cd0258c5b14861cd3d25fd4a90f5402e68a6ac4a62970e5c26a590afc4336238"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rabbitmq_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rabbitmq/releases/download/v0.1.0/terraform-provider-rabbitmq_0.1.0_windows_amd64.zip",
+          "shasum": "84bcd8a424e1e1713dd38ff1bc2c0ab9a1eaff01342bef7f32eaa30c89bb19a4"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/rancher.json
+++ b/providers/h/hashicorp/rancher.json
@@ -1,0 +1,499 @@
+{
+  "versions": [
+    {
+      "version": "1.5.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_darwin_amd64.zip",
+          "shasum": "a41dcab9beb5f15f3f39dcfc1da1599b23e1b0b0161ebab886f4281b88ebe111"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.5.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_linux_386.zip",
+          "shasum": "66e5a05a7bb45a20ab1a454c5aaf3b2e1965e2938f82389935627ef06a2e57ec"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_linux_amd64.zip",
+          "shasum": "d458c178a92a98e334f44f36637b2a9e91cf7a72c64299389e7798ca5cb4ca17"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.5.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_windows_386.zip",
+          "shasum": "c4743d8e13edd6d0eedfe01ba33330c7abd5e5243d220f0331662d45f0e769af"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.5.0/terraform-provider-rancher_1.5.0_windows_amd64.zip",
+          "shasum": "9e6ed2812eea0b0b1ef895077541f109203a2950890ccafc3dc6f5332855bec9"
+        }
+      ]
+    },
+    {
+      "version": "1.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_darwin_amd64.zip",
+          "shasum": "6e286cc541c71022b6675624de270d986ed9392f685c8cbd93edba4b3e6bd5fe"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.4.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_linux_386.zip",
+          "shasum": "6e3b5532442fc9e336ec4efb75a642ec7914198fc4d59778efe52678dcdf302d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_linux_amd64.zip",
+          "shasum": "52c5adbef2cbebe0a040eac4f4fc96b6fc6bab6274ed971dda21c1efa9f84e35"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.4.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_windows_386.zip",
+          "shasum": "a31030386460375a86f79dd096841a442c45c00af607d3ec46f9fcd9bb6cc0b3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.4.0/terraform-provider-rancher_1.4.0_windows_amd64.zip",
+          "shasum": "02135857a6bf2f30765cb167710fc3b45257be6a63d52f890eb04cabb1cf373d"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_darwin_amd64.zip",
+          "shasum": "903cbe6daa7761458a11f95d930569dd90554695e5d50a9d40519d0afb2e111f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_linux_386.zip",
+          "shasum": "728fc41a59ca6f54be260d924e27d01517b37e5ff791e9b535bd6e9ee72623e2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_linux_amd64.zip",
+          "shasum": "8b3a3ff58f709a255e1a612db827e31fbd1abc20d05258fd4f52f29854107414"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_windows_386.zip",
+          "shasum": "f53a96daf1c0c842aadcd57114e23476e6fb042296b8bb150707798d553caa18"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.3.0/terraform-provider-rancher_1.3.0_windows_amd64.zip",
+          "shasum": "2a623e324c42dc2638bb786b49bb40bc20cf0f5c8565f98a6e3f4e45af9e6f0c"
+        }
+      ]
+    },
+    {
+      "version": "1.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_darwin_amd64.zip",
+          "shasum": "03cba8b2d16af6e77f7ed95ecbd1ce6cda6a9f23c435b8b9e99b11b757933ced"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.2.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_linux_386.zip",
+          "shasum": "b2272d5bb9091f684ec8fdf0803159575682eaed6d71b46b2250782dbc7548cd"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_linux_amd64.zip",
+          "shasum": "a8e03ef1451146b8452c89df433f8d81419246c63826ad151382a18eb3f7ad82"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.2.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_windows_386.zip",
+          "shasum": "3b24a68894c45248f30b0dd0ebddd617f1671a72c065183db6a586e1cee46d26"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.1/terraform-provider-rancher_1.2.1_windows_amd64.zip",
+          "shasum": "fdf573ef436f2b0d5c6a3b49b1fe6680bb08bd43441e02e81ff855b9c41bae6e"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_darwin_amd64.zip",
+          "shasum": "4852e45db3f2d2bc8c2f645a100680f0a5bf6542d71268ccd4436aff387c062e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_linux_386.zip",
+          "shasum": "ba067c48c71f891c5b42d6fb4e46f5fa99bb12220f6e5ccd3eebda9f2ddcb879"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_linux_amd64.zip",
+          "shasum": "16c63443ffda8191e374aad008a64ac213bb2965674e2320eb3e26e352d1b515"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_windows_386.zip",
+          "shasum": "c59d26802c438f0bbdb4b907c7a296753c3f4a1ee93fe6417422d14e9ccbaff0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.2.0/terraform-provider-rancher_1.2.0_windows_amd64.zip",
+          "shasum": "37aba3e378d69465ae471647e8c763e39cd8650c64458d6c62fb5d11655573c9"
+        }
+      ]
+    },
+    {
+      "version": "1.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_darwin_amd64.zip",
+          "shasum": "01c3beb8fdf9527442f369b75d80689f49b22788031a98df32541dc5419fceef"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.1.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_linux_386.zip",
+          "shasum": "39f5241813419d0b3ef7609917ec0cb271cb9c0e4e798e4f5aeda52335a6bc4f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_linux_amd64.zip",
+          "shasum": "888a542a6e57993bb2c07c77f5ce7cbea59424569b1ac50fa27658c5692d1067"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.1.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_windows_386.zip",
+          "shasum": "0de13fc6ff2199525910d1cc0b396764595b0a6e8d05f57536debdd2acd0e17f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.1/terraform-provider-rancher_1.1.1_windows_amd64.zip",
+          "shasum": "c70f830b8190b271b00280fd68675d2c4d7757aa55fc7132c33bcad9d55c04e1"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_darwin_amd64.zip",
+          "shasum": "caa6d732eb52dcf8bb9dc1a5d6d7774e1f08b7ab7a0cb0842a2db0e4b893a4d5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_linux_386.zip",
+          "shasum": "5e7c59bdae3937e8946e2f89d1714b6dc87d5d479cf3400e80a4ec16d31d62f2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_linux_amd64.zip",
+          "shasum": "575162a7e67fff8bf36471255897ee887aafefe2bf0b8e4f803d845cb914bab1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_windows_386.zip",
+          "shasum": "a735beb03d2d52e80e7af1b1cfe648b311acc90e29763eb683a7e5b28dda4467"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.1.0/terraform-provider-rancher_1.1.0_windows_amd64.zip",
+          "shasum": "2f813f8308329ec5a524459490f849fddc2cbaadfbf112202de83a1ec0c68875"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_darwin_amd64.zip",
+          "shasum": "1baaf75ed4affe0ed20a6a662920dc69f5f082c077bbcc4b637cd73012046cba"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_linux_386.zip",
+          "shasum": "d6b481a8ac23fa2af3483dee45518910f0d96501db37bd541863d4e51741ff78"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_linux_amd64.zip",
+          "shasum": "b175cdfad4b28f3fc0ab9e69ea6c35a0239d8782db3fd2db70003819ad123c8d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_windows_386.zip",
+          "shasum": "42d4fb40af71ce5ee31d54626e627f076ab82f3d487577c47680a20fe9ef8d64"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v1.0.0/terraform-provider-rancher_1.0.0_windows_amd64.zip",
+          "shasum": "f155723ec9c1204edbc76449fbebd6ee6c31cbe24191b57341a97623b98588a6"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_darwin_amd64.zip",
+          "shasum": "ac5c35398ada921fae52fc3f96de94daf8fed33a7ddf872d2d5a80fcbb8f05d5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_linux_386.zip",
+          "shasum": "e2fbf5c7fdd54cefeee01a56dff222c62321a8508e203c24803236be9507dc86"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_linux_amd64.zip",
+          "shasum": "06104fd2f6127d475eac0b28f12091dbc1a9afae2ead6f019491a28764d2c036"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_windows_386.zip",
+          "shasum": "5e410b4f3cb52d18165702b9c8f6cf457828f95a4aef17d8b5069f7245337784"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.2.0/terraform-provider-rancher_0.2.0_windows_amd64.zip",
+          "shasum": "1b7052485e80a50912f4453299d2a97ec65378910e37f68cf899344f2aaacdf2"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_darwin_amd64.zip",
+          "shasum": "1953b8ce2ceb6547e15dc2df6e69e925d438d25920c58df785a71ec905249e17"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_linux_386.zip",
+          "shasum": "a26ef6a2359209a5063e3b7afea6650c3fdfbda860cc3dcb67e8fbd84b4ccd6a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_linux_amd64.zip",
+          "shasum": "0353bd9739ed75b3fec11a1fae60f1c38f3921f4afa813704a1e915f1aed0d88"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_windows_386.zip",
+          "shasum": "c9f38ca5a4b0ae8568edcc2657a45bef2932d96b29f64a099230b5aa37cf38e0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.1/terraform-provider-rancher_0.1.1_windows_amd64.zip",
+          "shasum": "4e8814d026e336894081f531872973e8da3fbc56feb95b76e5287a008327f73a"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_darwin_amd64.zip",
+          "shasum": "418029a3e7b2d9308a4a51d384f353868d2340aa5d47a963c2742a75ee57a5dc"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_linux_386.zip",
+          "shasum": "74e7d54eda25b8f357542b594530845ac38c35317c55ab08a49b443f604940d7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_linux_amd64.zip",
+          "shasum": "5939f38bbb09754c0441e1815d91d03f1dbcdd8795ff74a086ad7c92322046d7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rancher_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_windows_386.zip",
+          "shasum": "be556406cd41951aa1a5f1165fa6da8becc5004d53a23135b3968ff783ba59f5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rancher_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rancher/releases/download/v0.1.0/terraform-provider-rancher_0.1.0_windows_amd64.zip",
+          "shasum": "bd972420a2ce18e8a7686f0753c5cae166a01579179336c173c15d57ed1487a6"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/rightscale.json
+++ b/providers/h/hashicorp/rightscale.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "1.3.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rightscale_1.3.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_darwin_amd64.zip",
+          "shasum": "42e024e26dfc4d7892a28ea6d519857099c909d11ef4116cad03d8aa4d074753"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rightscale_1.3.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_linux_386.zip",
+          "shasum": "087cd24cd23e717548af9e0299a734925f2a94c04171eb5d5e5f0468df696d07"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rightscale_1.3.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_linux_amd64.zip",
+          "shasum": "22383b3ccc308fa4bc53e9a14ff69cc83c93f5470d2150b535ad63543ba5a907"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rightscale_1.3.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_windows_386.zip",
+          "shasum": "c9acd11ce654d6fbd4d2d01e16d0551df117078decd5c679a42dffc07449de5b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rightscale_1.3.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.1/terraform-provider-rightscale_1.3.1_windows_amd64.zip",
+          "shasum": "549269117de4a2517bc0b6a32367c690d69a3c7adabd20efac119c30c607575c"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rightscale_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_darwin_amd64.zip",
+          "shasum": "a07fc43f8489c5dd19421febda5e99d0c61831b0c01a0314bbc662fd071743f3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rightscale_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_linux_386.zip",
+          "shasum": "83ac9f5f4cbd78f04e9bf75765cd56fbb2f356c88751071433dcaa8990850b8d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rightscale_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_linux_amd64.zip",
+          "shasum": "765e7f86b388732e57be8ce6280a84130e07003062d72e0130705b9287cb8f44"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rightscale_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_windows_386.zip",
+          "shasum": "31c881beb104131e7e8519fb0f320fbc947387b952aa6e06783caabf8ce3e463"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rightscale_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rightscale/releases/download/v1.3.0/terraform-provider-rightscale_1.3.0_windows_amd64.zip",
+          "shasum": "42732ac1017e852b855b61872bdeff21c0803cdf8f9876d455b9601c577573f3"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/rubrik.json
+++ b/providers/h/hashicorp/rubrik.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rubrik_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_darwin_amd64.zip",
+          "shasum": "a92642847591c207ecb5a9aea638a02f0e8dfd81f21bb9c32f3ba9d52723f9f3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rubrik_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_linux_386.zip",
+          "shasum": "092066d5541c5f9abaa91b012ef56442a5c65a9990ba1bd5e06e75602e0009e5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rubrik_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_linux_amd64.zip",
+          "shasum": "ff8fd494913b259db1bc58749d622139ee41e575a47cae864bb283df7fab7a2a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rubrik_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_windows_386.zip",
+          "shasum": "7282e55277395a690c431beb886d0315879b8651fa3159f1e3214c644bd0b92b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rubrik_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-rubrik/releases/download/v0.2.0/terraform-provider-rubrik_0.2.0_windows_amd64.zip",
+          "shasum": "06c9e7937ada93b1c4479994a6f27ae93935b761e6f2fd5f22bfbf5fcadf3338"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/runscope.json
+++ b/providers/h/hashicorp/runscope.json
@@ -1,0 +1,274 @@
+{
+  "versions": [
+    {
+      "version": "0.6.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.6.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_darwin_amd64.zip",
+          "shasum": "f5b8979dabe6dcaeb46f15d7c77e1b70dc350bfad7e340fe997d638ffb7879e7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.6.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_linux_386.zip",
+          "shasum": "534de2576d9240d5f0806b910486457a6e43af2621c07a4f3108f6d5279af88f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.6.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_linux_amd64.zip",
+          "shasum": "8325b79bc12553a920162fb1f0ae9fb004db3ab85210c694032eea1306114893"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.6.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_windows_386.zip",
+          "shasum": "5c6765287020c82b1032675b193575404d0a90a85107cdcb5fc9b02596588cbf"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.6.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.6.0/terraform-provider-runscope_0.6.0_windows_amd64.zip",
+          "shasum": "cab49be47b3faaa4329c65d18e9509b684b24e5116e2bab1e1abd90264f578aa"
+        }
+      ]
+    },
+    {
+      "version": "0.5.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_darwin_amd64.zip",
+          "shasum": "071a3b99d322c6553fc1a8d668a5ce227a69345422f70c663bcfc17d3d0ff4a9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.5.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_linux_386.zip",
+          "shasum": "120040b2f9dc599ed4c581d522acc203355edd7d98f49de45c0843bb0aa02159"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_linux_amd64.zip",
+          "shasum": "7b77ebcadc4f3198f0fbe71c45a97b3f9e560133c2fb0c53aaa625cd183798e4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.5.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_windows_386.zip",
+          "shasum": "bb5003aa6a36c2792845e2b88d2e8a31921ab245b9bea55280675c6960179760"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.5.0/terraform-provider-runscope_0.5.0_windows_amd64.zip",
+          "shasum": "d495ffd9e018a73868349b9b5cac6367735eb787a7d0323511021cfd13e8ba44"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_darwin_amd64.zip",
+          "shasum": "4c153cc31eb1970113c2f09fe77f18d0799f8b7a5c895a63f78c18c67784ff6d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.4.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_linux_386.zip",
+          "shasum": "e186361f8cc4d64f0bbe16ce91331dffdce7f4499c2d3e6e03b0d3c26af39584"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_linux_amd64.zip",
+          "shasum": "c7e6a72f87db1fad0f0f26312338c51eda0282062e35d0d0c63f1f33c514b480"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.4.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_windows_386.zip",
+          "shasum": "fce4c2c817c06b2c1087645ab658062c9a287c20a8e7ee8ed00911d01e851312"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.4.0/terraform-provider-runscope_0.4.0_windows_amd64.zip",
+          "shasum": "430664b563a66de698407e76f851c18d13dccc16c44a664c0dfeb2b522ce3db2"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_darwin_amd64.zip",
+          "shasum": "38ea1faeca571c19e9aa7465497fdfe7352b87820d85bb96cade6fcd1f527cee"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_linux_386.zip",
+          "shasum": "e4ac988cebdab3c3e1b4ecfadab2ec0588f87f003f6fbede2fb08bc8853dff39"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_linux_amd64.zip",
+          "shasum": "0358889eaf778063254ac5ccc56577c6235ac58a0af1e141334a7dd92c8e80d4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_windows_386.zip",
+          "shasum": "70e03599b17336178f589c96d1a3ac8c917e21b4908fdd73f99464be49d3f47a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.3.0/terraform-provider-runscope_0.3.0_windows_amd64.zip",
+          "shasum": "1d88eccbc41616f248e16f3bca416a6c3e30dc39439e65f289473a457d67c1c6"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_darwin_amd64.zip",
+          "shasum": "cd04b63300a8b733058e5071003bce4914d5ac90b02c3eb143912f15bc6b4256"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_linux_386.zip",
+          "shasum": "cdaa67f06434a908593af73a1aee17fabbcaaaa70b9996cd3080e639ccc1e1d7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_linux_amd64.zip",
+          "shasum": "0225464bf8d7ec08926d1e72e1df000297c4351499a149e4c38ab9cf9eb6b628"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_windows_386.zip",
+          "shasum": "453c9a34431ef86e0a33f4d810e3c72f4cca4378a958da991bb397a78b7a0b40"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.2.0/terraform-provider-runscope_0.2.0_windows_amd64.zip",
+          "shasum": "5904a6a0e0488d1801cd5177954769138e92921e95be80026973185943dddbff"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_darwin_amd64.zip",
+          "shasum": "b67b701b0d65ee68df105f71953e26f368bc9d6d064c4603e15b11ab1559a984"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_linux_386.zip",
+          "shasum": "98358221af0266cbe212813a7beb41980619752b4386fe8884af0bb147b1c0dd"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_linux_amd64.zip",
+          "shasum": "c950f00df3dcc3ce921506c163ce9182ad7a8577734fd6c7b1fef89a153206cb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-runscope_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_windows_386.zip",
+          "shasum": "8bedcdf528e5a515a2e98ae77d409ef8707539792bcaa0f77df916ce12894045"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-runscope_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-runscope/releases/download/v0.1.0/terraform-provider-runscope_0.1.0_windows_amd64.zip",
+          "shasum": "35680fe6404a2d0a3a20b0b3988eb7710353a33c9d16312e76d4827ea7247440"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/softlayer.json
+++ b/providers/h/hashicorp/softlayer.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "0.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-softlayer_0.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_darwin_amd64.zip",
+          "shasum": "6e4603306555df356c8d45f00084c3da8286fb6849e826b058b89e81379c949a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-softlayer_0.0.1_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_linux_386.zip",
+          "shasum": "342d95a5350462c0bcbeec3caeea91feb7f1bdf6fb39bcfd55f7b3ec4bf48a98"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-softlayer_0.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_linux_amd64.zip",
+          "shasum": "dfff34d165c3c1ed87caead40e40715f60f49731f7cea9af0f8c3c34816ef787"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-softlayer_0.0.1_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_windows_386.zip",
+          "shasum": "695583728637b913ce3edb8710474ccc6bdb8c074196ef482278cfbaf519ce75"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-softlayer_0.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-softlayer/releases/download/v0.0.1/terraform-provider-softlayer_0.0.1_windows_amd64.zip",
+          "shasum": "3e5b67d03fb9c2ef9f7ec94d1853f4bbfefc42df809e18d0ca481114ca215d7e"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/telefonicaopencloud.json
+++ b/providers/h/hashicorp/telefonicaopencloud.json
@@ -1,0 +1,49 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-telefonicaopencloud_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_darwin_amd64.zip",
+          "shasum": "5ae0e621375dde024a77fa2a439c96fdd8776c6d8ed10b182964faf32ef7f6b2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-telefonicaopencloud_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_linux_386.zip",
+          "shasum": "7787439ea822a39c3c40a8395ebc4c8d1d9072de736f213fac7b12819e02c46e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-telefonicaopencloud_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_linux_amd64.zip",
+          "shasum": "b94bc7ea1a73cbb4914d6e5e15bcf6cbb7958d131ef7cb2ef7f24ac123f2c40b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-telefonicaopencloud_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_windows_386.zip",
+          "shasum": "87a1fed01dbf21c5d3bbd3d253ebfe55e528ff0dfe9553fb7d7b423f31ee02c3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-telefonicaopencloud_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-telefonicaopencloud/releases/download/v1.0.0/terraform-provider-telefonicaopencloud_1.0.0_windows_amd64.zip",
+          "shasum": "128ff94a41e0ded68a71157f67b9945e666c59f2fa69b9214da22621bfc95d31"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/ultradns.json
+++ b/providers/h/hashicorp/ultradns.json
@@ -1,0 +1,94 @@
+{
+  "versions": [
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_darwin_amd64.zip",
+          "shasum": "f691e60b9696f425ec5766f02e759763611e3ea4f64567db4f32ddbd7f969b49"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_linux_386.zip",
+          "shasum": "3dbda45517f8328726b4a7dc6cb7af6cbb89d73df5fc3493f5f70dbffdcd54aa"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_linux_amd64.zip",
+          "shasum": "47e1fc10c2b724e211353e262423656d4da0886523ac4768cc4189a1067256fc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_windows_386.zip",
+          "shasum": "faa22f7b33ad36b73ac7fbf6dd4f9fa69f9bafe905e8d9e867d160b34eae7fb5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.2.0/terraform-provider-ultradns_0.2.0_windows_amd64.zip",
+          "shasum": "533386bd347ec9042049515d9f526c945dc43a0c800d0f548c8dd4eb84b71608"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_darwin_amd64.zip",
+          "shasum": "384232a866acb7f5b7a20fbf85b57d6643a04127b1a26dadfcd09e6276e27b35"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_linux_386.zip",
+          "shasum": "334e0a2658ad7f855e04020b2e53b1830ff9e35a13638d7c16b06f30cf154844"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_linux_amd64.zip",
+          "shasum": "085c47a00d5d3351ec569886acc2ae31825590745f76c18b6e8d7b78cf845da9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-ultradns_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_windows_386.zip",
+          "shasum": "d5e16e30ab3a3fbb4303d4782c8f48ccb445ee18333d6ef344f28bc7e372f436"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-ultradns_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-ultradns/releases/download/v0.1.0/terraform-provider-ultradns_0.1.0_windows_amd64.zip",
+          "shasum": "1cd7de425074f71ae492d84d2f638a0faa81f5e66db85d944f301c452795268f"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/h/hashicorp/vthunder.json
+++ b/providers/h/hashicorp/vthunder.json
@@ -1,0 +1,184 @@
+{
+  "versions": [
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_darwin_amd64.zip",
+          "shasum": "b8a395f3b5ed0575e15f8dedd69e212b31cc0542f4be7090e409b936f87cfe84"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.4.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_linux_386.zip",
+          "shasum": "f78c4d45cd8c7381d005078b2aa2506223e32ab9567917e98148f61eff6fe720"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_linux_amd64.zip",
+          "shasum": "829f69fa942a4048eb5d730ffde8ca1ff308de160768406683c10a4b1dde5f92"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.4.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_windows_386.zip",
+          "shasum": "4e595e2717cdaca69d4622d15a0b4c132537a2d03e9c57546a683f9c00ef24b3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.4.0/terraform-provider-vthunder_0.4.0_windows_amd64.zip",
+          "shasum": "8cf0b3eba700460632313e91f8d6554fdcd9bad5e7408742f3e054022f809a3e"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_darwin_amd64.zip",
+          "shasum": "348942f06ca51be648fc17d066732ecbd74e6cbb3ef3ba2496d0c24c359869de"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.3.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_linux_386.zip",
+          "shasum": "1ccfdec8973f3eae338795c53678defcfe87e41a0eeb6d02d7973374461b4eff"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_linux_amd64.zip",
+          "shasum": "49778d8560ef9424a0f30c91a5c5b7a51ce7991cb41f48d23e9b5128fa167269"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.3.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_windows_386.zip",
+          "shasum": "50ea468fb17d03fc65144a4bfd0559016ea7812292760d8902b1f6aa69742a4b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.3.0/terraform-provider-vthunder_0.3.0_windows_amd64.zip",
+          "shasum": "e51802dd605b4756888d5f174cf0988984fcfb5a1c1a820e92ee6f880080b03a"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_darwin_amd64.zip",
+          "shasum": "2f61c1f68ef075e6d91a645905698c94e0e900fd5431d8120465aa882dc49189"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_linux_386.zip",
+          "shasum": "62b23335f8a39b960fadb33d358ff7d7c31b0c0487de5370a2f5c3a00c5efcd8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_linux_amd64.zip",
+          "shasum": "f94494d9f133f17bb931a0252a40df0b515c4526eb7f5f20a22548b0d16b26e9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_windows_386.zip",
+          "shasum": "fe14c9862d746177d2c7efe5721ce4af05b27863bb49ae1128971cdf47457e44"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.2.0/terraform-provider-vthunder_0.2.0_windows_amd64.zip",
+          "shasum": "3701cf6a0cfb879bc971b1aa3a478929df8cbff71e14dcf0dab99051e168d69c"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_darwin_amd64.zip",
+          "shasum": "2ba827b3c55409e98c419e76571b808da4b58cf13b8d4120db9541bb474208b5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_linux_386.zip",
+          "shasum": "58821c21548a2cdf215248966af76ce3cf473fe78fd823284ccdbd011773f0d8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_linux_amd64.zip",
+          "shasum": "308249e6b13d2851afae4eaf875ff7ff837bcd4740547f9afc56911669a994e3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-vthunder_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_windows_386.zip",
+          "shasum": "5e6c0b457bd3dfa708ad9306e627fe535c6fd47aaa420faac12e40d50e2d6110"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-vthunder_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-vthunder/releases/download/v0.1.0/terraform-provider-vthunder_0.1.0_windows_amd64.zip",
+          "shasum": "c142c2d51a11f306fc81378e4932908b18a5f9499d9ff6ab1b3dbd7cc813953d"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/j/jfrog/platform.json
+++ b/providers/j/jfrog/platform.json
@@ -1,0 +1,220 @@
+{
+  "versions": [
+    {
+      "version": "1.0.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_darwin_amd64.zip",
+          "shasum": "851b242c80f4db14995a1d0b5cc0da753ccf9c60eec19a89fb5f33dbf14f57d9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.1_darwin_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_darwin_arm64.zip",
+          "shasum": "2720722cdb4d95f0a9786b60010ffac7663825263be49487731788f04a95cb9c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-platform_1.0.1_freebsd_386.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_freebsd_386.zip",
+          "shasum": "884930f6d27dc3f356f926a6d0e18efa1360a839f43dad7cae852926c743b64f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_freebsd_amd64.zip",
+          "shasum": "78d42aae9785b9d353feb15050213c6f5fc339dea1e08aa1c919bed2e61e5d0f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-platform_1.0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_freebsd_arm.zip",
+          "shasum": "5e8f5876a10653744c3c91062da2ee5f71559675e29121c27c928a040502899f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_freebsd_arm64.zip",
+          "shasum": "c29f099b472b10d40b801837796de92975532c928342a0797b5a5c6148f2d8ac"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-platform_1.0.1_linux_386.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_linux_386.zip",
+          "shasum": "7656d646848daadc3e5daf89a93fa98e6cb2aa1bfeeb85de5ba34a91341c2d07"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_linux_amd64.zip",
+          "shasum": "d36ce5b42c1788ed2528d6ab509e1ef08c415b558dfbd504bd728cd1c714c39a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-platform_1.0.1_linux_arm.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_linux_arm.zip",
+          "shasum": "ea00bfafa041202ea985549cba776f5a7132d3ddfe20a89bb9622fcfd8150d45"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.1_linux_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_linux_arm64.zip",
+          "shasum": "2bfa13e662b7e51c6c1920501f7e94507dc94dc263828a2bd1ed352bf7f7cdfc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-platform_1.0.1_windows_386.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_windows_386.zip",
+          "shasum": "463540a7cfd0298297f73411c2d9e9d3d9a419be7d3d583da9f529483fe9dfa5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_windows_amd64.zip",
+          "shasum": "97b48202b794b8196fb76c18162cdd80c61c9d63b84dc5bae99c34b48f1bf013"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-platform_1.0.1_windows_arm.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_windows_arm.zip",
+          "shasum": "74a89e4e94699dc6bebd3bf4c7d2465587734e2e1b9681812c8ea867f92274b9"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.1_windows_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.1/terraform-provider-platform_1.0.1_windows_arm64.zip",
+          "shasum": "eb0d33c79701f750c901572ae3c580cb7c4d2ff0c3255c5b69f06b9e9db9c9e1"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_darwin_amd64.zip",
+          "shasum": "d7a888c726a864f61d3e32b3d8dafb334e09c7f527850f5fec398328b1cb2782"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.0_darwin_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_darwin_arm64.zip",
+          "shasum": "44bcd28276bb9f601621adfe024b9c4d67f801c8d4b7d8dcf91aa15206356e20"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-platform_1.0.0_freebsd_386.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_freebsd_386.zip",
+          "shasum": "a0b70e005124bdad1c17636d0ab9a480a0362ecf999b00b1351888593cafb053"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_freebsd_amd64.zip",
+          "shasum": "d93712fdafe356da940153bd289594dc25f467feefbdcd33ac100dfbb2e4b3da"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-platform_1.0.0_freebsd_arm.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_freebsd_arm.zip",
+          "shasum": "eeb134599f76b91d88f352e881fc51245dbd8786731f3565aa6278b2458bc00c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_freebsd_arm64.zip",
+          "shasum": "e8102bb57ea7153bc9008905a4bb2506c6f4e68ce14bd858081079f6675687e1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-platform_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_linux_386.zip",
+          "shasum": "f977320b87938d798fbb4a7949294e1766b6f169fb0d03580655f88a737d2947"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_linux_amd64.zip",
+          "shasum": "9d23071e8bbc567d5c00148413f0b0ae7595dde827855d0555636150a92e7065"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-platform_1.0.0_linux_arm.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_linux_arm.zip",
+          "shasum": "207ec2cfb081c339ae9fe1184e4173c83f61d72a0adde452e36e814a0070883d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.0_linux_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_linux_arm64.zip",
+          "shasum": "c6a1928bc86010f4e91e1a1f41ac1b60e3a4f88fbbd4a69017789113101da635"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-platform_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_windows_386.zip",
+          "shasum": "8dcc76025b846683e5e13bb5441f68ec9575c4a80df85a2fb92160913ba62bd0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-platform_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_windows_amd64.zip",
+          "shasum": "ed3b449048866cb39e195cfd62aef5587ce3cf68f2ded92c635bf88c8b9ac9f2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-platform_1.0.0_windows_arm.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_windows_arm.zip",
+          "shasum": "3c7d1d0b6fd6051770f68557c3ef9ab63ff2105bac1b2ec43beb8de178e7ed98"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-platform_1.0.0_windows_arm64.zip",
+          "download_url": "https://github.com/jfrog/terraform-provider-platform/releases/download/v1.0.0/terraform-provider-platform_1.0.0_windows_arm64.zip",
+          "shasum": "8df4a0ab4c3ea8e001e224610334fef6083e4a234a19ef2640a4ba5663caa4c0"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/k/kiwicom/misc.json
+++ b/providers/k/kiwicom/misc.json
@@ -1,0 +1,112 @@
+{
+  "versions": [
+    {
+      "version": "0.0.1",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-misc_0.0.1_darwin_amd64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_darwin_amd64.zip",
+          "shasum": "dce4b6d987a31ce65e76c8c2425349d24095f3ad583e5d9fa40e79e911b8c2f8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-misc_0.0.1_darwin_arm64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_darwin_arm64.zip",
+          "shasum": "6f5edef96fbf263b6b2f492f639b4ff7dbd9f9f1f99b42982d460154a061eb24"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-misc_0.0.1_freebsd_386.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_freebsd_386.zip",
+          "shasum": "e4be823c20dc96b19a46c3a2be69bd975f02c927d64607155b0006d63fef8a1d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-misc_0.0.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_freebsd_amd64.zip",
+          "shasum": "48be63317387606c9adc30253cb010b4ec9a0d355d698cf9a5763786e80dbfe0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-misc_0.0.1_freebsd_arm.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_freebsd_arm.zip",
+          "shasum": "0542c419390b7b6aab90269311ddb7acebcbd95fa59d73e660948ef09a4f2e04"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-misc_0.0.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_freebsd_arm64.zip",
+          "shasum": "ca39e944c908b0bbb1c01934f7c9b0351ca33a25c4a4d463d60e269571e705ea"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-misc_0.0.1_linux_386.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_linux_386.zip",
+          "shasum": "2415698d81e9d88aa62219acffd2cb3b7a220f871c189d7506880f09ae46bd0c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-misc_0.0.1_linux_amd64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_linux_amd64.zip",
+          "shasum": "67dc74ee14624067ecffced0052eb9ada5c110f5c7e7d9e3abd1eceb566b5453"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-misc_0.0.1_linux_arm.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_linux_arm.zip",
+          "shasum": "90f383a8da8b4d58fcfaa6b6b710fb438eef9f65aaa4f42a33f91b3b70e13128"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-misc_0.0.1_linux_arm64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_linux_arm64.zip",
+          "shasum": "02b64bdafa8dbe263bd6917fd82b53a3b1b06ea54d904ba087e8f4bf5274c845"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-misc_0.0.1_windows_386.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_windows_386.zip",
+          "shasum": "162ee2bbfc7eca4425d2c55f136044518514b9c934c601debf7e6bde2e3671c4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-misc_0.0.1_windows_amd64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_windows_amd64.zip",
+          "shasum": "22e8c258ecb4df4483ddece9647faf58cbb4a163e075a01c318bfcfcf004e3aa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-misc_0.0.1_windows_arm.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_windows_arm.zip",
+          "shasum": "315d2e9923747037b4eeb3d3ba8582ad69cf89acbf6e59ed5063897b077616bc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-misc_0.0.1_windows_arm64.zip",
+          "download_url": "https://github.com/kiwicom/terraform-provider-misc/releases/download/v0.0.1/terraform-provider-misc_0.0.1_windows_arm64.zip",
+          "shasum": "754dde73dc3cd07d79a4e9f08ef67759e1f3537c25dc5bfd345f08a10d1de46c"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/l/LumenTech/lumen.json
+++ b/providers/l/LumenTech/lumen.json
@@ -1,6 +1,100 @@
 {
   "versions": [
     {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-lumen_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_darwin_amd64.zip",
+          "shasum": "231e2442d38462f1ce4407e4538472188cbd88f3e7ac2c1bf4323b71e90169e7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-lumen_1.0.0_freebsd_386.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_freebsd_386.zip",
+          "shasum": "4d4f481465abf48e00dc894d8719ffe6454aa9705a3c3fdf4017ce2c45d6affb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-lumen_1.0.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_freebsd_amd64.zip",
+          "shasum": "b34ba96fd67135a9f2ca27dfe69d0b26e5184c8897313d4ab2c990ad41ef85b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-lumen_1.0.0_freebsd_arm.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_freebsd_arm.zip",
+          "shasum": "c9132bf444c149c7a1da0c9224ba856dc604ad59d7ea1976cde6b0a0e604cd17"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-lumen_1.0.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_freebsd_arm64.zip",
+          "shasum": "c42343a88e272e9edb4076f42616a32722e45e8430e16b886aae3932af32d821"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-lumen_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_linux_386.zip",
+          "shasum": "b97ad5d282da5e26cbda7c690186b98c09686e4d4fb132d4e41af90a62263182"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-lumen_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_linux_amd64.zip",
+          "shasum": "d4ec39111e4564864664f02ed239b37350b6f3f1ae448a7c8a47d95ec8556a58"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-lumen_1.0.0_linux_arm.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_linux_arm.zip",
+          "shasum": "42232f33a9e0087fdb7b8edf8b45285cbc564a0f56346924a8c3c04dbd66486c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-lumen_1.0.0_linux_arm64.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_linux_arm64.zip",
+          "shasum": "c189029b904841fd669af7bce133e9de866ce0bf7a04c7af4f58999fc8c3dd5d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-lumen_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_windows_386.zip",
+          "shasum": "9654c248997c4d1d20fc76e4a95d20369c5bb827f9b132487a2f6595f446414d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-lumen_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_windows_amd64.zip",
+          "shasum": "bca71cdacda83886bb1d0c97bae820e000d0a2376795690e1e4ec44c286d8003"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-lumen_1.0.0_windows_arm.zip",
+          "download_url": "https://github.com/LumenTech/terraform-provider-lumen/releases/download/v1.0.0/terraform-provider-lumen_1.0.0_windows_arm.zip",
+          "shasum": "eb11b1e621947207d641ac86b419614f2c7b5edb0e482e97661513472884745d"
+        }
+      ]
+    },
+    {
       "version": "0.6.0",
       "protocols": [
         "5.0"

--- a/providers/l/logicalclocks/hopsworksai.json
+++ b/providers/l/logicalclocks/hopsworksai.json
@@ -1,6 +1,114 @@
 {
   "versions": [
     {
+      "version": "1.10.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_darwin_amd64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_darwin_amd64.zip",
+          "shasum": "826e3ed9628c6d6f63947bdd0102c85030be58500f905200abed098ec2ab8585"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_darwin_arm64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_darwin_arm64.zip",
+          "shasum": "d633746550e905a3e77bac253c27d2554c59a7002991f61b77c1a83832fbaf89"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-hopsworksai_1.10.0_freebsd_386.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_freebsd_386.zip",
+          "shasum": "33a2e8efc72666b7d56412b2142671eba9c6851c35de32a56adac0aa83ef3cad"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_freebsd_amd64.zip",
+          "shasum": "c2123c40f720e58d2fec4ff4322a19a7ab77141530fda94e15c69f0554ce5e6d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-hopsworksai_1.10.0_freebsd_arm.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_freebsd_arm.zip",
+          "shasum": "c5d1dee05838be58ca120ae09da9884dd6c2c8d5bc14bb46a81f841170907a28"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_freebsd_arm64.zip",
+          "shasum": "078b04e82796be95f331c84481048df961a6b51be23c1173eb52c997b9be1a49"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-hopsworksai_1.10.0_linux_386.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_linux_386.zip",
+          "shasum": "ed1d4ed0af764c28df28d7dc5cff4ab476a6c57222577832b35f34e97b67dcd6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_linux_amd64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_linux_amd64.zip",
+          "shasum": "434b6c042fc83bef9c1c9b41679b6a7c6fd08bab210f09985d366a97562a12b2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-hopsworksai_1.10.0_linux_arm.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_linux_arm.zip",
+          "shasum": "111a0298e17a00c318522238773468c1194d5b07ea462e8124e34642f7f6f0fb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_linux_arm64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_linux_arm64.zip",
+          "shasum": "f1ff2a2d6688abb6280cf97f344aece2d05e2eb967d161aa71f2a3d85dabeb85"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-hopsworksai_1.10.0_windows_386.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_windows_386.zip",
+          "shasum": "7969533cece1a91be9bfebca3e06a77b762a5e22668d2ea66944b7fc61c7b3f6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_windows_amd64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_windows_amd64.zip",
+          "shasum": "e9ee2f9b0cd56dd255cff4f978879a594b1e440b314342199905a3c2fd241151"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-hopsworksai_1.10.0_windows_arm.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_windows_arm.zip",
+          "shasum": "883ab9e6ba586cfa2ecb51211b134900e4d6a598f44957c3f0e92d96cabd3dc1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-hopsworksai_1.10.0_windows_arm64.zip",
+          "download_url": "https://github.com/logicalclocks/terraform-provider-hopsworksai/releases/download/v1.10.0/terraform-provider-hopsworksai_1.10.0_windows_arm64.zip",
+          "shasum": "de4edc5ac5c14f7a2d79526834cea4048b29719e79a6595c0ba9339c546f2ac1"
+        }
+      ]
+    },
+    {
       "version": "1.9.0",
       "protocols": [
         "5.0"

--- a/providers/o/OMO-NOSA/etcd.json
+++ b/providers/o/OMO-NOSA/etcd.json
@@ -1,0 +1,98 @@
+{
+  "versions": [
+    {
+      "version": "1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-etcd_1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_darwin_amd64.zip",
+          "shasum": "f704474f7c8cb18baf5a2b379b54427c05ecf1feca957879696b885fa4c412c7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-etcd_1.0_freebsd_386.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_freebsd_386.zip",
+          "shasum": "59db01295a12d7c74f2569c59cd54052bf67c5cc03149c85af28de475badd2be"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-etcd_1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_freebsd_amd64.zip",
+          "shasum": "69a3fe7c5581ce84bdc0503dcfbd81e35c3957821fe4cd06316215be6be147fa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-etcd_1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_freebsd_arm.zip",
+          "shasum": "c4e2847f68b41816252eff5899e5bfe6eab5632804ee67152eaba89a9e873a6e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-etcd_1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_freebsd_arm64.zip",
+          "shasum": "3a2b6014b6142d704258fce629bb05556369e65295f6cbd25ace06dce5ae29e4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-etcd_1.0_linux_386.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_linux_386.zip",
+          "shasum": "8fb506ad3d3ddbe33253d8528b8b836d20c19bab90629833cf8c29edc9ca5488"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-etcd_1.0_linux_amd64.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_linux_amd64.zip",
+          "shasum": "b5a6e4ce6cc2fa671caecab5af9472c4fa96b838ba343ba6d6c654f7d5e6844c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-etcd_1.0_linux_arm.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_linux_arm.zip",
+          "shasum": "470127303df716421ba82a49445c69727f5f603dcbd80575d78ef9bf4d638354"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-etcd_1.0_linux_arm64.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_linux_arm64.zip",
+          "shasum": "2877d1d4ef9377a15ad6ed70a172fe40ef877f3f23e09341da19368b9b053e0b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-etcd_1.0_windows_386.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_windows_386.zip",
+          "shasum": "abc3aa2c0f3fbe73cb065826fdccbcc393be11f5443cd9370107632147a4fa1f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-etcd_1.0_windows_amd64.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_windows_amd64.zip",
+          "shasum": "77952e5ee356561a2aba384b82cb706dab6bd961f972c682fb774c5621142d2c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-etcd_1.0_windows_arm.zip",
+          "download_url": "https://github.com/OMO-NOSA/terraform-provider-etcd/releases/download/v1.0/terraform-provider-etcd_1.0_windows_arm.zip",
+          "shasum": "46ef5e2c03114b64406ea2492cbef0eb973ac29e77b00b23b4ecb5bb7dc460de"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/o/opentofu/cloudinit.json
+++ b/providers/o/opentofu/cloudinit.json
@@ -1,6 +1,86 @@
 {
   "versions": [
     {
+      "version": "2.3.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudinit_2.3.3_darwin_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_darwin_amd64.zip",
+          "shasum": "21e7ab6820990f314de03be87af71cb4bae2409fa18007d11cfa60066a7f924c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-cloudinit_2.3.3_darwin_arm64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_darwin_arm64.zip",
+          "shasum": "af20410183201bbbe4e13f7fa69f0a57eea5b925e3092036f1aaa2767f1a7516"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_386.zip",
+          "shasum": "bbb60400a2c17aa31728b348d4f7ba2de8a20b014b0c0658c7ff1f54a4e1f776"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_amd64.zip",
+          "shasum": "5ab08771183c7dd6070ae95be84154540f15c41b34606e55fe87639e0bfddc0c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_arm.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_arm.zip",
+          "shasum": "132f1782bb198a635892ea4b116fd69ffabcf4b6b11f86c57faf53b19575c23d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-cloudinit_2.3.3_linux_arm64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_linux_arm64.zip",
+          "shasum": "e8cd5c617707b5e5f78a2dba45e864b7690930f39aa6c84e9455e9f3943cb83c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_386.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_386.zip",
+          "shasum": "2cf69cac676eb20e5f82b1dbb739c30b963fd6010e430e1b0bf3dfedc6554000"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_amd64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_amd64.zip",
+          "shasum": "f43b99f6b6d581d2745e4f0cfdeb0425f381c113bebf2cc95c08c8f8c2d6506b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_arm.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_arm.zip",
+          "shasum": "3c508f6ef48fc8073d2e4ebd1ea1532b52e4d7ac679908d73891e8f4b451a71d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-cloudinit_2.3.3_windows_arm64.zip",
+          "download_url": "https://github.com/opentofu/terraform-provider-cloudinit/releases/download/v2.3.3/terraform-provider-cloudinit_2.3.3_windows_arm64.zip",
+          "shasum": "2a6a71194f3923ba6136c8a17765f505fa3e20624f4cd1078f36bdb92cafbe00"
+        }
+      ]
+    },
+    {
       "version": "2.3.2",
       "protocols": [
         "5.0"

--- a/providers/p/pmw-rp/pmwrp.json
+++ b/providers/p/pmw-rp/pmwrp.json
@@ -1,0 +1,328 @@
+{
+  "versions": [
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_darwin_amd64.zip",
+          "shasum": "d0b90ff0c763fece91ec406085a354641a7dded55bb7268310d37e50e2b12efc"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.4_darwin_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_darwin_arm64.zip",
+          "shasum": "6dbe6068b26f1a3e3009aca46e75c013b50e30a3bb4de5cae262c76544597649"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.4_freebsd_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_freebsd_386.zip",
+          "shasum": "a33355abb8ce4f26a65ac23877eef6c83af9e3af341caa0115f803f24cdf5277"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_freebsd_amd64.zip",
+          "shasum": "6a81cacb27a1b2dff2eda60d62665e593d3c2fbf9a3cadbfaa07f00fcee14d82"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.4_freebsd_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_freebsd_arm.zip",
+          "shasum": "f954faa282ec59824ac133ea30e4bedb9b3778dbd04cff2ca01b6e1b300ab34a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_freebsd_arm64.zip",
+          "shasum": "5ad99b0e6f6d03d3f6bb3f578bcd13a8b425cc43d6a10b645097984954642f81"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.4_linux_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_linux_386.zip",
+          "shasum": "a07320c15e007cf9d89f41f9760ea6052d31f66e4476580981405b43cca7e98c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_linux_amd64.zip",
+          "shasum": "2212b46492ebe15a526732d686b7840d59170ee6522e6c075647b8c64d105abc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.4_linux_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_linux_arm.zip",
+          "shasum": "2ba756e3ee52a469e8454aaa4bf7115e3d887b8e0ce46b3bcd46632a263dfb17"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_linux_arm64.zip",
+          "shasum": "880f4779a76fb2b1b292e5f17d1abe5fc80b09d077449d11ac586eb3a65a70c9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.4_windows_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_windows_386.zip",
+          "shasum": "595cb43793e36294c57941f4286e684be2700f4d4952099661241cd1b3efbce0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.4_windows_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_windows_amd64.zip",
+          "shasum": "2b140eb2527c164f2986cf4e3d0a2bec49c89a84f89a4d8a4770defb1f3a2534"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.4_windows_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_windows_arm.zip",
+          "shasum": "23655a044cd734616bcaa3d49943918d023a482be8dca8931b9fb0ab2988dbed"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.4_windows_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.4/terraform-provider-pmwrp_0.0.4_windows_arm64.zip",
+          "shasum": "ce6eb13522aa2e50212a98b36830166803cd611c29133d7018652a93d7b5d8a4"
+        }
+      ]
+    },
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_darwin_amd64.zip",
+          "shasum": "97dc064cd52d9058d91cd9438e1a51cf1d3fab6a7d3e12968a685dd2d4ec9a80"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.3_darwin_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_darwin_arm64.zip",
+          "shasum": "e4aebe352f55a66e873fa11b32c6ab634e9003236a3a5388a984cf8a2f87a28f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.3_freebsd_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_freebsd_386.zip",
+          "shasum": "0fff4a5ee9ee47d0fac8490a5032f35fd2145b7402a7a58cdecf4abcae0e15f8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_freebsd_amd64.zip",
+          "shasum": "5bd546d9161a0cb576d871c7baff0fabbd99887597e27e38e7a8870e3307ea5c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.3_freebsd_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_freebsd_arm.zip",
+          "shasum": "e381ffab8b07af15665005a23521fc9f78f13c4dd0aca402244768ab70e95259"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_freebsd_arm64.zip",
+          "shasum": "6e19afd9e79fef9a9a807711d4bd4c84144407ae06a9d0c11a11830055773dbf"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.3_linux_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_linux_386.zip",
+          "shasum": "9e0345031e21b39eb27bab07278660368ae53cc70d2e03d27f4dc0691e1d58af"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_linux_amd64.zip",
+          "shasum": "787ae1abbc4a7c48fbb0b1969cf31ad1b95cce04d5ce43184b95f72c13a3edc1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.3_linux_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_linux_arm.zip",
+          "shasum": "d38e165d304d1e1ac18f5030e198e5ad693185bc62ca4fc579c5981efdc2159e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_linux_arm64.zip",
+          "shasum": "a5b6acffefb8f25045ed76b47516f3a5c90cb664cf84ff86370a0abee935991e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.3_windows_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_windows_386.zip",
+          "shasum": "f80fe8ac9935ab76622ff58d2a8dcfb504057b1a282263ca3c03832c6b4f6535"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.3_windows_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_windows_amd64.zip",
+          "shasum": "07e7eecb2de1ce7faf4deaa71095d5e1d21bda03fbde93b4cff2b20ae577ab36"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.3_windows_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_windows_arm.zip",
+          "shasum": "73b08e68025acfe63daa0a9d231d4b26e75d2c5fc27e0c6ccf028202326cbd44"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.3_windows_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.3/terraform-provider-pmwrp_0.0.3_windows_arm64.zip",
+          "shasum": "c3baabfeac76ae4082ed4be1da860d78bb7f5a6aa45a545657f1ba3f37999747"
+        }
+      ]
+    },
+    {
+      "version": "0.0.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.2_darwin_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_darwin_amd64.zip",
+          "shasum": "3d8ffb6e1d601dddbc5e17ed6fd3350452e000823c37598cb7b9186a78962a03"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.2_darwin_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_darwin_arm64.zip",
+          "shasum": "662197b3b40da713cdb7d88ac0e6631547432cff106b7c8f14dc1efcf0232dc9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.2_freebsd_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_freebsd_386.zip",
+          "shasum": "7ed529bbea1ea7aa13e9ad2520b17e7a5c968318c651550fb9f639c0a44690ff"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_freebsd_amd64.zip",
+          "shasum": "ab3f864b23ae2bda5956fc391735601bd1d5ddf284de536546a1d0e41b83c04f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.2_freebsd_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_freebsd_arm.zip",
+          "shasum": "aa60617f6c8e424bd6f16f772377c757865049e7f6f4a16da342298199c8cda9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_freebsd_arm64.zip",
+          "shasum": "ca2d897e479729b16ea387157fbec76b5e01dd698e2b58aa226aebc1a9db5b65"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.2_linux_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_linux_386.zip",
+          "shasum": "e44877c3d58e9fe567ca80dee73cfe2f1f438ea44aa14d0092b0b09a7b1012d7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.2_linux_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_linux_amd64.zip",
+          "shasum": "fa942b8198cdac4437ec26369afcc27ef629e5bb0a5c96d957030a3bd6d1eafd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.2_linux_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_linux_arm.zip",
+          "shasum": "fcc2923ba84c5a728ee2cf8f8b74d7e597d870ac1bcede153e18d3071aa8e524"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.2_linux_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_linux_arm64.zip",
+          "shasum": "abd303e28f21b246dd7dc777dfe1000f97ace8fb68a22fad96526889bf1013ac"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-pmwrp_0.0.2_windows_386.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_windows_386.zip",
+          "shasum": "f6b95a2c50caf8123f53f4bc87a8582dc4e4667b657ccac0bb66a1e3c1ea404b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-pmwrp_0.0.2_windows_amd64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_windows_amd64.zip",
+          "shasum": "6395fe695f769730ab95f21601dd08c91d9633618835df2ed16efa1fa3cc1bb0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-pmwrp_0.0.2_windows_arm.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_windows_arm.zip",
+          "shasum": "2a3bb152258067ade1b6ed2fd3c2868473d48f503d23c0d0c6bd8d12308720b7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-pmwrp_0.0.2_windows_arm64.zip",
+          "download_url": "https://github.com/pmw-rp/terraform-provider-pmwrp/releases/download/v0.0.2/terraform-provider-pmwrp_0.0.2_windows_arm64.zip",
+          "shasum": "47e3c89a1cba77d7644cc08617de6a4730c5a7fbd2b5763084ef836a6d56532b"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/t/tencentcloudstack/tencentcloud.json
+++ b/providers/t/tencentcloudstack/tencentcloud.json
@@ -1,6 +1,114 @@
 {
   "versions": [
     {
+      "version": "1.81.52",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_darwin_amd64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_darwin_amd64.zip",
+          "shasum": "3eb8a592a130e7cafb25a3fca7c6ca88077719a65d3edf99b434bf698f13c354"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_darwin_arm64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_darwin_arm64.zip",
+          "shasum": "790ad6914d410116f94e39f1c6448de159b7f7f2eb81aabe9514329d994a99f1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-tencentcloud_1.81.52_freebsd_386.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_freebsd_386.zip",
+          "shasum": "e8598ec9a5a5c18e5b77ea60475b06d55900d4053fa98bae0ad8355a3e555a4c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_freebsd_amd64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_freebsd_amd64.zip",
+          "shasum": "6376f95c72980e4dd777f9fc5e47e1a5e1f6a1b915cabc841a6a07270e6fa1a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-tencentcloud_1.81.52_freebsd_arm.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_freebsd_arm.zip",
+          "shasum": "7548b668caba4841bc06cc08e5a896d7410c309de5dacf615df68d9e6f31d829"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_freebsd_arm64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_freebsd_arm64.zip",
+          "shasum": "e472c823fddb6006f4c2eb9ddc800c184739b5100222481fead56bb76e260e78"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-tencentcloud_1.81.52_linux_386.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_linux_386.zip",
+          "shasum": "6d403560f4c8a8b59460c2274d1428f0f0c6cae8bb14be66fc75cbd80ba0d384"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_linux_amd64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_linux_amd64.zip",
+          "shasum": "13d567d49362ff71d426ee3176da3c6858dc013ddec4619df813aaa3a798e1f5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-tencentcloud_1.81.52_linux_arm.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_linux_arm.zip",
+          "shasum": "fed6a884de2710d581b2beabd6f65f6058e9430dc0ca1dfc7e423c9a691dd275"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_linux_arm64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_linux_arm64.zip",
+          "shasum": "9693b43fb50508c6956599016022a77896b834f9030d228424eccb31134e27c5"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-tencentcloud_1.81.52_windows_386.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_windows_386.zip",
+          "shasum": "e6331bd4f907b5af117df7e2ffd179c2909b3f4f0143d11c01f0352aabb056ad"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_windows_amd64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_windows_amd64.zip",
+          "shasum": "688951c59871d1987b3117911bc5e926d5a7fc09188756071d30e8d06940f3b5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-tencentcloud_1.81.52_windows_arm.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_windows_arm.zip",
+          "shasum": "32e7dea76d20a69e1461417412b634c3d4d5c15bec43461d3e24bc32b000edf2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-tencentcloud_1.81.52_windows_arm64.zip",
+          "download_url": "https://github.com/tencentcloudstack/terraform-provider-tencentcloud/releases/download/v1.81.52/terraform-provider-tencentcloud_1.81.52_windows_arm64.zip",
+          "shasum": "45d0ff3efd6dfa710f2bc9356a6261570a609ec5618773dd6f5744b9bd72f050"
+        }
+      ]
+    },
+    {
       "version": "1.81.51",
       "protocols": [
         "5.0"

--- a/providers/t/trajan0x/helmproxy.json
+++ b/providers/t/trajan0x/helmproxy.json
@@ -1,0 +1,156 @@
+{
+  "versions": [
+    {
+      "version": "0.0.6",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.6/terraform-provider-helmproxy_0.0.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.6/terraform-provider-helmproxy_0.0.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.6_darwin_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.6/terraform-provider-helmproxy_0.0.6_darwin_amd64.zip",
+          "shasum": "ce7f9f4a4ed00c93bfb004da21d2dae3af73a120063b1413ebe29229be932143"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.6_darwin_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.6/terraform-provider-helmproxy_0.0.6_darwin_arm64.zip",
+          "shasum": "9bfa5f7cadc29f2deb9c404a28d18ffc000e4bac769263311e160d85854cd38f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.6_linux_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.6/terraform-provider-helmproxy_0.0.6_linux_amd64.zip",
+          "shasum": "ce1e9688f7669c8eb2261549e89647e22838bbb7ef2b68c298f34b676677e696"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.6_linux_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.6/terraform-provider-helmproxy_0.0.6_linux_arm64.zip",
+          "shasum": "97eb1bd787ae025fcde20c997d63c9bce16d74a126d53510b1d461ea1fa164f7"
+        }
+      ]
+    },
+    {
+      "version": "0.0.4",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.4/terraform-provider-helmproxy_0.0.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.4/terraform-provider-helmproxy_0.0.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.4_darwin_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.4/terraform-provider-helmproxy_0.0.4_darwin_amd64.zip",
+          "shasum": "55561a779c751730cbfd08ed2c8d29f3082557a7cf552da57fe90b41705b362c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.4_darwin_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.4/terraform-provider-helmproxy_0.0.4_darwin_arm64.zip",
+          "shasum": "01a1ec8fd59a08ea221bf55707fb9c4196e04595b107804719e1e4799371e55b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.4_linux_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.4/terraform-provider-helmproxy_0.0.4_linux_amd64.zip",
+          "shasum": "96da0532d71632dc48296cba3b5db83c2d82c318aa79cda8d315363b51ea1bdb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.4_linux_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.4/terraform-provider-helmproxy_0.0.4_linux_arm64.zip",
+          "shasum": "267ea6c247c9d6b9b8f4cedba698f75e3ac89c36cb418a4981a7ebaee6982ba6"
+        }
+      ]
+    },
+    {
+      "version": "0.0.3",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.3/terraform-provider-helmproxy_0.0.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.3/terraform-provider-helmproxy_0.0.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.3_darwin_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.3/terraform-provider-helmproxy_0.0.3_darwin_amd64.zip",
+          "shasum": "2c2d5c6a404fbf62aa9e12a8c74bf1084b1c215b82730a9430287d86e4ee16f6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.3_darwin_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.3/terraform-provider-helmproxy_0.0.3_darwin_arm64.zip",
+          "shasum": "28df9ba45d70446de804e7260fd241d1ad661beba0cc877bc7f3160116e5af25"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.3_linux_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.3/terraform-provider-helmproxy_0.0.3_linux_amd64.zip",
+          "shasum": "ffe468abe4349c307ccb7c345adbe0ba92fc58c50dfa2a67519adc61284b24ea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.3_linux_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.3/terraform-provider-helmproxy_0.0.3_linux_arm64.zip",
+          "shasum": "0bf7d190b88528a820836c74f4a0d75c06c1c1a4249a8e25b0b9f200f30a5a81"
+        }
+      ]
+    },
+    {
+      "version": "0.0.2",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.2/terraform-provider-helmproxy_0.0.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.2/terraform-provider-helmproxy_0.0.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.2_darwin_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.2/terraform-provider-helmproxy_0.0.2_darwin_amd64.zip",
+          "shasum": "ef54706fbfd2a2a23397f80517e60485ab87127dfde7c842f6fa398585e1a1a0"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.2_darwin_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.2/terraform-provider-helmproxy_0.0.2_darwin_arm64.zip",
+          "shasum": "d098cdacd5aa599c2bade83a7a25aedb2e3365abf73dff778653ca5a3904e517"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-helmproxy_0.0.2_linux_amd64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.2/terraform-provider-helmproxy_0.0.2_linux_amd64.zip",
+          "shasum": "29304dc22c1f1fffd3535eea983cfdf3b656f691981473d924af7eb1406912fa"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-helmproxy_0.0.2_linux_arm64.zip",
+          "download_url": "https://github.com/trajan0x/terraform-provider-helmproxy/releases/download/v0.0.2/terraform-provider-helmproxy_0.0.2_linux_arm64.zip",
+          "shasum": "2e1e2090b03dc71d9af548c0ec799ef9cff41b5b5297edf6a0a427c121651717"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/v/vast-data/vastdata.json
+++ b/providers/v/vast-data/vastdata.json
@@ -1,0 +1,56 @@
+{
+  "versions": [
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-vastdata_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_darwin_amd64.zip",
+          "shasum": "68f8484e1972e80dffadb000b74f584ed339c17616e793a5539bed10bb61e1f8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-vastdata_1.0.0_darwin_arm64.zip",
+          "download_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_darwin_arm64.zip",
+          "shasum": "ec56d80e2fa78c4fb002fa0b39a33b3e2d7beacdb6f41c21032c3a049bc76de1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-vastdata_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_linux_amd64.zip",
+          "shasum": "3a9d47a8098e33c52d2c11e441bfb9fdfb6fec624eece73d17c9c5cdb9dd2ef4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-vastdata_1.0.0_linux_arm64.zip",
+          "download_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_linux_arm64.zip",
+          "shasum": "bf153a1c5afe300d51652456b6a039bf6f180d90f713d94d0b3d277aff111ea2"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-vastdata_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_windows_amd64.zip",
+          "shasum": "c1af5bd0c2cbc37f0a2514b0d7a2778dc3e2b382604a3098436ef23d9d9e40ec"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-vastdata_1.0.0_windows_arm64.zip",
+          "download_url": "https://github.com/vast-data/terraform-provider-vastdata/releases/download/v1.0.0/terraform-provider-vastdata_1.0.0_windows_arm64.zip",
+          "shasum": "eeae3bcadfa62d580ad30c9a580c1297e5efdb219a20bdcc2d3b15c0116887fb"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Queried by date/page `https://api.github.com/search/repositories?q=terraform-provider+in:name+fork:true+created:$p..$i&per_page=100&page=1` to get a full list of potential providers.  I ended up filtering out forks in a subsequent step for time.

```bash
# Filter out entries that don't match the name pattern and are not forks
cat providers_all.json | jq -r '.items[] | select(.full_name | contains("/terraform-provider-")) | select(.fork == false) | .full_name' > providers_all_nofork.txt
# Make directories based on filtered list
cat providers_all_nofork.txt | sed -e 's,\(.\)\(.*\)/terraform-provider-\(.*\),../providers/\L\1\E/\1\2/\3.json,' | sort | xargs dirname | xargs mkdir -p
# Create empty files based on filtered list
cat providers_all_nofork.txt | sed -e 's,\(.\)\(.*\)/terraform-provider-\(.*\),../providers/\L\1\E/\1\2/\3.json,' | xargs -I foo bash -c "echo '{}' > foo"

# Run bumper
~/go/bin/bump-versions

# Remove providers without versions or invalid.
grep '"versions": \[\]' ../providers/ ../modules -r | tr ':' ' ' | awk '{print $1}' | xargs git rm
grep '"versions": null' ../providers/ ../modules -r | tr ':' ' ' | awk '{print $1}' | xargs git rm
grep '{}' ../providers/ ../modules -r | tr ':' ' ' | awk '{print $1}' | xargs git rm
```

This is a follow up on https://github.com/opentofu/registry-stable/pull/46