### PR TITLE
Update cloudstack.json - Removing versions to allow for a re-fetch

### DIFF
--- a/providers/a/american-cloud/cloudstack.json
+++ b/providers/a/american-cloud/cloudstack.json
@@ -1,28 +1,4 @@
 {
   "versions": [
-    {
-      "version": "0.4.1",
-      "protocols": [
-        "5.0"
-      ],
-      "shasums_url": "https://github.com/american-cloud/terraform-provider-cloudstack/releases/download/v0.4.1/terraform-provider-cloudstack_0.4.1_SHA256SUMS",
-      "shasums_signature_url": "https://github.com/american-cloud/terraform-provider-cloudstack/releases/download/v0.4.1/terraform-provider-cloudstack_0.4.1_SHA256SUMS.sig",
-      "targets": [
-        {
-          "os": "linux",
-          "arch": "amd64",
-          "filename": "terraform-provider-cloudstack_0.4.1_linux_amd64.zip",
-          "download_url": "https://github.com/american-cloud/terraform-provider-cloudstack/releases/download/v0.4.1/terraform-provider-cloudstack_0.4.1_linux_amd64.zip",
-          "shasum": "00f4eb994327b6d4a15fd1db560cfb330c3cfd57175deb07cb57de91336217f1"
-        },
-        {
-          "os": "windows",
-          "arch": "amd64",
-          "filename": "terraform-provider-cloudstack_0.4.1_windows_amd64.zip",
-          "download_url": "https://github.com/american-cloud/terraform-provider-cloudstack/releases/download/v0.4.1/terraform-provider-cloudstack_0.4.1_windows_amd64.zip",
-          "shasum": "7720b08524d9ea885708ad0377b29fe523302e693500ec071b0e02350c016f09"
-        }
-      ]
-    }
   ]
 }


### PR DESCRIPTION
This release has been re-created now and includes their new darwin build.

Because we do not currently have a process around re-fetching builds, I'm proposing this PR so that our tool automatically refetches new versions by wiping out all existing ones.

