### PR TITLE
Update provider_key.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/provider_key.yml
+++ b/.github/ISSUE_TEMPLATE/provider_key.yml
@@ -7,7 +7,14 @@ body:
     id: namespace
     attributes:
       label: Provider Namespace
-      description: Github Username or Organization that contains Providers
+      description: GitHub Username or Organization that contains Providers
+    validations:
+      required: true
+  - type: checkboxes
+    id: public_membership
+    attributes:
+      label: Public Membership
+      description: If this is for a GitHub organization, I have [made my membership in that organization public](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
### Description

This gives the issue opener all of the information they need up-front, rather than causing them to be surprised by an extra requirement in the bot's comment response.

### Changes

* [X] Changed the spelling of "Github" to the branding-corrected "GitHub".
* [X] Added an additional checkbox which informs the PR opener of the requirement up-front, which may not otherwise be obvious until the bot responds in the comments.