### PR TITLE
Added basic gpg verification process that generates a markdown report

### DIFF
--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"net/mail"
+	"os"
+	"regexp"
+
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/opentofu/registry-stable/internal/github"
+	"github.com/opentofu/registry-stable/internal/gpg"
+	"github.com/opentofu/registry-stable/pkg/verification"
+	"github.com/shurcooL/githubv4"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	keyFile := flag.String("key-file", "", "Location of the GPG key to verify")
+	username := flag.String("username", "", "Github username to verify the GPG key against")
+	orgName := flag.String("org", "", "Github organization name to verify the GPG key against")
+	flag.Parse()
+
+	logger = logger.With(slog.String("github", *username), slog.String("org", *orgName))
+	// TODO: Pass the logger around properly
+	slog.SetDefault(logger)
+	logger.Debug("Verifying GPG key from location", slog.String("location", *keyFile))
+
+	token, err := github.EnvAuthToken()
+	if err != nil {
+		logger.Error("Initialization Error", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+	ghClient := github.NewClient(ctx, logger, token)
+
+	result := &verification.Result{}
+
+	s := VerifyKey(*keyFile)
+	result.Steps = append(result.Steps, s)
+
+	s = VerifyGithubUser(ghClient, *username, *orgName)
+	result.Steps = append(result.Steps, s)
+
+	// TODO: Add verification to ensure that the key has been used to sign providers in this github organization
+
+	fmt.Println(result.RenderMarkdown())
+}
+
+func VerifyGithubUser(client github.Client, username string, orgName string) *verification.Step {
+	verifyStep := &verification.Step{
+		Name: "Validate Github user",
+	}
+
+	var user *github.GHUser
+
+	verifyStep.RunStep("User exists", func() error {
+		u, err := client.GetUser(username)
+		if err != nil {
+			return fmt.Errorf("failed to get user: %w", err)
+		}
+
+		user = u
+		return nil
+	})
+
+	if user == nil {
+		// quickly skip the rest of the steps because the first failed
+		verifyStep.AddStep(fmt.Sprintf("User is a member of the organization %s", orgName), "skipped", "User does not exist")
+		return verifyStep
+	}
+
+	verifyStep.RunStep(fmt.Sprintf("User is a member of the organization %s", orgName), func() error {
+		// Todo: maybe handle pagination, but in theory I doubt people are in 99+ organizations
+		for _, org := range user.User.Organizations.Nodes {
+			if org.Name == githubv4.String(orgName) {
+				return nil
+			}
+		}
+		// TODO: Output a helpful error message here that includes the list of organizations the user is a member of
+		// and how they can publicly display their organization membership
+		return fmt.Errorf("user is not a member of the organization")
+	})
+
+	return verifyStep
+}
+
+var gpgNameEmailRegex = regexp.MustCompile(`\<(.*)\>`)
+
+func VerifyKey(location string) *verification.Step {
+	verifyStep := &verification.Step{
+		Name: "Validate GPG key",
+	}
+
+	// read the key from the filesystem
+	data, err := os.ReadFile(location)
+	if err != nil {
+		verifyStep.AddError(fmt.Errorf("failed to read key file: %w", err))
+		verifyStep.Status = verification.StatusFailure
+		return verifyStep
+	}
+
+	var key *crypto.Key
+	verifyStep.RunStep("Key is a valid PGP key", func() error {
+		k, err := gpg.ParseKey(string(data))
+		if err != nil {
+			return fmt.Errorf("could not parse key: %w", err)
+		}
+		key = k
+		return nil
+	})
+
+	verifyStep.RunStep("Key is not expired", func() error {
+		if key.IsExpired() {
+			return fmt.Errorf("key is expired")
+		}
+		return nil
+	})
+
+	verifyStep.RunStep("Key is not revoked", func() error {
+		if key.IsRevoked() {
+			return fmt.Errorf("key is revoked")
+		}
+		return nil
+	})
+
+	verifyStep.RunStep("Key can be used for signing", func() error {
+		if !key.CanVerify() {
+			return fmt.Errorf("key cannot be used for signing")
+		}
+		return nil
+	})
+
+	verifyStep.RunStep("Key has a valid identity and email", func() error {
+		if key.GetFingerprint() == "" {
+			return fmt.Errorf("key has no fingerprint")
+		}
+
+		entity := key.GetEntity()
+		if entity == nil {
+			return fmt.Errorf("key has no entity")
+		}
+
+		identities := entity.Identities
+		if len(identities) == 0 {
+			return fmt.Errorf("key has no identities")
+		}
+
+		for idName, identity := range identities {
+			if identity.Name == "" {
+				return fmt.Errorf("Key identity %s has no name", idName)
+			}
+
+			email := gpgNameEmailRegex.FindStringSubmatch(identity.Name)
+			if len(email) != 2 {
+				return fmt.Errorf("Key identity %s has no email", idName)
+			}
+
+			_, err := mail.ParseAddress(email[1])
+			if err != nil {
+				return fmt.Errorf("Key identity %s has an invalid email: %w", idName, err)
+			}
+		}
+
+		return nil
+	})
+
+	return verifyStep
+}

--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -25,7 +25,6 @@ func main() {
 	flag.Parse()
 
 	logger = logger.With(slog.String("github", *username), slog.String("org", *orgName))
-	// TODO: Pass the logger around properly
 	slog.SetDefault(logger)
 	logger.Debug("Verifying GPG key from location", slog.String("location", *keyFile))
 
@@ -70,7 +69,7 @@ func VerifyGithubUser(client github.Client, username string, orgName string) *ve
 
 	if user == nil {
 		// quickly skip the rest of the steps because the first failed
-		verifyStep.AddStep(fmt.Sprintf("User is a member of the organization %s", orgName), "skipped", "User does not exist")
+		verifyStep.AddStep(fmt.Sprintf("User is a member of the organization %s", orgName), verification.StatusSkipped, "User does not exist")
 		return verifyStep
 	}
 

--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -74,7 +74,7 @@ func VerifyGithubUser(client github.Client, username string, orgName string) *ve
 		return verifyStep
 	}
 
-	verifyStep.RunStep(fmt.Sprintf("User is a member of the organization %s", orgName), func() error {
+	s := verifyStep.RunStep(fmt.Sprintf("User is a member of the organization %s", orgName), func() error {
 		// Todo: maybe handle pagination, but in theory I doubt people are in 99+ organizations
 		for _, org := range user.User.Organizations.Nodes {
 			if org.Name == githubv4.String(orgName) {
@@ -85,6 +85,7 @@ func VerifyGithubUser(client github.Client, username string, orgName string) *ve
 		// and how they can publicly display their organization membership
 		return fmt.Errorf("user is not a member of the organization")
 	})
+	s.Remarks = []string{"If this is incorrect, please ensure that your organization membership is public. For more information, see [Github Docs - Publicizing or hiding organization membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership)"}
 
 	return verifyStep
 }

--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -89,7 +89,7 @@ func VerifyGithubUser(client github.Client, username string, orgName string) *ve
 	return verifyStep
 }
 
-var gpgNameEmailRegex = regexp.MustCompile(`\<(.*)\>`)
+var gpgNameEmailRegex = regexp.MustCompile(`.*\<(.*)\>`)
 
 func VerifyKey(location string) *verification.Step {
 	verifyStep := &verification.Step{
@@ -135,7 +135,7 @@ func VerifyKey(location string) *verification.Step {
 		return nil
 	})
 
-	verifyStep.RunStep("Key has a valid identity and email", func() error {
+	verifyStep.RunStep("Key has a valid identity and email. (Email is preferable but optional)", func() error {
 		if key.GetFingerprint() == "" {
 			return fmt.Errorf("key has no fingerprint")
 		}

--- a/src/internal/github/user.go
+++ b/src/internal/github/user.go
@@ -18,7 +18,7 @@ type GHUser struct {
 				EndCursor   githubv4.String
 				HasNextPage githubv4.Boolean
 			}
-		} `graphql:"organizations(first: 99)"` // Adjust the 'first' parameter as needed
+		} `graphql:"organizations(first: 99)"`
 	} `graphql:"user(login: $login)"`
 }
 
@@ -26,7 +26,7 @@ func (c Client) GetUser(username string) (*GHUser, error) {
 	logger := c.log.With("username", username)
 	logger.Debug("GetUser")
 	variables := map[string]interface{}{
-		"login": githubv4.String(username), // Replace with the username you're interested in
+		"login": githubv4.String(username),
 	}
 
 	var user GHUser

--- a/src/internal/github/user.go
+++ b/src/internal/github/user.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/shurcooL/githubv4"
 )
@@ -32,7 +33,7 @@ func (c Client) GetUser(username string) (*GHUser, error) {
 	var user GHUser
 	err := c.ghClient.Query(c.ctx, &user, variables)
 	if err != nil {
-		logger.Error("unable to fetch user", "error", err)
+		logger.Error("unable to fetch user", slog.Any("err", err))
 		return nil, fmt.Errorf("unable to fetch user: %w", err)
 	}
 

--- a/src/internal/github/user.go
+++ b/src/internal/github/user.go
@@ -1,0 +1,40 @@
+package github
+
+import (
+	"fmt"
+
+	"github.com/shurcooL/githubv4"
+)
+
+type GHUser struct {
+	User struct {
+		Login         githubv4.String
+		Name          githubv4.String
+		Organizations struct {
+			Nodes []struct {
+				Name githubv4.String
+			}
+			PageInfo struct {
+				EndCursor   githubv4.String
+				HasNextPage githubv4.Boolean
+			}
+		} `graphql:"organizations(first: 99)"` // Adjust the 'first' parameter as needed
+	} `graphql:"user(login: $login)"`
+}
+
+func (c Client) GetUser(username string) (*GHUser, error) {
+	logger := c.log.With("username", username)
+	logger.Debug("GetUser")
+	variables := map[string]interface{}{
+		"login": githubv4.String(username), // Replace with the username you're interested in
+	}
+
+	var user GHUser
+	err := c.ghClient.Query(c.ctx, &user, variables)
+	if err != nil {
+		logger.Error("unable to fetch user", "error", err)
+		return nil, fmt.Errorf("unable to fetch user: %w", err)
+	}
+
+	return &user, nil
+}

--- a/src/internal/gpg/key.go
+++ b/src/internal/gpg/key.go
@@ -28,13 +28,23 @@ func buildKey(path string) (*Key, error) {
 
 	asciiArmor := string(data)
 
-	key, err := crypto.NewKeyFromArmored(asciiArmor)
+	key, err := ParseKey(asciiArmor)
 	if err != nil {
-		return nil, fmt.Errorf("could not build public key from ascii armor: %w", err)
+		return nil, fmt.Errorf("could not parse key: %w", err)
 	}
 
 	return &Key{
 		ASCIIArmor: asciiArmor,
 		KeyID:      strings.ToUpper(key.GetHexKeyID()),
 	}, nil
+}
+
+// ParseKey parses a GPG key from ascii armor.
+func ParseKey(data string) (*crypto.Key, error) {
+	key, err := crypto.NewKeyFromArmored(data)
+	if err != nil {
+		return nil, fmt.Errorf("could not build public key from ascii armor: %w", err)
+	}
+
+	return key, nil
 }

--- a/src/internal/gpg/key_test.go
+++ b/src/internal/gpg/key_test.go
@@ -1,23 +1,70 @@
 package gpg
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
 	"testing"
 
+	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"github.com/ProtonMail/gopenpgp/v2/helper"
 	"github.com/stretchr/testify/assert"
 )
+
+func generatePrivateKey() (string, error) {
+	// Generate a new RSA private key with 2048 bits
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", err
+	}
+	// Encode the private key to the PEM format
+	privateKeyPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}
+
+	return string(pem.EncodeToMemory(privateKeyPEM)), nil
+}
+
+func generateGPGKey() (string, error) {
+	rsaKey, err := helper.GenerateKey("test", "test", []byte("test"), "rsa", 1024)
+	if err != nil {
+		panic(err)
+	}
+
+	keyRing, err := crypto.NewKeyFromArmoredReader(strings.NewReader(rsaKey))
+	if err != nil {
+		panic(err)
+	}
+
+	publicKey, err := keyRing.GetArmoredPublicKey()
+	if err != nil {
+		panic(err)
+	}
+
+	return publicKey, nil
+}
 
 func TestParseKey(t *testing.T) {
 	stringPtr := func(s string) *string {
 		return &s
 	}
 
-	privateKey := `-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC/rbBBBC0iJkW3\nbRnKICpWrVhEsjmgSPs/cF7KihVYhriGspcgpaF8RmVw+k98Wj0SmO+sGc81pfDv\nxpl4PrN9lTsvvkxF4CfNXZr21vLaaC32jD8HnZtEuWsA+bByd7lEKw0N0652cWjm\nRD8/CYUSMFWe4VM1tjPMD1l9/oL8T6/z2nGHgMH+hXkES2aYOclfyqwHkHnLObMf\nZGvYxp0CZ+fbSW+KRfL6qHaM03/1ZsofNS2phJhk341R09suxn1fWpkhyWPtUSZF\n1TVUEjgCkUlppTvoCtE/UAsM17ey5AZKlhFxgh0IvN21sFeXFtRjzQrcZTUA5Dj5\n7lYaicmJAgMBAAECggEBALcloq+86dMjdqHZITc8nLfNUfXxxZYdpdPr7ubgIZ1A\nvLgXlMeg+zffm7Xjtmc/YfOPJhLvZkoAkMLKpIF8h8yK9s6bqg1qLR3RPux0Xf/K\nY4CcaO1B7sYv1MpNygbV1rQH3qVDigOqQW0j8LquwfOrM2RoMDW2Lq/gSsZUlZu2\nb6OpJJWRTDEbHsJausOU8Yp/u2ZOv0fIGE65cU/oyX4pcJzSnXXrrB6bdEJfkgJ2\nejzK3rvdz97iE7N8i/9o3mBNTTZgnO6sqGH4vIa5dZpEuAgUpYPanbO27ELRkA2K\nMsyukonBdkGhNAAEIHfYErFw+a8C/29dXwCe1C8ipDECgYEA8ZMpccSnIssnV2xB\nRP5AXTkyQMrBqtqGzmcs1BT3D1TsOywe5U3OaDZlFcdEJq3DIgYheNZsalQNy55C\nPQO6Mh4McXHlAQ7BA4ukYg+ww3E5LbXo+5TkPpHgq6iIxSNusOk3boloMEhlT56G\nIwY2YHgesiCQWvc2hC92+2QGgpcCgYEAyx/I46PSThkoRCxzIHKERJA6XghbNI+y\nnXW0N0M87iVeT261FhTbOBx8uzGzTnqTXdgBZLO2Kdw4r4stR8cMXlFESciX7Jw6\n+aOJrNMIXXI/lhTqhcni6ncPYgipM77a9quvx/oGEpx/0yitkFY772z3UMUiH8Wh\nzuXZbxi7ON8CgYBMuc/M+YeYDmwVYSWt0w8ATN1AJOWz7Sopvi1HwszhSrio5o99\nhuPKx5P9gceMfV3fnZDd/0R51O54wHALTvbBWjfbhDAW0OfOx3hTSOZ8fKaLdR5l\nYVnI4a449xNRgbpzZ+8aJXw48ZVz30Z9M0jsBNrC+oK+0Yu4GhcxKwjCSwKBgHjN\nLmwzwZ8w1wG0bcOeV4tvO0cxMQzRaSi8F7HGCzaWgsA61veK79UvG/84T6scuwfU\nrv904aGDlzLPUt6dQn3VVweKhM/zGh/dYsOlvhPVHnvjdJacupc2t69V90sO9qo8\n8Q29ZF8tM9ghGRf+MSbzZyJiGylKIDEsAWRREQeBAoGAPfqkmisNWKuHpcGsyYjT\nAkPVev7SZrUW9YwMcOa2+aA56CI/zKCO7U0ZvVf6TEWnPzT/UGedkYFP+/6vQxUh\n2TxMmjU7l4C829k5ZZ0OlG6IHvtaK2vkJmEKWI7sGE2GMewwXEsfjJs0y+Szxb6U\nzPRa6IiVxnJAiqbjs+W/fC4=\n-----END PRIVATE KEY-----\n`
+	privateKey, _ := generatePrivateKey()
+	publicGPGKey, _ := generateGPGKey()
 
 	tests := []struct {
 		name        string
 		data        string
 		expectedErr *string
 	}{
+		{
+			name:        "public gpg key should succeed",
+			data:        publicGPGKey,
+			expectedErr: nil,
+		},
 		{
 			name:        "private key should fail",
 			data:        privateKey,

--- a/src/internal/gpg/key_test.go
+++ b/src/internal/gpg/key_test.go
@@ -1,0 +1,39 @@
+package gpg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseKey(t *testing.T) {
+	stringPtr := func(s string) *string {
+		return &s
+	}
+
+	privateKey := `-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC/rbBBBC0iJkW3\nbRnKICpWrVhEsjmgSPs/cF7KihVYhriGspcgpaF8RmVw+k98Wj0SmO+sGc81pfDv\nxpl4PrN9lTsvvkxF4CfNXZr21vLaaC32jD8HnZtEuWsA+bByd7lEKw0N0652cWjm\nRD8/CYUSMFWe4VM1tjPMD1l9/oL8T6/z2nGHgMH+hXkES2aYOclfyqwHkHnLObMf\nZGvYxp0CZ+fbSW+KRfL6qHaM03/1ZsofNS2phJhk341R09suxn1fWpkhyWPtUSZF\n1TVUEjgCkUlppTvoCtE/UAsM17ey5AZKlhFxgh0IvN21sFeXFtRjzQrcZTUA5Dj5\n7lYaicmJAgMBAAECggEBALcloq+86dMjdqHZITc8nLfNUfXxxZYdpdPr7ubgIZ1A\nvLgXlMeg+zffm7Xjtmc/YfOPJhLvZkoAkMLKpIF8h8yK9s6bqg1qLR3RPux0Xf/K\nY4CcaO1B7sYv1MpNygbV1rQH3qVDigOqQW0j8LquwfOrM2RoMDW2Lq/gSsZUlZu2\nb6OpJJWRTDEbHsJausOU8Yp/u2ZOv0fIGE65cU/oyX4pcJzSnXXrrB6bdEJfkgJ2\nejzK3rvdz97iE7N8i/9o3mBNTTZgnO6sqGH4vIa5dZpEuAgUpYPanbO27ELRkA2K\nMsyukonBdkGhNAAEIHfYErFw+a8C/29dXwCe1C8ipDECgYEA8ZMpccSnIssnV2xB\nRP5AXTkyQMrBqtqGzmcs1BT3D1TsOywe5U3OaDZlFcdEJq3DIgYheNZsalQNy55C\nPQO6Mh4McXHlAQ7BA4ukYg+ww3E5LbXo+5TkPpHgq6iIxSNusOk3boloMEhlT56G\nIwY2YHgesiCQWvc2hC92+2QGgpcCgYEAyx/I46PSThkoRCxzIHKERJA6XghbNI+y\nnXW0N0M87iVeT261FhTbOBx8uzGzTnqTXdgBZLO2Kdw4r4stR8cMXlFESciX7Jw6\n+aOJrNMIXXI/lhTqhcni6ncPYgipM77a9quvx/oGEpx/0yitkFY772z3UMUiH8Wh\nzuXZbxi7ON8CgYBMuc/M+YeYDmwVYSWt0w8ATN1AJOWz7Sopvi1HwszhSrio5o99\nhuPKx5P9gceMfV3fnZDd/0R51O54wHALTvbBWjfbhDAW0OfOx3hTSOZ8fKaLdR5l\nYVnI4a449xNRgbpzZ+8aJXw48ZVz30Z9M0jsBNrC+oK+0Yu4GhcxKwjCSwKBgHjN\nLmwzwZ8w1wG0bcOeV4tvO0cxMQzRaSi8F7HGCzaWgsA61veK79UvG/84T6scuwfU\nrv904aGDlzLPUt6dQn3VVweKhM/zGh/dYsOlvhPVHnvjdJacupc2t69V90sO9qo8\n8Q29ZF8tM9ghGRf+MSbzZyJiGylKIDEsAWRREQeBAoGAPfqkmisNWKuHpcGsyYjT\nAkPVev7SZrUW9YwMcOa2+aA56CI/zKCO7U0ZvVf6TEWnPzT/UGedkYFP+/6vQxUh\n2TxMmjU7l4C829k5ZZ0OlG6IHvtaK2vkJmEKWI7sGE2GMewwXEsfjJs0y+Szxb6U\nzPRa6IiVxnJAiqbjs+W/fC4=\n-----END PRIVATE KEY-----\n`
+
+	tests := []struct {
+		name        string
+		data        string
+		expectedErr *string
+	}{
+		{
+			name:        "private key should fail",
+			data:        privateKey,
+			expectedErr: stringPtr("bleh"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := ParseKey(test.data)
+
+			if test.expectedErr != nil {
+				assert.ErrorContains(t, err, "could not build public key from ascii armor")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/src/internal/gpg/key_test.go
+++ b/src/internal/gpg/key_test.go
@@ -21,7 +21,7 @@ func TestParseKey(t *testing.T) {
 		{
 			name:        "private key should fail",
 			data:        privateKey,
-			expectedErr: stringPtr("bleh"),
+			expectedErr: stringPtr("could not build public key from ascii armor"),
 		},
 	}
 
@@ -30,7 +30,7 @@ func TestParseKey(t *testing.T) {
 			_, err := ParseKey(test.data)
 
 			if test.expectedErr != nil {
-				assert.ErrorContains(t, err, "could not build public key from ascii armor")
+				assert.ErrorContains(t, err, *test.expectedErr)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/src/pkg/verification/render.go
+++ b/src/pkg/verification/render.go
@@ -1,0 +1,49 @@
+package verification
+
+import "fmt"
+
+func (r *Result) RenderMarkdown() string {
+	var output string
+	for _, step := range r.Steps {
+		output += fmt.Sprintf("## %s\n", step.Name)
+		for _, remark := range step.Remarks {
+			output += fmt.Sprintf("> [!NOTE]\n")
+			output += fmt.Sprintf("> %s\n\n", remark)
+		}
+		if step.Status == StatusSuccess {
+			output += "✅ **Success**\n"
+		} else if step.Status == StatusFailure {
+			output += "❌ **Failure**\n"
+		} else if step.Status == StatusNotRun {
+			output += "⚠️ **Not Run**\n"
+		} else if step.Status == StatusSkipped {
+			output += "⚠️ **Skipped**\n"
+		}
+
+		for _, err := range step.Errors {
+			output += fmt.Sprintf("- %s\n", err)
+		}
+		for _, subStep := range step.SubSteps {
+			output += fmt.Sprintf("### %s\n", subStep.Name)
+			for _, remark := range subStep.Remarks {
+				output += fmt.Sprintf("> [!NOTE]\n")
+				output += fmt.Sprintf("> %s\n\n", remark)
+			}
+			if subStep.Status == StatusSuccess {
+				output += "✅ **Success**\n"
+			} else if subStep.Status == StatusFailure {
+				output += "❌ **Failure**\n"
+			} else if subStep.Status == StatusNotRun {
+				output += "⚠️ **Not Run**\n"
+			} else if subStep.Status == StatusSkipped {
+				output += "⚠️ **Skipped**\n"
+			}
+
+			for _, err := range subStep.Errors {
+				output += fmt.Sprintf("- %s\n", err)
+			}
+		}
+		output += "\n"
+	}
+	return output
+}

--- a/src/pkg/verification/render_test.go
+++ b/src/pkg/verification/render_test.go
@@ -1,0 +1,29 @@
+package verification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRender(t *testing.T) {
+	result := Result{}
+	result.AddStep("Step 1", StatusSuccess)
+	result.AddStep("Step 2", StatusFailure, "Error 1", "Error 2")
+	result.AddStep("Step 3", StatusNotRun)
+	s := result.AddStep("Step 4", StatusSkipped)
+
+	s.AddStep("Sub Step 1", StatusSuccess)
+
+	rendered := result.RenderMarkdown()
+	assert.Equal(t, "## Step 1\n✅ **Success**\n\n## Step 2\n❌ **Failure**\n- Error 1\n- Error 2\n\n## Step 3\n⚠️ **Not Run**\n\n## Step 4\n⚠️ **Skipped**\n### Sub Step 1\n✅ **Success**\n\n", rendered)
+}
+
+func TestRender_Remarks(t *testing.T) {
+	result := Result{}
+	s := result.AddStep("Step 1", StatusSuccess)
+	s.Remarks = append(s.Remarks, "Remark 1", "Remark 2")
+
+	rendered := result.RenderMarkdown()
+	assert.Equal(t, "## Step 1\n> [!NOTE]\n> Remark 1\n\n> [!NOTE]\n> Remark 2\n\n✅ **Success**\n\n", rendered)
+}

--- a/src/pkg/verification/result.go
+++ b/src/pkg/verification/result.go
@@ -1,7 +1,5 @@
 package verification
 
-import "fmt"
-
 type Status string
 
 const (
@@ -10,41 +8,6 @@ const (
 	StatusNotRun  Status = "not_run"
 	StatusSkipped Status = "skipped"
 )
-
-type Step struct {
-	Name    string   `json:"name"`
-	Status  Status   `json:"status"`
-	Errors  []string `json:"errors"`
-	Remarks []string `json:"remarks"`
-
-	SubSteps []*Step `json:"sub_steps"`
-}
-
-func (s *Step) AddStep(name string, status Status, errors ...string) *Step {
-	step := Step{
-		Name:   name,
-		Status: status,
-		Errors: errors,
-	}
-	s.SubSteps = append(s.SubSteps, &step)
-	return &step
-}
-
-func (s *Step) RunStep(name string, fn func() error) *Step {
-	step := s.AddStep(name, StatusNotRun)
-	err := fn()
-	if err != nil {
-		step.AddError(err)
-		step.Status = StatusFailure
-	} else {
-		step.Status = StatusSuccess
-	}
-	return step
-}
-
-func (s *Step) AddError(err error) {
-	s.Errors = append(s.Errors, err.Error())
-}
 
 type Result struct {
 	Steps []*Step `json:"steps"`
@@ -60,19 +23,6 @@ func (r *Result) AddStep(name string, status Status, errors ...string) *Step {
 	return &step
 }
 
-func (s *Step) DidFail() bool {
-	if s.Status == StatusFailure {
-		return true
-	}
-
-	for _, step := range s.SubSteps {
-		if step.DidFail() {
-			return true
-		}
-	}
-	return false
-}
-
 func (r *Result) DidFail() bool {
 	for _, step := range r.Steps {
 		if step.DidFail() {
@@ -80,50 +30,4 @@ func (r *Result) DidFail() bool {
 		}
 	}
 	return false
-}
-
-func (r *Result) RenderMarkdown() string {
-	var output string
-	for _, step := range r.Steps {
-		output += fmt.Sprintf("## %s\n", step.Name)
-		for _, remark := range step.Remarks {
-			output += fmt.Sprintf("> [!NOTE]> Remark\n")
-			output += fmt.Sprintf("> %s\n\n", remark)
-		}
-		if step.Status == StatusSuccess {
-			output += "✅ **Success**\n"
-		} else if step.Status == StatusFailure {
-			output += "❌ **Failure**\n"
-		} else if step.Status == StatusNotRun {
-			output += "⚠️ **Not Run**\n"
-		} else if step.Status == StatusSkipped {
-			output += "⚠️ **Skipped**\n"
-		}
-
-		for _, err := range step.Errors {
-			output += fmt.Sprintf("- %s\n", err)
-		}
-		for _, subStep := range step.SubSteps {
-			output += fmt.Sprintf("### %s\n", subStep.Name)
-			for _, remark := range subStep.Remarks {
-				output += fmt.Sprintf("> [!NOTE]\n")
-				output += fmt.Sprintf("> %s\n\n", remark)
-			}
-			if subStep.Status == StatusSuccess {
-				output += "✅ **Success**\n"
-			} else if subStep.Status == StatusFailure {
-				output += "❌ **Failure**\n"
-			} else if subStep.Status == StatusNotRun {
-				output += "⚠️ **Not Run**\n"
-			} else if subStep.Status == StatusSkipped {
-				output += "⚠️ **Skipped**\n"
-			}
-
-			for _, err := range subStep.Errors {
-				output += fmt.Sprintf("- %s\n", err)
-			}
-		}
-		output += "\n"
-	}
-	return output
 }

--- a/src/pkg/verification/result.go
+++ b/src/pkg/verification/result.go
@@ -12,9 +12,10 @@ const (
 )
 
 type Step struct {
-	Name   string   `json:"name"`
-	Status Status   `json:"status"`
-	Errors []string `json:"errors"`
+	Name    string   `json:"name"`
+	Status  Status   `json:"status"`
+	Errors  []string `json:"errors"`
+	Remarks []string `json:"remarks"`
 
 	SubSteps []*Step `json:"sub_steps"`
 }
@@ -85,6 +86,10 @@ func (r *Result) RenderMarkdown() string {
 	var output string
 	for _, step := range r.Steps {
 		output += fmt.Sprintf("## %s\n", step.Name)
+		for _, remark := range step.Remarks {
+			output += fmt.Sprintf("> [!NOTE]> Remark\n")
+			output += fmt.Sprintf("> %s\n\n", remark)
+		}
 		if step.Status == StatusSuccess {
 			output += "✅ **Success**\n"
 		} else if step.Status == StatusFailure {
@@ -94,11 +99,16 @@ func (r *Result) RenderMarkdown() string {
 		} else if step.Status == StatusSkipped {
 			output += "⚠️ **Skipped**\n"
 		}
+
 		for _, err := range step.Errors {
 			output += fmt.Sprintf("- %s\n", err)
 		}
 		for _, subStep := range step.SubSteps {
 			output += fmt.Sprintf("### %s\n", subStep.Name)
+			for _, remark := range subStep.Remarks {
+				output += fmt.Sprintf("> [!NOTE]\n")
+				output += fmt.Sprintf("> %s\n\n", remark)
+			}
 			if subStep.Status == StatusSuccess {
 				output += "✅ **Success**\n"
 			} else if subStep.Status == StatusFailure {
@@ -108,6 +118,7 @@ func (r *Result) RenderMarkdown() string {
 			} else if subStep.Status == StatusSkipped {
 				output += "⚠️ **Skipped**\n"
 			}
+
 			for _, err := range subStep.Errors {
 				output += fmt.Sprintf("- %s\n", err)
 			}

--- a/src/pkg/verification/result_test.go
+++ b/src/pkg/verification/result_test.go
@@ -16,7 +16,16 @@ func TestRender(t *testing.T) {
 	s.AddStep("Sub Step 1", StatusSuccess)
 
 	rendered := result.RenderMarkdown()
-	assert.Equal(t, rendered, "## Step 1\n✅ **Success**\n\n## Step 2\n❌ **Failure**\n- Error 1\n- Error 2\n\n## Step 3\n⚠️ **Not Run**\n\n## Step 4\n⚠️ **Skipped**\n### Sub Step 1\n✅ **Success**\n\n")
+	assert.Equal(t, "## Step 1\n✅ **Success**\n\n## Step 2\n❌ **Failure**\n- Error 1\n- Error 2\n\n## Step 3\n⚠️ **Not Run**\n\n## Step 4\n⚠️ **Skipped**\n### Sub Step 1\n✅ **Success**\n\n", rendered)
+}
+
+func TestRender_Remarks(t *testing.T) {
+	result := Result{}
+	s := result.AddStep("Step 1", StatusSuccess)
+	s.Remarks = append(s.Remarks, "Remark 1", "Remark 2")
+
+	rendered := result.RenderMarkdown()
+	assert.Equal(t, "## Step 1\n> [!NOTE]> Remark\n> Remark 1\n> [!NOTE]> Remark\n> Remark 2\n✅ **Success**\n\n", rendered)
 }
 
 func TestDidFail_MainStepFailed(t *testing.T) {

--- a/src/pkg/verification/result_test.go
+++ b/src/pkg/verification/result_test.go
@@ -6,28 +6,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRender(t *testing.T) {
-	result := Result{}
-	result.AddStep("Step 1", StatusSuccess)
-	result.AddStep("Step 2", StatusFailure, "Error 1", "Error 2")
-	result.AddStep("Step 3", StatusNotRun)
-	s := result.AddStep("Step 4", StatusSkipped)
-
-	s.AddStep("Sub Step 1", StatusSuccess)
-
-	rendered := result.RenderMarkdown()
-	assert.Equal(t, "## Step 1\n✅ **Success**\n\n## Step 2\n❌ **Failure**\n- Error 1\n- Error 2\n\n## Step 3\n⚠️ **Not Run**\n\n## Step 4\n⚠️ **Skipped**\n### Sub Step 1\n✅ **Success**\n\n", rendered)
-}
-
-func TestRender_Remarks(t *testing.T) {
-	result := Result{}
-	s := result.AddStep("Step 1", StatusSuccess)
-	s.Remarks = append(s.Remarks, "Remark 1", "Remark 2")
-
-	rendered := result.RenderMarkdown()
-	assert.Equal(t, "## Step 1\n> [!NOTE]> Remark\n> Remark 1\n> [!NOTE]> Remark\n> Remark 2\n✅ **Success**\n\n", rendered)
-}
-
 func TestDidFail_MainStepFailed(t *testing.T) {
 	result := Result{}
 	result.AddStep("Step 1", StatusSuccess)

--- a/src/pkg/verification/step.go
+++ b/src/pkg/verification/step.go
@@ -1,0 +1,49 @@
+package verification
+
+type Step struct {
+	Name    string   `json:"name"`
+	Status  Status   `json:"status"`
+	Errors  []string `json:"errors"`
+	Remarks []string `json:"remarks"`
+
+	SubSteps []*Step `json:"sub_steps"`
+}
+
+func (s *Step) AddStep(name string, status Status, errors ...string) *Step {
+	step := Step{
+		Name:   name,
+		Status: status,
+		Errors: errors,
+	}
+	s.SubSteps = append(s.SubSteps, &step)
+	return &step
+}
+
+func (s *Step) RunStep(name string, fn func() error) *Step {
+	step := s.AddStep(name, StatusNotRun)
+	err := fn()
+	if err != nil {
+		step.AddError(err)
+		step.Status = StatusFailure
+	} else {
+		step.Status = StatusSuccess
+	}
+	return step
+}
+
+func (s *Step) AddError(err error) {
+	s.Errors = append(s.Errors, err.Error())
+}
+
+func (s *Step) DidFail() bool {
+	if s.Status == StatusFailure {
+		return true
+	}
+
+	for _, step := range s.SubSteps {
+		if step.DidFail() {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This process will generate a markdown report that we can attach to issues nicely to help users identify where the verification failed.

For example it could generate:

---

## Validate GPG key
### Key is a valid PGP key
✅ **Success**
### Key is not expired
✅ **Success**
### Key is not revoked
✅ **Success**
### Key can be used for signing
✅ **Success**
### Key has a valid identity and email
✅ **Success**

## Validate Github user
### User exists
❌ **Failure**
- failed to get user: unable to fetch user: Could not resolve to a User with the login of 'Yantrioiiii'.
### User is a member of the organization OpenTofuu
⚠️ **Skipped**
- User does not exist

