### PR TITLE
Added verification package with result type to render markdown reports

### DIFF
--- a/src/pkg/verification/result.go
+++ b/src/pkg/verification/result.go
@@ -1,0 +1,80 @@
+package verification
+
+import "fmt"
+
+type Status string
+
+const (
+	StatusSuccess Status = "success"
+	StatusFailure Status = "failure"
+	StatusNotRun  Status = "not_run"
+	StatusSkipped Status = "skipped"
+)
+
+type Step struct {
+	Name   string   `json:"name"`
+	Status Status   `json:"status"`
+	Errors []string `json:"errors"`
+
+	SubSteps []*Step `json:"sub_steps"`
+}
+
+func (s *Step) AddStep(name string, status Status, errors ...string) *Step {
+	step := Step{
+		Name:   name,
+		Status: status,
+		Errors: errors,
+	}
+	s.SubSteps = append(s.SubSteps, &step)
+	return &step
+}
+
+type Result struct {
+	Steps []*Step `json:"steps"`
+}
+
+func (r *Result) AddStep(name string, status Status, errors ...string) *Step {
+	step := Step{
+		Name:   name,
+		Status: status,
+		Errors: errors,
+	}
+	r.Steps = append(r.Steps, &step)
+	return &step
+}
+
+func (r *Result) RenderMarkdown() string {
+	var output string
+	for _, step := range r.Steps {
+		output += fmt.Sprintf("### %s\n", step.Name)
+		if step.Status == StatusSuccess {
+			output += "✅ **Success**\n"
+		} else if step.Status == StatusFailure {
+			output += "❌ **Failure**\n"
+		} else if step.Status == StatusNotRun {
+			output += "⚠️ **Not Run**\n"
+		} else if step.Status == StatusSkipped {
+			output += "⚠️ **Skipped**\n"
+		}
+		for _, err := range step.Errors {
+			output += fmt.Sprintf("- %s\n", err)
+		}
+		for _, subStep := range step.SubSteps {
+			output += fmt.Sprintf("#### %s\n", subStep.Name)
+			if subStep.Status == StatusSuccess {
+				output += "✅ **Success**\n"
+			} else if subStep.Status == StatusFailure {
+				output += "❌ **Failure**\n"
+			} else if subStep.Status == StatusNotRun {
+				output += "⚠️ **Not Run**\n"
+			} else if subStep.Status == StatusSkipped {
+				output += "⚠️ **Skipped**\n"
+			}
+			for _, err := range subStep.Errors {
+				output += fmt.Sprintf("- %s\n", err)
+			}
+		}
+		output += "\n"
+	}
+	return output
+}

--- a/src/pkg/verification/result_test.go
+++ b/src/pkg/verification/result_test.go
@@ -1,0 +1,20 @@
+package verification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRender(t *testing.T) {
+	result := Result{}
+	result.AddStep("Step 1", StatusSuccess)
+	result.AddStep("Step 2", StatusFailure, "Error 1", "Error 2")
+	result.AddStep("Step 3", StatusNotRun)
+	s := result.AddStep("Step 4", StatusSkipped)
+
+	s.AddStep("Sub Step 1", StatusSuccess)
+
+	rendered := result.RenderMarkdown()
+	assert.Equal(t, rendered, "### Step 1\n✅ **Success**\n\n### Step 2\n❌ **Failure**\n- Error 1\n- Error 2\n\n### Step 3\n⚠️ **Not Run**\n\n### Step 4\n⚠️ **Skipped**\n\n")
+}


### PR DESCRIPTION
This package is intended to be used by our many stages of validation, and to simplify the process of us generating reports from multi-stage verifications and aid end-users in their journey.

Overall, It should allow us to have one method of reporting errors in the validation stage across all our processes.


### Preview

It will generate that looks something like this:

---

### Step 1
✅ **Success**

### Step 2
❌ **Failure**
- Error 1
- Error 2

### Step 3
⚠️ **Not Run**

### Step 4
⚠️ **Skipped**
#### Sub Step 1
✅ **Success**

