### PR TITLE
feat: add concurrency to workflow

### DIFF
--- a/.github/workflows/bump-and-publish-versions-prod.yml
+++ b/.github/workflows/bump-and-publish-versions-prod.yml
@@ -5,8 +5,11 @@ on:
     - cron: '5 * * * *'
   workflow_dispatch:
 
+# Use global lock
+#
+# https://github.com/opentofu/registry/pull/272#discussion_r1511031778
 concurrency:
-  group: ${{ github.head_ref }}
+  group: main
 
 jobs:
   bump-versions:

--- a/.github/workflows/bump-and-publish-versions-prod.yml
+++ b/.github/workflows/bump-and-publish-versions-prod.yml
@@ -5,6 +5,9 @@ on:
     - cron: '5 * * * *'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.head_ref }}
+
 jobs:
   bump-versions:
     uses: opentofu/registry/.github/workflows/bump-versions.yml@main


### PR DESCRIPTION
Allow only one workflow at that time.

If a second workflow is triggered, it will be put in pending state, and only start once the first workflow finish.
If the workflow is triggered a third time while the first one is running, the second workflow is canceled, and the third takes over the pending state.

Fix #163.