### PR TITLE
Use lowercase paths for all generated files to allow for case-insensitive url rewrite rules to be put in place

### DIFF
--- a/src/internal/v1api/modules.go
+++ b/src/internal/v1api/modules.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 
 	"github.com/opentofu/registry-stable/internal"
 	"github.com/opentofu/registry-stable/internal/files"
@@ -36,12 +37,12 @@ func NewModuleGenerator(m module.Module, destination string) (ModuleGenerator, e
 
 // VersionListingPath returns the path to the module version listing file
 func (m ModuleGenerator) VersionListingPath() string {
-	return filepath.Join(m.Destination, "v1", "modules", m.Module.Namespace, m.Module.Name, m.Module.TargetSystem, "versions")
+	return strings.ToLower(filepath.Join(m.Destination, "v1", "modules", m.Module.Namespace, m.Module.Name, m.Module.TargetSystem, "versions"))
 }
 
 // VersionDownloadPath returns the path to the module version download file for the given version
 func (m ModuleGenerator) VersionDownloadPath(v module.Version) string {
-	return filepath.Join(m.Destination, "v1", "modules", m.Module.Namespace, m.Module.Name, m.Module.TargetSystem, internal.TrimTagPrefix(v.Version), "download")
+	return strings.ToLower(filepath.Join(m.Destination, "v1", "modules", m.Module.Namespace, m.Module.Name, m.Module.TargetSystem, internal.TrimTagPrefix(v.Version), "download"))
 }
 
 // VersionListing converts the module metadata into a ModuleVersionListingResponse, ready to be serialized to a file

--- a/src/internal/v1api/modules.go
+++ b/src/internal/v1api/modules.go
@@ -37,12 +37,19 @@ func NewModuleGenerator(m module.Module, destination string) (ModuleGenerator, e
 
 // VersionListingPath returns the path to the module version listing file
 func (m ModuleGenerator) VersionListingPath() string {
-	return strings.ToLower(filepath.Join(m.Destination, "v1", "modules", m.Module.Namespace, m.Module.Name, m.Module.TargetSystem, "versions"))
+	namespace := strings.ToLower(m.Module.Namespace)
+	name := strings.ToLower(m.Module.Name)
+	target := strings.ToLower(m.Module.TargetSystem)
+	return filepath.Join(m.Destination, "v1", "modules", namespace, name, target, "versions")
+
 }
 
 // VersionDownloadPath returns the path to the module version download file for the given version
 func (m ModuleGenerator) VersionDownloadPath(v module.Version) string {
-	return strings.ToLower(filepath.Join(m.Destination, "v1", "modules", m.Module.Namespace, m.Module.Name, m.Module.TargetSystem, internal.TrimTagPrefix(v.Version), "download"))
+	namespace := strings.ToLower(m.Module.Namespace)
+	name := strings.ToLower(m.Module.Name)
+	target := strings.ToLower(m.Module.TargetSystem)
+	return filepath.Join(m.Destination, "v1", "modules", namespace, name, target, internal.TrimTagPrefix(v.Version), "download")
 }
 
 // VersionListing converts the module metadata into a ModuleVersionListingResponse, ready to be serialized to a file

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -46,14 +46,14 @@ func NewProviderGenerator(p provider.Provider, destination string, gpgKeyLocatio
 func (p ProviderGenerator) VersionListingPath() string {
 	namespacePath := strings.ToLower(p.Provider.Namespace)
 	providerNamePath := strings.ToLower(p.Provider.ProviderName)
-	return filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, "versions")
+	return strings.ToLower(filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, "versions"))
 }
 
 // VersionDownloadPath returns the path to the provider version download file.
 func (p ProviderGenerator) VersionDownloadPath(ver provider.Version, details ProviderVersionDetails) string {
 	namespacePath := strings.ToLower(p.Provider.Namespace)
 	providerNamePath := strings.ToLower(p.Provider.ProviderName)
-	return filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, ver.Version, "download", details.OS, details.Arch)
+	return strings.ToLower(filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, ver.Version, "download", details.OS, details.Arch))
 }
 
 // VersionListing will take the provider metadata and generate the responses for the provider version listing API endpoints.

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -46,14 +46,14 @@ func NewProviderGenerator(p provider.Provider, destination string, gpgKeyLocatio
 func (p ProviderGenerator) VersionListingPath() string {
 	namespacePath := strings.ToLower(p.Provider.Namespace)
 	providerNamePath := strings.ToLower(p.Provider.ProviderName)
-	return strings.ToLower(filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, "versions"))
+	return filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, "versions")
 }
 
 // VersionDownloadPath returns the path to the provider version download file.
 func (p ProviderGenerator) VersionDownloadPath(ver provider.Version, details ProviderVersionDetails) string {
 	namespacePath := strings.ToLower(p.Provider.Namespace)
 	providerNamePath := strings.ToLower(p.Provider.ProviderName)
-	return strings.ToLower(filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, ver.Version, "download", details.OS, details.Arch))
+	return filepath.Join(p.Destination, "v1", "providers", namespacePath, providerNamePath, ver.Version, "download", details.OS, details.Arch)
 }
 
 // VersionListing will take the provider metadata and generate the responses for the provider version listing API endpoints.


### PR DESCRIPTION
Resolves #503 

Once this is merged, it will regenerate files with lowercase names. We will introduce a case-insensitive url re-write rule on the side of cloudfront which will help match to the new lowercase file paths.