### PR TITLE
Dont remove objects from bucket on sync

### DIFF
--- a/.github/workflows/generate-and-deploy-with-delete.yml
+++ b/.github/workflows/generate-and-deploy-with-delete.yml
@@ -1,0 +1,38 @@
+name: Generate and Sync Files with Delete
+
+on:
+  workflow_dispatch
+
+jobs:
+  generate-and-sync:
+    runs-on: ubuntu-latest
+
+    environment: Development-with-delete
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: './src/go.mod'
+
+      - name: Setup dependencies
+        run: sudo apt-get install rclone
+
+      - name: Run Generation script
+        working-directory: ./src
+        run: go run ./cmd/generate-v1 --destination ../generated
+        env:
+           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Sync Data to R2
+        run: rclone sync --checkers=512 --transfers=512 --checksum --fast-list ./generated R2:${{ secrets.R2_BUCKET_NAME }}
+        env:
+          # R2 credentials should be stored as GitHub secrets
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}

--- a/.github/workflows/generate-and-deploy-with-delete.yml
+++ b/.github/workflows/generate-and-deploy-with-delete.yml
@@ -1,3 +1,4 @@
+# Be aware: This workflow should be kept in sync with generate-and-deploy.yml
 name: Generate and Sync Files with Delete
 
 on:

--- a/.github/workflows/generate-and-deploy-with-delete.yml
+++ b/.github/workflows/generate-and-deploy-with-delete.yml
@@ -7,7 +7,7 @@ jobs:
   generate-and-sync:
     runs-on: ubuntu-latest
 
-    environment: Development-with-delete
+    environment: Production-with-delete
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
            GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Sync Data to R2
-        run: rclone sync --checkers=512 --transfers=512 --checksum --fast-list ./generated R2:${{ secrets.R2_BUCKET_NAME }}
+        run: rclone sync --checkers=512 --transfers=512 --checksum --fast-list --max-delete 0 ./generated R2:${{ secrets.R2_BUCKET_NAME }}
         env:
           # R2 credentials should be stored as GitHub secrets
           RCLONE_CONFIG_R2_TYPE: s3

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -7,7 +7,7 @@ jobs:
   generate-and-sync:
     runs-on: ubuntu-latest
 
-    environment: Development
+    environment: Production
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -1,3 +1,4 @@
+# Be aware: This workflow should be kept in sync with generate-and-deploy-with-delete.yml
 name: Generate and Sync Files
 
 on:

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -28,7 +28,7 @@ jobs:
            GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Sync Data to R2
-        run: rclone sync --checkers=512 --transfers=512 --checksum --fast-list --max-delete 0 ./generated R2:${{ secrets.R2_BUCKET_NAME }}
+        run: rclone sync --checkers=512 --transfers=512 --checksum --fast-list --max-delete 0 --delete-after ./generated R2:${{ secrets.R2_BUCKET_NAME }}
         env:
           # R2 credentials should be stored as GitHub secrets
           RCLONE_CONFIG_R2_TYPE: s3


### PR DESCRIPTION
By default, we don't want our R2 sync process to delete objects from the bucket. 
1. I added the flags `--max-delete 0 --delete-after` to the existing workflow `generate-and-deploy.yml`.
It's worth mentioning that if the `rclone sync` tries to delete objects from the bucket, the workflow will fail with an error. If it bugs us, we might consider switching to `rclone copy` instead.
2. In addition, I added a new workflow that allows the deletion of objects in case we want to overwrite the objects in the bucket. This workflow will use a new environment that will require 2 approvals.
3. Also changed the GH environments to represent production instead of development.

Fully tested it [on my fork](https://github.com/Evi1Pumpkin/registry).


Fixes https://github.com/opentofu/registry/issues/65
