### PR TITLE
Temporarily Reduce Syncing Frequency

### DIFF
--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -3,7 +3,7 @@ name: Generate and Sync Files
 
 on:
   schedule:
-    - cron: '5,20,35,50 * * * *'
+    - cron: '0 * * * *'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
In an effort to temporarily (for a few hours) reduce costs of read actions in cloudflare, we are reducing the registry syncing frequency to one hour.

This change will be followed up by a more permanent change later on.