### PR TITLE
feat: add run-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.pem
 .idea
 
 generated/

--- a/src/cmd/run-server/README.md
+++ b/src/cmd/run-server/README.md
@@ -14,7 +14,7 @@ We use `mkcert` to create a locally-trusted SSL certificate.
 
 ```sh
 # Create and install CA in system trust store.
-mkcert -install # Create and install CA in system trust store.
+mkcert -install
 # Create a new certificate valid for localhost
 mkcert -cert-file cmd/run-server/localhost.pem -key-file cmd/run-server/localhost-key.pem localhost
 ```
@@ -72,5 +72,4 @@ module "consul" {
   source = "localhost.:8443/hashicorp/consul/aws" # Keep the dot after localhost, it is not a typo
   version = "0.11.0"
 }
-
 ```

--- a/src/cmd/run-server/README.md
+++ b/src/cmd/run-server/README.md
@@ -1,0 +1,76 @@
+# run-server
+
+Small HTTPS server meant for testing in local environment.
+
+## Dependencies
+
+- [mkcert](https://github.com/FiloSottile/mkcert/?tab=readme-ov-file#installation)
+- Golang
+
+## Setup
+
+The registry must run on HTTPS for OpenTofu to be able to communicate with it.
+We use `mkcert` to create a locally-trusted SSL certificate.
+
+```sh
+# Create and install CA in system trust store.
+mkcert -install # Create and install CA in system trust store.
+# Create a new certificate valid for localhost
+mkcert -cert-file cmd/run-server/localhost.pem -key-file cmd/run-server/localhost-key.pem localhost
+```
+
+## Run
+
+First, populate the `generated` folder with the registry content
+
+```sh
+go run ./cmd/generate-v1 --destination ../generated
+```
+
+Then you can start the server
+
+```sh
+go run ./cmd/run-server/ -certificate cmd/run-server/localhost.pem -key cmd/run-server/localhost-key.pem
+```
+
+## Test
+
+Check if the registry is reachable with `curl`
+
+```sh
+$ curl -D - https://localhost:8443/.well-known/terraform.json
+HTTP/2 200
+accept-ranges: bytes
+content-type: application/json
+last-modified: Mon, 11 Mar 2024 14:31:37 GMT
+content-length: 72
+date: Mon, 11 Mar 2024 14:34:19 GMT
+
+{
+          "modules.v1": "/v1/modules/",
+          "providers.v1": "/v1/providers/"
+}
+```
+
+Fetch providers
+
+```sh
+terraform {
+  required_providers {
+    random = {
+      source  = "localhost:8443/hashicorp/random"
+      version = "~> 3"
+    }
+  }
+}
+```
+
+Fetch modules
+
+```sh
+module "consul" {
+  source = "localhost.:8443/hashicorp/consul/aws" # Keep the dot after localhost, it is not a typo
+  version = "0.11.0"
+}
+
+```

--- a/src/cmd/run-server/main.go
+++ b/src/cmd/run-server/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"flag"
+	"log/slog"
+	"net/http"
+	"os"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	destinationDir := flag.String("destination", "../generated", "Directory to read the generated responses")
+	certFile := flag.String("certificate", "localhost.pem", "Path to certificate file")
+	keyFile := flag.String("key", "localhost-key.pem", "Path to key file")
+
+	flag.Parse()
+
+	_, err := os.Stat(*destinationDir)
+	if err != nil {
+		logger.Error("Could not open folder", err)
+		os.Exit(1)
+	}
+
+	fs := http.FileServer(http.Dir(*destinationDir))
+	http.Handle("/", fs)
+
+	logger.Info("Starting HTTPS server at :8443...")
+
+	err = http.ListenAndServeTLS(":8443", *certFile, *keyFile, nil)
+	if err != nil {
+		logger.Error("Failed to start server", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
`run-server` is a small HTTPS server meant for testing in the local environment.

Support HTTPS, which is needed for OpenTofu to reach the registry.

It could also be used for E2E testing (https://github.com/opentofu/registry/issues/164)

### Examples

```sh
$ curl -D - https://localhost:8443/.well-known/terraform.json
HTTP/2 200
accept-ranges: bytes
content-type: application/json
last-modified: Mon, 11 Mar 2024 14:31:37 GMT
content-length: 72
date: Mon, 11 Mar 2024 14:34:19 GMT

{
          "modules.v1": "/v1/modules/",
          "providers.v1": "/v1/providers/"
}
```

Fetch providers

```sh
terraform {
  required_providers {
    random = {
      source  = "localhost:8443/hashicorp/random"
      version = "~> 3"
    }
  }
}
```

Fetch modules

```sh
module "consul" {
  source = "localhost.:8443/hashicorp/consul/aws" # Keep the dot after localhost, it is not a typo
  version = "0.11.0"
}
```

I have been using this for a while. It allows me to quickly test ideas for the Registry UI. I hope it's as useful to OpenTofu as it is to me.