### PR TITLE
Fix links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![](https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/SVG/on-dark.svg#gh-dark-mode-only)
 ![](https://raw.githubusercontent.com/opentofu/brand-artifacts/main/full/transparent/SVG/on-light.svg#gh-light-mode-only)
 
-This repository is home to the metadata that drives the provider and module registry for [OpenTofu](github.com/opentofu/opentofu)
+This repository is home to the metadata that drives the provider and module registry for [OpenTofu](https://github.com/opentofu/opentofu)
 
-It also contains the applications used to manage version bumping, validation and API generation of the registry that is hosted at [registry.opentofu.org](registry.opentofu.org).
+It also contains the applications used to manage version bumping, validation and API generation of the registry that is hosted at [registry.opentofu.org](https://registry.opentofu.org).
 
 > [!IMPORTANT]
 > Please note this registry is a work in progress, and we are not currently accepting any new providers or modules from external contributors at this time until a full validation process has been put in place.


### PR DESCRIPTION
Links without a scheme are interpreted as relative file paths