### PR TITLE
Support artifacts with v in the version, added Azure/azapi

### DIFF
--- a/providers/a/Azure/azapi.json
+++ b/providers/a/Azure/azapi.json
@@ -1,0 +1,1790 @@
+{
+  "versions": [
+    {
+      "version": "1.10.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.10.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_darwin_amd64.zip",
+          "shasum": "6b345207665080642dedc4387e9affefbd9093d4812cf7a57f8009a7ab8f2383"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.10.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_darwin_arm64.zip",
+          "shasum": "2c243d610e522acbecf6193653226c322e6ee35f3a7f95d11373533de9eeae2e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.10.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_freebsd_386.zip",
+          "shasum": "7bfb6d9940d7ddd1e7b9851fb54c5157c118b7d83b870f7db3e0743a284c5453"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.10.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_freebsd_amd64.zip",
+          "shasum": "a92b399c488d767ad0375141a0c4c75a1a829d18442fd78097d1a91bf55264d0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.10.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_freebsd_arm.zip",
+          "shasum": "096ca824ab7ce61a3825335352a41e443b3355979dafb37eeded8d829ae6a6ba"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.10.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_freebsd_arm64.zip",
+          "shasum": "6f42952c5e77eb3ed59480817b220fe16768cb593740386c20e3dec90c5feee2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.10.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_linux_386.zip",
+          "shasum": "f7e08ee1e69f500bdb7d0b349d4489c989b415044765ae10a8ba329b76e64731"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.10.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_linux_amd64.zip",
+          "shasum": "bc8ba158f7495cb2ac1d25d8b7217780d9d2d070afc69b4148b457a1ea5c3f14"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.10.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_linux_arm.zip",
+          "shasum": "38dc218eba4f426aff1a3ed9ff8e93bf753fea84423b198fa66a6438d8c9b36c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.10.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_linux_arm64.zip",
+          "shasum": "5072dd8d446aa00aafc3b007b4947e2cde87c1fe6449ec21cfe360b07e8d3dc2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.10.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_windows_386.zip",
+          "shasum": "f542964189f21e2fc4250756dcfd798a336bd1bac8eb7e707fe9836ac7b790b6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.10.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.10.0/terraform-provider-azapi_1.10.0_windows_amd64.zip",
+          "shasum": "0852c7e4701a420be84380351bcc3b8b41a1f550916deb6b927fbd97a376a8aa"
+        }
+      ]
+    },
+    {
+      "version": "1.9.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.9.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_darwin_amd64.zip",
+          "shasum": "fa89e84cff0776b5b61ff27049b1d8ed52040bd58c81c4628890d644a6fb2989"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.9.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_darwin_arm64.zip",
+          "shasum": "ea5db4acc6413fd0fe6b35981e58cdc9850f5f3118031cc3d2581de511aee6aa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.9.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_freebsd_386.zip",
+          "shasum": "a8aace9897b28ea0b2dbd7a3be3df033e158af40412c9c7670be0956f216ed7e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.9.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_freebsd_amd64.zip",
+          "shasum": "ab23df7de700d9e785009a4ca9ceb38ae1ab894a13f5788847f15d018556f415"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.9.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_freebsd_arm.zip",
+          "shasum": "e58377bf36d8a14d28178a002657865ee17446182dac03525fd43435e41a1b5c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.9.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_freebsd_arm64.zip",
+          "shasum": "b4f13f0b13560a67d427c71c85246f8920f98987120341830071df4535842053"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.9.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_linux_386.zip",
+          "shasum": "54346d5fb78cbad3eb7cfd96e1dd7ce4f78666cabaaccfec6ee9437476330018"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.9.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_linux_amd64.zip",
+          "shasum": "9336ed9e112555e0fda8af6be9ba21478e30117d79ba662233311d9560d2b7c6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.9.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_linux_arm.zip",
+          "shasum": "349569471fbf387feaaf8b88da1690669e201147c342f905e5eb03df42b3cf87"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.9.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_linux_arm64.zip",
+          "shasum": "64b799da915ea3a9a58ac7a926c6a31c59fd0d911687804d8e815eda88c5580b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.9.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_windows_386.zip",
+          "shasum": "f1518e766a90c257d7eb36d360dafaf311593a4a9352ff8db0bcfe0ed8cf45ae"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.9.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.9.0/terraform-provider-azapi_1.9.0_windows_amd64.zip",
+          "shasum": "f0b32c06c6bd4e4af2c02a62be07b947766aeeb09289a03f21aba16c2fd3c60f"
+        }
+      ]
+    },
+    {
+      "version": "1.8.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.8.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_darwin_amd64.zip",
+          "shasum": "923327e1045dd60b2115c62ffe1e1f01ddb83f86281959943959a4855c73c890"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.8.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_darwin_arm64.zip",
+          "shasum": "f164342a9806959fa907a27aa0d368a1ed932cab9c8fdc6ce0050c88722b149a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.8.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_freebsd_386.zip",
+          "shasum": "4311c92c010bb280c949debc191fdd823dc78154c796586c2dd38e3af731049a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.8.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_freebsd_amd64.zip",
+          "shasum": "b3b95b29911de1fe80734fc9ccb191097dbc5286ebc83836007cadf12442ffbf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.8.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_freebsd_arm.zip",
+          "shasum": "df2216a5e5361899994e406a01436bda71e4c6bc572b59b1786711d4f42c96c6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.8.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_freebsd_arm64.zip",
+          "shasum": "a1c910fe07a02547766031570732332625a440fd3f61d8baa108879edf75a1bc"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.8.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_linux_386.zip",
+          "shasum": "3f2920e9d5a03d2ec464f0c7b7aaaccbf48b12f0f5f0606b8f663549f3d5265c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.8.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_linux_amd64.zip",
+          "shasum": "75b47514509be4a118b9d89ac2a7c7e7ba0a56a9ab7cd57081a78c3ea43adddf"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.8.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_linux_arm.zip",
+          "shasum": "8a1abd5a773ca99d1bae3926ddf388f15c2ab188a8641e2a0f61a520d14f97f5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.8.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_linux_arm64.zip",
+          "shasum": "9cac8f5169af1ef3d1b0ec71c1701ea5468d8ff594870aadc0df9f77c7c6fc91"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.8.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_windows_386.zip",
+          "shasum": "27d2ab70e5281e7fe69601496db902ad434874296f69ef9b252c1596ed011962"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.8.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.8.0/terraform-provider-azapi_1.8.0_windows_amd64.zip",
+          "shasum": "cc2c5877ee2d8f7a1a64be00c9c06c22ea17354a3d7fba729142bc1bcdc6e59a"
+        }
+      ]
+    },
+    {
+      "version": "1.7.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.7.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_darwin_amd64.zip",
+          "shasum": "dc984774af24948ffe1f1611f443380e204a465e3512045b5c1e6c8e845a8d3f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.7.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_darwin_arm64.zip",
+          "shasum": "a7761ed0fb78dfb773a81af953ba4a552642bbe76e9ad7e373e1a98875b9206f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.7.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_freebsd_386.zip",
+          "shasum": "aaa8da2ead6eb3b37a74e4a123788c099635ee8ef6236b26a4eb6f27c1626f0b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.7.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_freebsd_amd64.zip",
+          "shasum": "78675e6345890d0e04041abd2c14cc5f4f011e9482484a45856f2ac7a9931e76"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.7.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_freebsd_arm.zip",
+          "shasum": "4bb38a1861491ea380d5fe65062b73299aab49ec5baf58ad55edd9c99b2f5072"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.7.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_freebsd_arm64.zip",
+          "shasum": "4d572e30973b8dd1936ee60a2fd3dab201ec55ea16521905b06ac7e8e41ecc57"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.7.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_linux_386.zip",
+          "shasum": "39713f9aa01824a6db818dffcb2fff9175cf888c70c6805e1dced17d42dd0d24"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.7.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_linux_amd64.zip",
+          "shasum": "a4e8ade7559febda858b406116595d8fab27290751c4b09817bbd56af79c146f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.7.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_linux_arm.zip",
+          "shasum": "b1e146bee793751ee432e5eb538feda225e78c63cd79e1f3ef05ef7a5dd02b5d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.7.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_linux_arm64.zip",
+          "shasum": "eb95f8d87116bc8b3a8b2be2d80216da21d4274329fbc69033d3c0062c3345cc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.7.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_windows_386.zip",
+          "shasum": "d415471c445eada01a7bedf5fe3132b937488b80d99454403991b3f96e092f85"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.7.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.7.0/terraform-provider-azapi_1.7.0_windows_amd64.zip",
+          "shasum": "78200e4e0a0f515a0c5752cb79954a4cd06b9eb2c70241cebff7372c212e5d94"
+        }
+      ]
+    },
+    {
+      "version": "1.6.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.6.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_darwin_amd64.zip",
+          "shasum": "0784acbac6d911f31176713bcfb5e3a4a8085cff8f55283a37b0d8e784b2ea79"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.6.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_darwin_arm64.zip",
+          "shasum": "a1974c3ee0fb9d6b6318985460c21c7bd439eff157f318b74570f725f0a537b1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.6.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_freebsd_386.zip",
+          "shasum": "61f7b11d51508cb3c988cc2d846b8edb88f5461b5a6ff3a6539c6131999c4bf8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.6.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_freebsd_amd64.zip",
+          "shasum": "93feb60ab4781a01a54ef6983781ae76e60908ffeb1037f2702146542b235ddc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.6.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_freebsd_arm.zip",
+          "shasum": "966cbb563b7aa8180d6f0ac029eb6cc6a4261a6e4dc7d7662f270d99066abcec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.6.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_freebsd_arm64.zip",
+          "shasum": "d2a3284c4546804b84913237dbdb31966be733eb5199699df5af25b69e11e012"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.6.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_linux_386.zip",
+          "shasum": "3ff0ddb2b0dfff4037eb8da856b0ba7bfb1328004bee638028c17ef28326bfdc"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.6.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_linux_amd64.zip",
+          "shasum": "885236c0921e6ee20e5c3aa2a82e90fef74873f094a9c27c3ddc688ec5a83e94"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.6.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_linux_arm.zip",
+          "shasum": "5de832e66c2582063c5d29c2c4916deddbcbf7f7c277b60d30e3292f487f7064"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.6.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_linux_arm64.zip",
+          "shasum": "f83a023655e4385a6e4733c724c17eb262fcc06ad2a198ccb879c92ca50dcb2e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.6.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_windows_386.zip",
+          "shasum": "7c267b474d26dd0f6e1b9674250cc3c66b7e5a31d26cd4f2138154260712d000"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.6.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.6.0/terraform-provider-azapi_1.6.0_windows_amd64.zip",
+          "shasum": "830aef5fb62085652a151d8a593b6d60ce7e87f2526661840ecd147a5ca13e23"
+        }
+      ]
+    },
+    {
+      "version": "1.5.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_darwin_amd64.zip",
+          "shasum": "14109c169973e1b0d526131ca047e25f62700a44ecce4303aacb15793764be3e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.5.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_darwin_arm64.zip",
+          "shasum": "80563967234c853f18cffffa821df7a5dd43c0a72c02e499111dcda0064223d7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.5.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_freebsd_386.zip",
+          "shasum": "c5093f71eb18e84f93947d24c369e67a7dc4fa02950b9ae6b09cb71bc62a8b40"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.5.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_freebsd_amd64.zip",
+          "shasum": "7858f0e8b63590c34defd0ef7e844beaed942f8e2ae6df5a591d031d1db077a4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.5.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_freebsd_arm.zip",
+          "shasum": "b5700bab09282c0c05d76ca7910d43158e065d854e0780348fa8a5de06fba44f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.5.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_freebsd_arm64.zip",
+          "shasum": "34d9a96e6401f4fc087100b9c63aa47c77904a45478155671787854db13872c1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.5.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_linux_386.zip",
+          "shasum": "ae691de55bd1fd18820a5bf1b6bf8204711e8ddd01adde70a2db4e585523fb42"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_linux_amd64.zip",
+          "shasum": "6d3fc50788e74fba509586d99c4b80a1ef96345f21a0033746dfbf69dc6c2c1d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.5.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_linux_arm.zip",
+          "shasum": "19417f2bbbadd0a079d51646a929d43ae7a0293f0fc13c3fa369d32780c1c846"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.5.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_linux_arm64.zip",
+          "shasum": "3254370d3304227ea0ec1352d98aa4a4a59e6a76ddede26454bdb55048101ec3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.5.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_windows_386.zip",
+          "shasum": "c378578d65b4a51e2aa57122c8149e136bad72e5c8de516d269e6259051f9428"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.5.0/terraform-provider-azapi_1.5.0_windows_amd64.zip",
+          "shasum": "62f615527a6bda5b9808baf75edf80648b106ba449418665ea4841ded978aee7"
+        }
+      ]
+    },
+    {
+      "version": "1.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_darwin_amd64.zip",
+          "shasum": "12597b79f5142bde9c0e36f181c2c64b6cdec9edc73f1fd9fc7966f6823e2815"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.4.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_darwin_arm64.zip",
+          "shasum": "48a85d722072ee78bb0642417b5625e6aae3f8d4a2e0170986f80f5ef4d2e120"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.4.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_freebsd_386.zip",
+          "shasum": "6f685f2c78720273d9b98d2b3ab8b9398286f1b7cb3d4f0b9998f01fd6cc33dc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.4.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_freebsd_amd64.zip",
+          "shasum": "807c3b27ab8b092cdbcffdcb42f4a7483efcf7fafffeaee17a10c7f9ce8f50f5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.4.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_freebsd_arm.zip",
+          "shasum": "6ef808949d8bb0091bae4857dbc65fd01d44b051a975633bffe84599fdc7415c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.4.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_freebsd_arm64.zip",
+          "shasum": "b0bd890c0a7043830e1826859bb4ce45433a1a364d65866d44923d5782ed6563"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.4.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_linux_386.zip",
+          "shasum": "29d1b3f08c2db87057892adeff527a5b367259d2c7111b4db61afa27c77e9e2a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_linux_amd64.zip",
+          "shasum": "8e8f3af41eb5baee290c56035c583c647f26137b3ac339c811245bdcf76d0d48"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.4.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_linux_arm.zip",
+          "shasum": "1699b8555e8adcf59c64ad6cfb7d7af34b3dc54872040a68f57ac5ec27e30e21"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.4.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_linux_arm64.zip",
+          "shasum": "48790687133691ea4fb075c5cad94070661fdf8eefd2858f1c2cf6e21f7d9e8e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.4.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_windows_386.zip",
+          "shasum": "654d1abc11b5ba69b8fa0307d5dfa2ae5024980d52fc1091d1a117da39293ca7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.4.0/terraform-provider-azapi_1.4.0_windows_amd64.zip",
+          "shasum": "1d482a769c20512f98644b6c309a048fdf320eaf2565ab0b07f6d674940db01f"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_darwin_amd64.zip",
+          "shasum": "6cb7081745b378e910e0cf09fb5717a2ad35e629ce3e07415d6682c1c1407872"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.3.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_darwin_arm64.zip",
+          "shasum": "c6fa7af32a7a47d23a85e0eea4d4cbb065378ae75aed8c9c628fb625b04bc619"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_freebsd_386.zip",
+          "shasum": "5c1514392a5c3dd51084aa70cb6c4dcc8b027c4508b5e4eb9f8c3990fd403213"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_freebsd_amd64.zip",
+          "shasum": "0923b297c5b71ed584e5f3a0b2393e80244076e85102a90438159833353274b0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_freebsd_arm.zip",
+          "shasum": "7107eda5125c1b983380f1f6418c592fb7fb2eb5b589ad0e08f6c47341f36318"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_freebsd_arm64.zip",
+          "shasum": "14af830fb6091d084bfc2711c8e9c7bf05aa3c56fe8fd8e2fb4eddeb345be88d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.3.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_linux_386.zip",
+          "shasum": "6b3ecac7099ab86c007b5ad636bd029f5e5f3e9bd06b0f74c82f0451a7995ecc"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_linux_amd64.zip",
+          "shasum": "32c9360305e00c25d0f9d0a84dfbdbad8da2465be769a9c1f11f132c0225358e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.3.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_linux_arm.zip",
+          "shasum": "11fa2922aa98ca55beaf7cc33c7edbde81bbd405fdfea2955276c7f5a8537240"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_linux_arm64.zip",
+          "shasum": "2922b535fe4d4f0963189548f2f8360a0aaf951fd411354f2269a111d8a0c1ad"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.3.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_windows_386.zip",
+          "shasum": "4ddd3ee23c340d5000839d8d30ba7f94e695476d63075f95cfb041e67d8f6ef6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.3.0/terraform-provider-azapi_1.3.0_windows_amd64.zip",
+          "shasum": "25258425ecbffbdf09b0c8131d2c680cddd19b504e0036ee5f83972dcae7df0a"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_darwin_amd64.zip",
+          "shasum": "0dcca6970347a67c2192be251ea1e98b5df50a8f7cb352adbf2fbdb6cbe02b03"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_darwin_arm64.zip",
+          "shasum": "fa1f470859b8c5dc778561cbf0749b0c002cfa13bbd3574a2574ea682368d73f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_freebsd_386.zip",
+          "shasum": "306545eedf8a6dbc64d34fdc9fe104b874d45f9ab5ca1232e9670e36376f7d04"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_freebsd_amd64.zip",
+          "shasum": "36fda73c39c56495bfda7fa746863357ab8284d27724d809130c03fada62301f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_freebsd_arm.zip",
+          "shasum": "40075df5e753032bd9a7d2698e762d355524f56a4a7e8df65489d44273aa0e32"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_freebsd_arm64.zip",
+          "shasum": "a522991b3d8dfb3b7073c3cd44fb6b8d9957c006ad304e299342e29d11bde854"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.2.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_linux_386.zip",
+          "shasum": "6b7667b74eaa0e0884423704e48bb3468e465fd99de108e64b93c9e26c8c4b0d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_linux_amd64.zip",
+          "shasum": "9b5d3c6a753cc57be31ba6a6e14b571ebbaa5c0c14791ef20a975b9c15c65252"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.2.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_linux_arm.zip",
+          "shasum": "b1f931cd16e5a8235131b11c4a0d93f122d22dec597534da1bac03324e564fb1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_linux_arm64.zip",
+          "shasum": "86d864576520952d74b0ac5d92ed9efe09894c5405cbadddf1d95c2b39c4a514"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.2.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_windows_386.zip",
+          "shasum": "8248289b744cdeb9d3e20dedd13a66ba3225f8efd6694a556f69acf16825f45f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.2.0/terraform-provider-azapi_1.2.0_windows_amd64.zip",
+          "shasum": "31484f398b08b10b86af2d89c89ae13e513bf738dfe90e2ff3dc564332b8c180"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_darwin_amd64.zip",
+          "shasum": "364ed09ddfc50d9bed8d930f7de489cb654a9908feb139413a097823a50075fd"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_darwin_arm64.zip",
+          "shasum": "9094ae76ed66cb328a4f35bd18b9140fb6fc6859c2e46431ec73c018bcb58d96"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_freebsd_386.zip",
+          "shasum": "2b443a836a39724663fe455d4deee408ff3a2d9a8b86f8408aa7db2e8aa743f8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_freebsd_amd64.zip",
+          "shasum": "870ea9cc24807ef5142e4cad0281dac7173f7b6bf818a79762b6c690d12d4c4b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_freebsd_arm.zip",
+          "shasum": "ff5bd6883d9ac8334e043434246357a55107411e9a962856c1d17e47ee15ac37"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_freebsd_arm64.zip",
+          "shasum": "d89149cfd01cb70012459536b4d36490b58e43312440562e5910bd5160537858"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.1.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_linux_386.zip",
+          "shasum": "60ded375fdb305b60bcb4d9e596dbb222cab166bad1b4958199b05a72aaeacfd"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_linux_amd64.zip",
+          "shasum": "dba7ec06171ca062fc423ba5b4776a5600444e45e57f4d1cb043bdc3eee538b7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.1.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_linux_arm.zip",
+          "shasum": "523bc005f56ae785867d230d55c29f59db4b599dbc6c38b4d03ea55a79458916"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_linux_arm64.zip",
+          "shasum": "823b2154ae2262dabcbd11aac992e3cc29eae0f7baa96bee1e3e2fe1ece8730b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.1.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_windows_386.zip",
+          "shasum": "2a25df6325a49f9e821f0b02c7da86167fc19a3bac647cd1edf231300f29d077"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.1.0/terraform-provider-azapi_1.1.0_windows_amd64.zip",
+          "shasum": "61e69c58642fead6814e511c872b7c0a6478ec6af4ab758b4512607d910ac078"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_darwin_amd64.zip",
+          "shasum": "01a33aaefe4d185e70d926103eeb0ac9fefeadf750f69c5977ead2ae02e0b038"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.0.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_darwin_arm64.zip",
+          "shasum": "1cf15bc8430377091c06373c74a68ce61a9f36dd1455929a64e8083332f2c291"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.0.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_freebsd_386.zip",
+          "shasum": "e67ddb150ff40cf9453fd56f47c2ac657ede1c1861b4d2f9009e98bddfc345b2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.0.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_freebsd_amd64.zip",
+          "shasum": "d6dad27af147a127027a8aa08a259f6dc418b09f842620e56e5db85547b1b090"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.0.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_freebsd_arm.zip",
+          "shasum": "6fc5e5017b8f87aff48732cc619f1295175913e3c1c039a170e8f0100a8233a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.0.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_freebsd_arm64.zip",
+          "shasum": "7f003da3b64cb5129627b96a5eb0a03113853a0b17fd4cb77bd505fd27a8ca0b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.0.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_linux_386.zip",
+          "shasum": "740f6c339f28406988204af6fadc9e58c754a22f234902b34c1f6d54421476c2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_linux_amd64.zip",
+          "shasum": "4372f59b2761b3ae4b59d59f978af547cd8fae44d2b2e5baa91735b0ea3b16e2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v1.0.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_linux_arm.zip",
+          "shasum": "6f0945ee6ae05cbd708c10ee7b0f8c987032e35122a01d661188538f7548e59f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v1.0.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_linux_arm64.zip",
+          "shasum": "6602e2aae7937456418f53372d7139d2f56aea5e46dfd46634f9b202988178c0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v1.0.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_windows_386.zip",
+          "shasum": "1ce767851be07e432b4cdde91b40beef84f030432bb7b431ffda85b89305414d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v1.0.0/terraform-provider-azapi_1.0.0_windows_amd64.zip",
+          "shasum": "a1ed7aa209cdee91b013691ddb61d77eb3d840f9cba2f4c8b923ba80823c5912"
+        }
+      ]
+    },
+    {
+      "version": "0.6.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.6.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_darwin_amd64.zip",
+          "shasum": "48b6dbc9175746c3a96546467ccff863e0ab5ef3d2acf3c122a7ba65db923362"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.6.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_darwin_arm64.zip",
+          "shasum": "ca7ecd1088a7401bafb02d2e653f39c3ee7313c6b91c935d5c96f625bcff96eb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.6.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_freebsd_386.zip",
+          "shasum": "c952258a110e5900aa6ffa91235affd56a63d69a2b0b0408aa35f3ae9cd6b3a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.6.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_freebsd_amd64.zip",
+          "shasum": "ac5921821783d3704fa61d27fe393ce6fa1a75a0073dd59fb6e3e3607d4615da"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.6.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_freebsd_arm.zip",
+          "shasum": "d1a64e0da183e9169418fea2ad0f7c4c7dced32cc1192f757a9bc03626b38c97"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.6.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_freebsd_arm64.zip",
+          "shasum": "2a86f7e6279059da62a3e10567486f044104cbffa4c12e87679fac57d10a9d79"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.6.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_linux_386.zip",
+          "shasum": "9f3a45605aac56c890b25f33adf6a66860e966ab7f386d5fd925fceb58db8b41"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.6.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_linux_amd64.zip",
+          "shasum": "43cc95204e874c831098e02913c17aa1b0ae036348006483c26bed1e15b47bfe"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.6.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_linux_arm.zip",
+          "shasum": "4bb3633200ed2774076b241615caececdb475d70099e4b48c7a0987c24e85503"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.6.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_linux_arm64.zip",
+          "shasum": "698bca1c816a525b221012c7ab54e6b3de6a4ce40e82900622ff3f2829bf8774"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.6.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_windows_386.zip",
+          "shasum": "a7bdfcfdd03b9b4e81391b7304fa454b24aa1afbb7663f7ab13f0229ea26b6a7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.6.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.6.0/terraform-provider-azapi_0.6.0_windows_amd64.zip",
+          "shasum": "1ffd75395464f242ea263fd233afd2a0f0982fd9ffc6e6d5e1d418992ca1ff91"
+        }
+      ]
+    },
+    {
+      "version": "0.5.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_darwin_amd64.zip",
+          "shasum": "4ce3d703c596bc998f4392a9a177b75ee4d48181c09512fee67ef38aff7dd945"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.5.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_darwin_arm64.zip",
+          "shasum": "f245a74fc9eca9b63ff0d6856da9d71ccab951b299d45af54e3d3b47bc5ef85f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.5.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_freebsd_386.zip",
+          "shasum": "2c52b4f0bd0e96d8f60c878947a63ae8ea08a735968d8603769f0da4654954b3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.5.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_freebsd_amd64.zip",
+          "shasum": "32837d15d002721c20f4561a1b2d44438b066f9812801295d864e0b4c93b6297"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.5.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_freebsd_arm.zip",
+          "shasum": "5aafa486486ec52d4ca621b490016fa7c022b3f5e3ac16b1dd3b01b98cd86a1c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.5.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_freebsd_arm64.zip",
+          "shasum": "df8e045e6fd72d94fa18c082989d69cd2c73d3b4ade008362ddb90dfcfa91ac7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.5.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_linux_386.zip",
+          "shasum": "d7fc35384b21c0209575c74ae057061048ab342d0bf8d923ed44d83bd6670e42"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_linux_amd64.zip",
+          "shasum": "3e9fbb1137a36d782df4935acbf89e88f14e6672934ac03fd0226e5ddd4430e4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.5.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_linux_arm.zip",
+          "shasum": "83817bb7dc503254e93972464c496d0f9f4fc7499d294b74c7df9105100c41e7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.5.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_linux_arm64.zip",
+          "shasum": "53ec2fcdb866b763cc05f8dbd6caf9320d86381c6083d69b4d838dc9bc8128cf"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.5.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_windows_386.zip",
+          "shasum": "9bce71b22b4700c625f8bd2dddd72e01470c410675fa5c2b014c71acfd7ecb3c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.5.0/terraform-provider-azapi_0.5.0_windows_amd64.zip",
+          "shasum": "1bbd3e887b13085aa1d989f11e3fc7c8cf0d81cc8dcfeb58f7f752478f061001"
+        }
+      ]
+    },
+    {
+      "version": "0.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_darwin_amd64.zip",
+          "shasum": "41a6916037cb158eea6363a050371c112823fd499e634009c8086dfe0d645e1f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.4.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_darwin_arm64.zip",
+          "shasum": "38f567310837875c7d3b5c96d643e9f9a5b8822cc5cf674f85048a001998ee13"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.4.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_freebsd_386.zip",
+          "shasum": "9b7fdf6b84db61793b7f693f93d1d2a07fa8274de43293b53d9a416fb8dc77bd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.4.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_freebsd_amd64.zip",
+          "shasum": "f360b6f3c33795448e3556cf79a2b7dc1a09d3c5d3639ba5cc7e4bf58b61f692"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.4.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_freebsd_arm.zip",
+          "shasum": "f49f44da535bb7bd5aae19c255c66a5889724c3efedde579e8b25933bfc2ddc9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.4.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_freebsd_arm64.zip",
+          "shasum": "6eec0375f44ff4abd770f0ed9a8c9223e2b591b9dd2d49bc8c83a3e64ef28f30"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.4.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_linux_386.zip",
+          "shasum": "60af935929903b7d3579a2db51b9771eeabf7699dbacd86587161afee4065ad7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_linux_amd64.zip",
+          "shasum": "4f6d51c29824e7192a4ee1dbbf2afc34923df68f55398ee85871fb224baaeca2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.4.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_linux_arm.zip",
+          "shasum": "9c83109776294d969987c3c7f8de582c962ffa68c898c8ee76891f9ddd5e80a5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.4.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_linux_arm64.zip",
+          "shasum": "d0931c36953eff58a5a18fb2edfc32f7041f12cd048fc1d61d21f970612a9ca1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.4.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_windows_386.zip",
+          "shasum": "df9f23eae831cbd8d3644fd6082f2e6f8103a71905e61b88ed107fca70d4c109"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.4.0/terraform-provider-azapi_0.4.0_windows_amd64.zip",
+          "shasum": "f682a436fb363d9e5767039f164d45215022258acc1c4e466705cc370ee8052d"
+        }
+      ]
+    },
+    {
+      "version": "0.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_darwin_amd64.zip",
+          "shasum": "63a5e9f037158dbf9676d7918ff5136cb006e6e44d05518732a1caef76f19032"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.3.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_darwin_arm64.zip",
+          "shasum": "472f93b81b30e07afcea8b56048847f80bc10237a74f75f178a69072a74109ca"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_freebsd_386.zip",
+          "shasum": "8636c942a64665a7a68b7d8eb8d30b535fe8c3bd5d8b28133b092416006693a3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_freebsd_amd64.zip",
+          "shasum": "2d6e75d48f649498982aa0405161f18715ce61f651e3bfb798d5eca19241e450"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_freebsd_arm.zip",
+          "shasum": "a425eb1a5d5bd17f5a2398c7efae1de89c09927f4c923da3ab9a6615725e1375"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_freebsd_arm64.zip",
+          "shasum": "fd6e626c32e8c10edae52e89aac13d43936522d1debe4a60acb8227a562c8173"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.3.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_linux_386.zip",
+          "shasum": "4b949da7e9c3f98a27a43e579e801e5878d33e9602272c1e79989b7b197db7d4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_linux_amd64.zip",
+          "shasum": "8552d620c2d5af9b947286ea1224642f507e103b542dde66a263bdd401672db4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.3.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_linux_arm.zip",
+          "shasum": "8ab0534b571335b17504a15c697ed71c80b63e78bf265f836bac778efc4b2f2e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_linux_arm64.zip",
+          "shasum": "f5ffb5eb96ffaa4e039569cf4d620dbfce1d68c65b6199b6d057556cadb7fe8f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.3.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_windows_386.zip",
+          "shasum": "c30d4577d22ef1bdf850c70c34be66066ada20739923cfced805a67bd5c0cbb1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.3.0/terraform-provider-azapi_0.3.0_windows_amd64.zip",
+          "shasum": "8f290f233240b4e2771e7a678186033c86b9b30dfcc86b52ee7b8d4552766fb3"
+        }
+      ]
+    },
+    {
+      "version": "0.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_darwin_amd64.zip",
+          "shasum": "9fdb3fab552e81334d2b6f817671eccc1bbd4b3e7569c9d19d22aaa6b6f2d7fd"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.2.1_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_darwin_arm64.zip",
+          "shasum": "74c9c7752b02b8306862949689b230e9f60cb6b7dcb225300abff88e83f7fc91"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.2.1_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_freebsd_386.zip",
+          "shasum": "f2c3c623c80bff2c29139069be214d3291f96954c9e7c106a620f8f0a38b82b9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_freebsd_amd64.zip",
+          "shasum": "b991909dd8440ae3f1ee404e38644406fc766e03adb3b5add5737dd776c24feb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.2.1_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_freebsd_arm.zip",
+          "shasum": "1c17dae7b723d8d1f655501459dfd2fd85a8e73f5df355002c34e027ab8ad429"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.2.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_freebsd_arm64.zip",
+          "shasum": "8dfad321cbedb77bd3b79905cd231142f103fe93e6821deb3b942430858ddc43"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.2.1_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_linux_386.zip",
+          "shasum": "1be3411a67ac9f918f225c13ef731c9602491e69b1f54422049cd805d344a8df"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_linux_amd64.zip",
+          "shasum": "5d181464b3e846c8e96bfef0d5da6472740f0b7f2100c5f15ab5266acdd5e307"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.2.1_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_linux_arm.zip",
+          "shasum": "93aae8592a0c89ceb790fddce370794d847608f12f951f88687605977a020cf8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.2.1_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_linux_arm64.zip",
+          "shasum": "7e075c9a2beff45338a03c3c41de609f4066340d71b64481df70c53e9354787c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.2.1_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_windows_386.zip",
+          "shasum": "bac4838276751a857ffb70f1c9ccbb3aa417bca6d3946b0c6766112e82809d29"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.1/terraform-provider-azapi_0.2.1_windows_amd64.zip",
+          "shasum": "4fb17a9f622dd019a5553f7ba646bffda03aa9d28a91c4663c798e2584a9efca"
+        }
+      ]
+    },
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_darwin_amd64.zip",
+          "shasum": "20d4bfd4931687fe9035419a0470bbd362f0dbbbd426afb627ef2e2397ceeeb3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_darwin_arm64.zip",
+          "shasum": "2f77abd562a17ed62c01402c5f15997c2482291fb9af65fd10779b522c601b67"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_freebsd_386.zip",
+          "shasum": "bdac2467ff8dcd98e6edfb2bba7644a70be1c046d1c26bb72e6daafb2490b6bf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_freebsd_amd64.zip",
+          "shasum": "9d98c7372ce87cefe210fc46651e60fff633a3134cf60385b1df1637c703e2b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_freebsd_arm.zip",
+          "shasum": "cbf62dfd4ee6bb12755958fc17e3443ac6de1fc4ea0b3d1255a4c539fed4ba03"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_freebsd_arm64.zip",
+          "shasum": "75b8fedf71b24a57eb788938bcab075e38b8709b90765923c8a89f7b7a08b637"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.2.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_linux_386.zip",
+          "shasum": "beef6bfa469982489ba5c735855396268a78e85d1fed2d793f52f4a2dc584032"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_linux_amd64.zip",
+          "shasum": "9b65447a4d65c08644c59499523b32d98db3e624277a4f8e110d160131a3884f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.2.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_linux_arm.zip",
+          "shasum": "369d4cded8380637ccb355157a30cf9ed5b7aeba15a064445700fd12a4d8642b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_linux_arm64.zip",
+          "shasum": "d1d7f216dd52be73a7ab6cade22b3bce4689f44d77f27d4569a2c59af61f71ff"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.2.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_windows_386.zip",
+          "shasum": "91a6ee0730a7439d37950a07c10e0b673718c9a6a736c64eedf81435d61b3665"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.2.0/terraform-provider-azapi_0.2.0_windows_amd64.zip",
+          "shasum": "3aa31b15c384305d7f81ddaa52b5926d6c6252b512be92b20c2edabe3716f555"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_darwin_amd64.zip",
+          "shasum": "52c42217bfa22c3faa6737fa2461148d89b4baf6ea0c049f8f653e66947fe3a1"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.1.1_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_darwin_arm64.zip",
+          "shasum": "8c2c5c5eeecd7860753a0646bd1800ee8c80e26cd7ae2312af9bfcd8ca18b596"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_freebsd_386.zip",
+          "shasum": "5bd4798e3686b8d9a5538c6225988c6be1eb745bc1e3bfe415d6eedb337c04b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_freebsd_amd64.zip",
+          "shasum": "9e8528bb8bb5d3ef796e8f2c1b9650b213a4930ed97b894ac3d691c9d2ef89cb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_freebsd_arm.zip",
+          "shasum": "01665910a506472f77fbaf02f67ed50a151c495ffa6692f651f0eba444d7bc9a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_freebsd_arm64.zip",
+          "shasum": "623d5101c121a6af0b2c41cc92bef6e58992f7d5340e5f6c501d620b2276783d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.1.1_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_linux_386.zip",
+          "shasum": "4e2b9d1a771b0ca9e754df6c8a8568cbf88084448a399ba35b89020e0fc3c53a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_linux_amd64.zip",
+          "shasum": "31c180d2d94269bac631f3dda2028d51f14b9f03467cb3785f77254ab24579f7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_linux_arm.zip",
+          "shasum": "eeede3adebd6849441bae2dfe7c42a2027295b7bec0890824bd27e7f6cbec1ea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_linux_arm64.zip",
+          "shasum": "dd43ce25d0f8d033db69c6d190bcfcfa53acf4431338b8a13e8e9a52b6712e05"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.1.1_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_windows_386.zip",
+          "shasum": "6ba21c1768d4179cd14a3c00ea67cfab9f9c58374f25caf39d9727acdb852eb8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.1/terraform-provider-azapi_0.1.1_windows_amd64.zip",
+          "shasum": "5622b655192074dbb9795899fa883fe40ad4be77dda9eb8194707efada10a1d4"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_darwin_amd64.zip",
+          "shasum": "a0f609144270ccc03e66726529b8be8bd77b3c80ebf89259625361e61797c354"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_darwin_arm64.zip",
+          "shasum": "1e6de8c6a6d7ca85ae4a3124cc1733ac0436a3426fd21c2970c867e269390c06"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_freebsd_386.zip",
+          "shasum": "b7d73d907d8ab57677e4808f7a4787efa024fd7326f3f50fd5ea8123a81cce1f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_freebsd_amd64.zip",
+          "shasum": "8dee1b5135ed8898114e859b640028dddb11707ed91077323fae5018e2e375b9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_freebsd_arm.zip",
+          "shasum": "1e9a43d975866698bcda3e0e0dd1d18c9b71403a309ece5978507ba640043da7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_freebsd_arm64.zip",
+          "shasum": "369340a3b441dcfca12097de26215b4a1910226cf91f26d0b21b2fe664556f6e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.1.0_linux_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_linux_386.zip",
+          "shasum": "8ed4627d7d68136ea3af6601aeb31975253d4fbc110c936f4e04dd17c4517657"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_linux_amd64.zip",
+          "shasum": "356cd346c93cecc429f701a48d301a22ea8137b1358b307d55ec6131ff69efb1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-azapi_v0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_linux_arm.zip",
+          "shasum": "1ce60ee8480f1e3af8a3534eedb6ec28e51adc72967d32f04393d0b033f3bb39"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-azapi_v0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_linux_arm64.zip",
+          "shasum": "35e4551806fc9783f003ff55e9b8afb00205492417587b7cb009a6ae8e408882"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-azapi_v0.1.0_windows_386.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_windows_386.zip",
+          "shasum": "fde411ecc0c59e8725d29f71adcc1920826ca0966e8d87bf51cc387e05677196"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-azapi_v0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/Azure/terraform-provider-azapi/releases/download/v0.1.0/terraform-provider-azapi_0.1.0_windows_amd64.zip",
+          "shasum": "ab938e078671745fe1d1ed80ebc1fcfa36b0e1af153421b2dc93f750435ae517"
+        }
+      ]
+    }
+  ]
+}

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -63,6 +63,13 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 			target.SHASum, ok = checksums[target.Filename]
 			if ok {
 				v.Targets = append(v.Targets, target)
+				continue
+			}
+			// now try and pull it with the v in the version
+			target.Filename = fmt.Sprintf("%s_v%s_%s_%s.zip", p.RepositoryName(), version, os, arch)
+			target.SHASum, ok = checksums[target.Filename]
+			if ok {
+				v.Targets = append(v.Targets, target)
 			}
 		}
 	}


### PR DESCRIPTION
This is adding support for providers where the artifacts have a `v` in the version for the artifacts.

This is specifically needed to support Azure/azapi but may be needed for others. 

@RLRabinowitz has some statistics on others this may be solved for.