### PR TITLE
Suggest using form parser/validator and split steps/jobs on #79

### DIFF
--- a/.github/ISSUE_TEMPLATE/module.yml
+++ b/.github/ISSUE_TEMPLATE/module.yml
@@ -4,13 +4,14 @@ title: "Module: "
 labels: ["module", "submission"]
 body:
   - type: input
-    id: repository
+    id: module_repository
     attributes:
-      label: Repository
+      label: Module Repository
       description: Path to a public GitHub repository following the pattern {owner}/terraform-{target}-{name}, ex. GoogleCloudPlatform/terraform-google-secured-data-warehouse
     validations:
       required: true
   - type: checkboxes
+    id: dco
     attributes:
       label: DCO
       options:

--- a/.github/ISSUE_TEMPLATE/provider.yml
+++ b/.github/ISSUE_TEMPLATE/provider.yml
@@ -4,13 +4,14 @@ title: "Provider: "
 labels: ["provider", "submission"]
 body:
   - type: input
-    id: repository
+    id: provider_repository
     attributes:
-      label: Repository
+      label: Provider Repository
       description: Path to a public GitHub repository following the pattern {owner}/terraform-provider-{name}, ex. opentofu/terraform-provider-aws
     validations:
       required: true
   - type: checkboxes
+    id: dco
     attributes:
       label: DCO
       options:

--- a/.github/validator/config.yml
+++ b/.github/validator/config.yml
@@ -1,0 +1,6 @@
+validators:
+  - field: provider_repository
+    script: provider-repository
+# TODO: follow a similar pattern for module_repository
+#  - field: module_repository
+#    script: module-repository

--- a/.github/validator/provider-repository.js
+++ b/.github/validator/provider-repository.js
@@ -1,16 +1,7 @@
 /**
- * Provider validator script
+ * Provider validator script used for further custom validation consumed by https://github.comissue-ops/validator
  *
  * @param {string | string[] | {label: string; required: boolean }} field The input field.
- *
- * This can be one of several types:
- *  - `string` -> The value of the field (e.g. `'my-team'`)
- *  - `string[]` -> The value(s) of the field (e.g. `['team-1', 'team-2']`)
- *  - A checkboxes object with a `label` and `required` property (e.g.
- *    `{ label: 'my-team', required: true }`)
- *
- *  You do not need to handle them all! It is up to the individual validation
- *  script to define which type(s) to expect and how to handle them.
  *
  * @returns {Promise<string>} An error message or `'success'`
  */

