### PR TITLE
Append module versions

### DIFF
--- a/src/internal/module/build.go
+++ b/src/internal/module/build.go
@@ -58,6 +58,11 @@ func (m Module) BuildMetadata() (*Metadata, error) {
 		}
 	}
 
+	semverSortFunc := func(a, b Version) int {
+		return -semver.Compare(fmt.Sprintf("v%s", internal.TrimTagPrefix(a.Version)), fmt.Sprintf("v%s", internal.TrimTagPrefix(b.Version)))
+	}
+	slices.SortFunc(meta.Versions, semverSortFunc)
+
 	return &meta, nil
 }
 

--- a/src/internal/module/build.go
+++ b/src/internal/module/build.go
@@ -39,12 +39,26 @@ func (m Module) BuildMetadata() (*Metadata, error) {
 		return nil, err
 	}
 
-	versions := make([]Version, len(tags))
-	for i, t := range tags {
-		versions[i] = Version{Version: t}
+	meta, err := m.ReadMetadata()
+	if err != nil {
+		return nil, err
 	}
 
-	return &Metadata{Versions: versions}, nil
+	// Merge current versions with new versions
+	for _, t := range tags {
+		found := false
+		for _, v := range meta.Versions {
+			if v.Version == t {
+				found = true
+				break
+			}
+		}
+		if !found {
+			meta.Versions = append(meta.Versions, Version{Version: t})
+		}
+	}
+
+	return &meta, nil
 }
 
 func (m Module) getSemverTags() ([]string, error) {

--- a/src/internal/v1api/modules.go
+++ b/src/internal/v1api/modules.go
@@ -48,7 +48,7 @@ func (m ModuleGenerator) VersionDownloadPath(v module.Version) string {
 func (m ModuleGenerator) VersionListing() ModuleVersionListingResponse {
 	versions := make([]ModuleVersionResponseItem, len(m.Metadata.Versions))
 	for i, v := range m.Metadata.Versions {
-		versions[i] = ModuleVersionResponseItem{Version: v.Version}
+		versions[i] = ModuleVersionResponseItem{Version: internal.TrimTagPrefix(v.Version)}
 	}
 	return ModuleVersionListingResponse{[]ModuleVersionListingResponseItem{{versions}}}
 }


### PR DESCRIPTION
Like providers, we don't want to remove old module tags.  This also adds semver sorting to module versions (which improves diffs) and fixes a bug where the listed module version would not match the download url.