### PR TITLE
Introduce warnings into the verification so that emails are optional

### DIFF
--- a/src/pkg/verification/render.go
+++ b/src/pkg/verification/render.go
@@ -18,6 +18,8 @@ func (r *Result) RenderMarkdown() string {
 			output += "⚠️ **Not Run**\n"
 		} else if step.Status == StatusSkipped {
 			output += "⚠️ **Skipped**\n"
+		} else if step.Status == StatusWarning {
+			output += "⚠️ **Warning**\n"
 		}
 
 		for _, err := range step.Errors {
@@ -37,6 +39,8 @@ func (r *Result) RenderMarkdown() string {
 				output += "⚠️ **Not Run**\n"
 			} else if subStep.Status == StatusSkipped {
 				output += "⚠️ **Skipped**\n"
+			} else if subStep.Status == StatusWarning {
+				output += "⚠️ **Warning**\n"
 			}
 
 			for _, err := range subStep.Errors {

--- a/src/pkg/verification/result.go
+++ b/src/pkg/verification/result.go
@@ -7,6 +7,7 @@ const (
 	StatusFailure Status = "failure"
 	StatusNotRun  Status = "not_run"
 	StatusSkipped Status = "skipped"
+	StatusWarning Status = "warning"
 )
 
 type Result struct {

--- a/src/pkg/verification/step.go
+++ b/src/pkg/verification/step.go
@@ -19,6 +19,12 @@ func (s *Step) AddStep(name string, status Status, errors ...string) *Step {
 	return &step
 }
 
+func (s *Step) FailureToWarning() {
+	if s.Status == StatusFailure {
+		s.Status = StatusWarning
+	}
+}
+
 func (s *Step) RunStep(name string, fn func() error) *Step {
 	step := s.AddStep(name, StatusNotRun)
 	err := fn()


### PR DESCRIPTION
This fixes the issue where a gpg key that had no email attached is marked as an error and not a warning.