--- a/.github/validator/provider-repository.js
+++ b/.github/validator/provider-repository.js
@@ -6,53 +6,39 @@
  * @returns {Promise<string>} An error message or `'success'`
  */
 module.exports = async (field) => {
-    const { Octokit } = require('@octokit/rest')
-    const core = require('@actions/core')
-
-    const github = new Octokit({
-        auth: core.getInput('github-token', { required: true })
-    })
+    const core = require('@actions/core');
 
     if (typeof field !== 'string') return 'Field type is invalid';
 
     if (!/^[a-zA-Z0-9-]+\/terraform-provider-[a-zA-Z0-9-]+$/.test(field))
         return 'Repository must be a valid terraform provider repo matching the pattern "<org>/<repo>/terraform-provider-<name>"';
 
-    try {
-        // Check if the provider repository exists
-        core.info(`Checking if repository '${field}' exists`)
-        const [owner, repo] = field.split('/');
+    // Check if the provider repository exists
+    core.info(`Checking if repository '${field}' exists`);
+    const [owner, repo] = field.split('/');
 
-        await github.rest.repos.get({
-            owner,
-            repo,
-        });
-
-        try {
-            await github.rest.repos.getContent({ owner: 'opentofu', repo: 'registry', path: `providers/${owner.charAt(0)}/${owner}/${repo}.json` });
-
-            // if we did not get 404 from github - the provider already exists
-            core.error(`Repository '${field}' already exists in the registry`)
-            return `Provider '${field}' already exists in the registry`
-        } catch (error) {
-            if (error.status === 404) {
-                // the provider does not exist in the registry, so good submission
-            } else {
-                // Otherwise, something else went wrong...
-                throw error
-            }
-        }
-
-        core.info(`Repository '${field}' exists`)
-        return 'success'
-    } catch (error) {
-        if (error.status === 404) {
+    // Check if the repository exists
+    const repoResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}`);
+    if (!repoResponse.ok) {
+        if (repoResponse.status === 404) {
             // If the repo does not exist, return an error message
-            core.error(`Repository '${field}' does not exist`)
-            return `Repository '${field}' does not exist`
+            core.error(`Repository '${field}' does not exist`);
+            return `Repository '${field}' does not exist`;
         } else {
-            // Otherwise, something else went wrong...
-            throw error
+            throw new Error(`Failed to check repository existence: ${repoResponse.statusText}`);
         }
     }
-}
+
+    // Check if the provider repository exists in the registry
+    const registryResponse = await fetch(`https://raw.githubusercontent.com/opentofu/registry/main/providers/${owner.charAt(0)}/${owner}/${repo}.json`);
+    if (registryResponse.ok) {
+        // If the provider exists in the registry, return an error message
+        core.error(`Repository '${field}' already exists in the registry`);
+        return `Provider '${field}' already exists in the registry`;
+    } else if (registryResponse.status !== 404) {
+        throw new Error(`Failed to check registry: ${registryResponse.statusText}`);
+    }
+
+    core.info(`Repository '${field}' exists`);
+    return 'success';
+};

--- a/.github/validator/provider-repository.js
+++ b/.github/validator/provider-repository.js
@@ -1,0 +1,67 @@
+/**
+ * Provider validator script
+ *
+ * @param {string | string[] | {label: string; required: boolean }} field The input field.
+ *
+ * This can be one of several types:
+ *  - `string` -> The value of the field (e.g. `'my-team'`)
+ *  - `string[]` -> The value(s) of the field (e.g. `['team-1', 'team-2']`)
+ *  - A checkboxes object with a `label` and `required` property (e.g.
+ *    `{ label: 'my-team', required: true }`)
+ *
+ *  You do not need to handle them all! It is up to the individual validation
+ *  script to define which type(s) to expect and how to handle them.
+ *
+ * @returns {Promise<string>} An error message or `'success'`
+ */
+module.exports = async (field) => {
+    const { Octokit } = require('@octokit/rest')
+    const core = require('@actions/core')
+
+    const github = new Octokit({
+        auth: core.getInput('github-token', { required: true })
+    })
+
+    if (typeof field !== 'string') return 'Field type is invalid';
+
+    if (!/^[a-zA-Z0-9-]+\/terraform-provider-[a-zA-Z0-9-]+$/.test(field))
+        return 'Repository must be a valid terraform provider repo matching the pattern "<org>/<repo>/terraform-provider-<name>"';
+
+    try {
+        // Check if the provider repository exists
+        core.info(`Checking if repository '${field}' exists`)
+        const [owner, repo] = field.split('/');
+
+        await github.rest.repos.get({
+            owner,
+            repo,
+        });
+
+        try {
+            await github.rest.repos.getContent({ owner: 'opentofu', repo: 'registry', path: `providers/${owner.charAt(0)}/${owner}/${repo}.json` });
+
+            // if we did not get 404 from github - the provider already exists
+            core.error(`Repository '${field}' already exists in the registry`)
+            return `Provider '${field}' already exists in the registry`
+        } catch (error) {
+            if (error.status === 404) {
+                // the provider does not exist in the registry, so good submission
+            } else {
+                // Otherwise, something else went wrong...
+                throw error
+            }
+        }
+
+        core.info(`Repository '${field}' exists`)
+        return 'success'
+    } catch (error) {
+        if (error.status === 404) {
+            // If the repo does not exist, return an error message
+            core.error(`Repository '${field}' does not exist`)
+            return `Repository '${field}' does not exist`
+        } else {
+            // Otherwise, something else went wrong...
+            throw error
+        }
+    }
+}

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Install Dependencies
         id: install
-        run: npm install
+        working-directory: .github/validator
+        run: | 
+          npm install @octokit/core@5.0.2 @octokit/rest@20.0.2
 
       # Validate the parsed issue body against the issue form template and custom validators - see validator/config.yml
       - name: Validate Issue

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -5,55 +5,111 @@ on:
       [opened, edited]
 
 jobs:
-  provider_issue_to_pr:
-    if: contains(github.event.issue.labels.*.name, 'provider') && contains(github.event.issue.labels.*.name, 'submission') 
+  parse-and-validate:
+    if: (contains(github.event.issue.labels.*.name, 'provider') || contains(github.event.issue.labels.*.name, 'module')) && contains(github.event.issue.labels.*.name, 'submission')
     runs-on: ubuntu-latest
+    steps:
+      # Classify as provider submission or module submission
+      - name: Issue Template Selector
+        id: template-selector
+        run: |
+          is_provider=$(echo '${{ github.event.issue.labels.*.name }}' | jq 'any(. == "provider")')
+
+          if [[ "$is_provider" == "true" ]]
+          then
+            echo "TEMPLATE=provider.yml" >> "$GITHUB_OUTPUT"
+          else
+            echo "TEMPLATE=module.yml" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Parse Issue Body
+        id: parse
+        uses: issue-ops/parser@v0.2.2
+        with:
+          body: ${{ github.event.issue.body }}
+          issue-form-template: ${{ steps.template-selector.outputs.TEMPLATE }}
+          workspace: ${{ github.workspace }}
+
+      # install node/dependencies for validation scripts requiring libs
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@vX.X.X
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Dependencies
+        id: install
+        run: npm install
+
+      # Validate the parsed issue body against the issue form template and custom validators - see validator/config.yml
+      - name: Validate Issue
+        id: validate
+        uses: issue-ops/validator@v0.2.1
+        with:
+          issue-form-template: ${{ steps.template-selector.outputs.TEMPLATE }}
+          parsed-issue-body: ${{ steps.parse.outputs.json }}
+          workspace: ${{ github.workspace }}
+
+      - name: Print Validation Results
+        id: print
+        run: |
+          echo "Result: ${{ steps.validate.outputs.result }}"
+          echo "Errors: ${{ steps.validate.outputs.errors }}"
+
+    outputs:
+      type: ${{ steps.template-selector.outputs.TEMPLATE }}
+      form: ${{ steps.parse.outputs.json }}
+
+  submit-provider:
+    if: github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'provider') && contains(github.event.issue.labels.*.name, 'submission')
+    runs-on: ubuntu-latest
+    needs: parse-and-validate
     permissions:
       issues: write
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: './src/go.mod'
-      - name: Provider Issue to Pull Request
+      - name: Split Provider Parts
+        id: provider-split
         run: |
