### PR TITLE
Fix submission namespace output when including dashes

### DIFF
--- a/src/cmd/add-module/main.go
+++ b/src/cmd/add-module/main.go
@@ -45,7 +45,7 @@ func main() {
 
 	err = func() error {
 		// Lower case input
-		re := regexp.MustCompile("(?P<Namespace>[a-zA-Z0-9]+)/terraform-(?P<Target>[a-zA-Z0-9]*)-(?P<Name>[a-zA-Z0-9-]*)")
+		re := regexp.MustCompile("(?P<Namespace>[a-zA-Z0-9-]+)/terraform-(?P<Target>[a-zA-Z0-9]*)-(?P<Name>[a-zA-Z0-9-]*)")
 		match := re.FindStringSubmatch(*repository)
 		if match == nil {
 			return fmt.Errorf("Invalid repository name: %s", *repository)

--- a/src/cmd/add-provider/main.go
+++ b/src/cmd/add-provider/main.go
@@ -44,7 +44,7 @@ func main() {
 
 	err = func() error {
 		// Lower case input
-		re := regexp.MustCompile("(?P<Namespace>[a-zA-Z0-9]+)/terraform-provider-(?P<Name>[a-zA-Z0-9-]*)")
+		re := regexp.MustCompile("(?P<Namespace>[a-zA-Z0-9-]+)/terraform-provider-(?P<Name>[a-zA-Z0-9-]*)")
 		match := re.FindStringSubmatch(strings.ToLower(*repository))
 		if match == nil {
 			return fmt.Errorf("Invalid repository name: %s", *repository)


### PR DESCRIPTION
When a new provider or module has been submitted which included a `-` within the namespace of the Git repository, only the last portion of the user or organization was picked.

See #125 as an example where `metal-stack-cloud/terraform-provider-metal` resulted in a errornous repository url of `https://github.com/cloud/terraform-provider-metal`.