-          # Pull provider out of issue body
-          provider=$(echo "$BODY" | grep "### Repository" -A2 | tail -n1 | sed -e 's/[\r\n]//g')
-          echo "Detected Provider '$provider'"
-
-          # Check that provider matches expected pattern
-          if ! [[ "$provider" =~ [a-zA-Z0-9\-]+/terraform-provider-[a-zA-Z0-9\-]+ ]]; then
-            gh issue comment $NUMBER -b "Failed validation: Invalid provider '$provider'"
-            exit 1
-          fi
-
           # Split provider into namespace/terraform-provider-name
+          provider=${{ fromJSON(steps.parse.outputs.json).provider_repository }}
           namespace=${provider/\/*/}
           name=${provider/*\/terraform-provider-/}
           echo "Detected Namespace '$namespace'"
           echo "Detected Name '$name'"
 
-          jsonfile=$(echo "$namespace/$name" | sed -e 's,\(.\)\(.*\)/\(.*\),./providers/\L\1\E/\1\2/\3.json,')
+          echo "::set-output name=provider::$provider"
+          echo "::set-output name=namespace::$namespace"
+          echo "::set-output name=name::$name"
 
+      - name: Create Provider file and PR
+        id: provider-split
+        env:
+          provider: ${{ steps.provider-split.outputs.provider }}
+          namespace: ${{ steps.provider-split.outputs.namespace }}
+          name: ${{ steps.provider-split.outputs.name }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          URL: ${{ github.event.issue.url }}
+          TITLE: ${{ github.event.issue.title }}
+          BODY: ${{ github.event.issue.body }}
+        run: |
+          jsonfile=$(echo "$namespace/$name" | sed -e 's,\(.\)\(.*\)/\(.*\),./providers/\L\1\E/\1\2/\3.json,')
           if [[ -f $jsonfile ]]; then
             gh issue comment $NUMBER -b "Failed validation: This provider already exists within the registry. $jsonfile"
             exit 1
           fi
-
           mkdir -p $(dirname $jsonfile)
           echo '{}' > $jsonfile
-
           echo "Bumping $namespace"
           cd src
           # This might "bump" a few extra providers, but it will only commit the specific provider below
           go run ./cmd/bump-versions -provider-namespace $namespace -module-namespace this-really-should-not-exist-please-ignore-me
           cd -
-
-
           # Validate json file
           set +e
           grep -c '"version":' $jsonfile
@@ -62,11 +118,9 @@ jobs:
             exit 1
           fi
           set -e
-
           
           git config --global user.email "no-reply@opentofu.org"
           git config --global user.name "OpenTOFU Automation"
-
           branch="provider-submission_${namespace}_${name}"
           set +e
           git checkout -b $branch
@@ -75,115 +129,20 @@ jobs:
             exit 1
           fi
           set -e
-
           git add $jsonfile
           git commit -s -m "Create provider $namespace/$name"
           git push -u origin $branch
-
           pr=$(gh pr create --title "$TITLE" --body "Created $jsonfile for provider $namespace/$name.  See issue #$NUMBER for details.") #--assignee opentofu/core-engineers)
-
           gh issue comment $NUMBER -b "Your submission has been accepted and has moved on to the pull request phase ($pr)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
-          URL: ${{ github.event.issue.url }}
-          TITLE: ${{ github.event.issue.title }}
-          BODY: ${{ github.event.issue.body }}
 
-  module_issue_to_pr:
-    if: contains(github.event.issue.labels.*.name, 'module') && contains(github.event.issue.labels.*.name, 'submission') 
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version-file: './src/go.mod'
-      - name: Module Issue to Pull Request
-        run: |
-          # Pull module out of issue body
-          module=$(echo "$BODY" | grep "### Repository" -A2 | tail -n1 | sed -e 's/[\r\n]//g')
-          echo "Detected Module '$module'"
+#
+#  submit-module:
+#    if: github.event.action == 'opened' && contains(github.event.issue.labels.*.name, 'module') && contains(github.event.issue.labels.*.name, 'submission')
+#    runs-on: ubuntu-latest
+#    permissions:
+#      issues: write
+#      contents: write
+#      pull-requests: write
+#    steps:
 
-          # Check that it's not a provider
-          if [[ "$module" =~ [a-zA-Z0-9\-]+/terraform-module-[a-zA-Z0-9\-]+ ]]; then
-            gh issue comment $NUMBER -b "Failed validation: Likely a provider '$module'"
-            exit 1
-          fi
-
-          # Check that module matches expected pattern
-          if ! [[ "$module" =~ [a-zA-Z0-9\-]+/terraform-[a-zA-Z0-9]+-[a-zA-Z0-9\-]+ ]]; then
-            gh issue comment $NUMBER -b "Failed validation: Invalid module '$module'"
-            exit 1
-          fi
-
-          # Split module into namespace/terraform-module-name
-          namespace=${module/\/*/}
-          full=${module/*\/terraform-/}
-          target=${full/-[^-]*/}
-          name=${full/$target-/}
-          echo "Detected Namespace '$namespace'"
-          echo "Detected Target '$target'"
-          echo "Detected Name '$name'"
-
-          jsonfile=$(echo "${namespace}/${name}/${target}.json" | sed -e 's,\(.\).*,./modules/\L\1\E/\0,')
-
-          if [[ -f $jsonfile ]]; then
-            gh issue comment $NUMBER -b "Failed validation: This module already exists within the registry. $jsonfile"
-            exit 1
-          fi
-
-          mkdir -p $(dirname $jsonfile)
-          echo '{}' > $jsonfile
-
-          echo "Bumping $namespace"
-          cd src
-          # This might "bump" a few extra modules, but it will only commit the specific module below
-          go run ./cmd/bump-versions -module-namespace $namespace -provider-namespace this-really-should-not-exist-please-ignore-me
-          cd -
-
-
-          # Validate json file
-          set +e
-          grep -c '"version":' $jsonfile
-          if [[ "$?" != 0 ]]; then
-            gh issue comment $NUMBER -b "Failed validation: No versions detected in $jsonfile"
-            exit 1
-          fi
-          set -e
-
-          
-          git config --global user.email "no-reply@opentofu.org"
-          git config --global user.name "OpenTOFU Automation"
-
-          branch="module-submission_${namespace}_${name}"
-          set +e
-          git checkout -b $branch
-          if [[ "$?" != 0 ]]; then
-            gh issue comment $NUMBER -b "Failed validation: A branch already exists for this module '$branch'"
-            exit 1
-          fi
-          set -e
-
-          git add $jsonfile
-          git commit -s -m "Create module $namespace/$name"
-          git push -u origin $branch
-
-          pr=$(gh pr create --title "$TITLE" --body "Created $jsonfile for module $namespace/$name.  See issue #$NUMBER for details.") #--assignee opentofu/core-engineers)
-
-          gh issue comment $NUMBER -b "Your submission has been accepted and has moved on to the pull request phase ($pr)"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          NUMBER: ${{ github.event.issue.number }}
-          URL: ${{ github.event.issue.url }}
-          TITLE: ${{ github.event.issue.title }}
-          BODY: ${{ github.event.issue.body }}
+  # TODO: account for what to do with issue/pr on module/provider *edits* next

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -30,19 +30,12 @@ jobs:
           issue-form-template: ${{ steps.template-selector.outputs.TEMPLATE }}
           workspace: ${{ github.workspace }}
 
-      # install node/dependencies for validation scripts requiring libs
       - name: Setup Node.js
         id: setup-node
         uses: actions/setup-node@vX.X.X
         with:
           node-version: 20
           cache: npm
-
-      - name: Install Dependencies
-        id: install
-        working-directory: .github/validator
-        run: | 
-          npm install @octokit/core@5.0.2 @octokit/rest@20.0.2
 
       # Validate the parsed issue body against the issue form template and custom validators - see validator/config.yml
       - name: Validate Issue


### PR DESCRIPTION
This is a code suggestion on top of https://github.com/opentofu/registry/pull/79  

It's meant to capture in code what I had in mind in [my review](https://github.com/opentofu/registry/pull/79#pullrequestreview-1761300271), namely:  
1. Use a dedicated action that parses form inputs
2. Use a dedicated action to validate the form matches the template on create/edit
3. Separate the various form field validation logic from the submission logic (using form action)
4. Split certain steps and new/edited issue jobs