### PR TITLE
Revert commit that removed Russian providers

### DIFF
--- a/providers/r/rustack-cloud-platform/rcp.json
+++ b/providers/r/rustack-cloud-platform/rcp.json
@@ -1,0 +1,652 @@
+{
+  "versions": [
+    {
+      "version": "1.2.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.2_darwin_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_darwin_amd64.zip",
+          "shasum": "5102eb7581fc75ffb8a41d1a0cae48f98d0ce61b09b3fa16931eed38d119a815"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.2_darwin_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_darwin_arm64.zip",
+          "shasum": "ed053258c57b57029d06a4cdfb48fc63672527145e90b3091b6875274d05da97"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.2_freebsd_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_freebsd_386.zip",
+          "shasum": "0c4d80a87bd5753d107d86578fe165e3102c6a781c0a6084753ecbd1a6cfe729"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_freebsd_amd64.zip",
+          "shasum": "1f3b989a45923880a470e96753422f887124f429f7249f9fa224ba8407f0c963"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.2_freebsd_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_freebsd_arm.zip",
+          "shasum": "ab2433ffbcab2a31b8cd4fff3c5784a531488cef659b7a7ef2a8355a1862d7ab"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_freebsd_arm64.zip",
+          "shasum": "c57fc4ce2066cdd279da90f61a962710ad979a93962693bdb1307065e3c45da3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.2_linux_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_linux_386.zip",
+          "shasum": "eb8ad7d7f5b792fbc3d229706d623753c24e3bfbfb3cb7c5a6594aca621a050a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.2_linux_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_linux_amd64.zip",
+          "shasum": "235d8f73810c369c02d62db406c4e362753eefe738904849930600efe3719476"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.2_linux_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_linux_arm.zip",
+          "shasum": "473daa629fcab4eeaa44c8e9b0ea4a91c6ff7c4d8cf78b4bb43911af664b142a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.2_linux_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_linux_arm64.zip",
+          "shasum": "d99b88610d6daca23e7d5643c03f4de4893945c3ddb0ab0572c695c5f0e42d76"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.2_windows_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_windows_386.zip",
+          "shasum": "d5dae30c8e7c826e6683be41b802faec472ab508d586317512808419a284f286"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.2_windows_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_windows_amd64.zip",
+          "shasum": "25552f8cd8dd8de1c7793da3fbff0d9e80677c4a7c3b9749f3163b8df1776643"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.2_windows_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_windows_arm.zip",
+          "shasum": "08c38728469d98ce2a2a9d692f17ea7fa0f68c6410a306782ea24ea0396d6583"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.2_windows_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.2/terraform-provider-rcp_1.2.2_windows_arm64.zip",
+          "shasum": "3e1721722b644fa7753284a97cc3838f2c5634828ae925723b70fd4ca65c6073"
+        }
+      ]
+    },
+    {
+      "version": "1.2.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.1_darwin_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_darwin_amd64.zip",
+          "shasum": "08b369352d994aa013ae8021403eae77940910c10b336a011ccbd8a54c561203"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.1_darwin_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_darwin_arm64.zip",
+          "shasum": "4a856c4eac030474d801c09764f80852218a3dc5cf3cf17fd2e5cea7c3396b5e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.1_freebsd_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_freebsd_386.zip",
+          "shasum": "3e29295a27927db7f464c040f93f90974955bde9abc77006ba248811388a54d1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_freebsd_amd64.zip",
+          "shasum": "ccb2d8d0af19b598c3d46e7b12d699d03e76ec12155a36a0550fd9ecedbf9af1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.1_freebsd_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_freebsd_arm.zip",
+          "shasum": "ee8f044c4c00ab477ca5d8fb7a45b98a2f17017f1869df65ceeea72c59e93404"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_freebsd_arm64.zip",
+          "shasum": "e7d0d3b6bbb82ba95748b86ac1a9ce5afe449bcf2b1c1251e61addfed379fe01"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.1_linux_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_linux_386.zip",
+          "shasum": "5b368c639a9ebfeac42578e575ca70efd92461dcf0bcb36d3c55804f5a56ab84"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.1_linux_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_linux_amd64.zip",
+          "shasum": "a648ddae3ea9cf37641f8695ba3178e74a91b13b32539bfe9cf3b89abe6ac801"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.1_linux_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_linux_arm.zip",
+          "shasum": "2db881333f47c11c084e8c6d95c47f1b51b86f7d34ab5048963c4f6977c07ee7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.1_linux_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_linux_arm64.zip",
+          "shasum": "444076a4b69c22f31d1ad296edf4f646834c95d05b5974b212e61ba630f8eb60"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.1_windows_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_windows_386.zip",
+          "shasum": "c890ccaf2d7c19f81ca3bb0a2477af139a10c46379adea69316ef921a6a2129c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.1_windows_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_windows_amd64.zip",
+          "shasum": "ee009dc80027faed6fd064456721df99cf1dba732ee474cc08c915c7df04883d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.1_windows_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_windows_arm.zip",
+          "shasum": "fb20ec0d0d407c36c87c50afec7e692f822e48ea9477d4fc7f2ec313eaeb4e11"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.1_windows_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.1/terraform-provider-rcp_1.2.1_windows_arm64.zip",
+          "shasum": "56cff77922cd73ae91f5408e14381497d0b0b1581914afe2077a04e825e4e1c7"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_darwin_amd64.zip",
+          "shasum": "5d90d202d078625e3f458ad38aae33110613d05eca8ddb56d1d1e7ed7404a218"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_darwin_arm64.zip",
+          "shasum": "032f0ff8f5c0347dac34370e99dc7f82582cc99f1ad31d27e81e226578780a34"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_freebsd_386.zip",
+          "shasum": "09f63b365054f60be735fbd5951a2207ad62e9bfae4d4d9bdad66be370cc1cc5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_freebsd_amd64.zip",
+          "shasum": "1aff39f5a7ba84c719f39c0d7888b92e0495c1fd9623cc077776aa95d543a833"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_freebsd_arm.zip",
+          "shasum": "19aec1d566863b81c82323f23101a7ed8c284a50227158857a1ccd0e4c3d0a7a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_freebsd_arm64.zip",
+          "shasum": "10a39527d1fd9d9743a2d253ac676b926b8655e0e184e037f72c3d3138131a2d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_linux_386.zip",
+          "shasum": "f0e7388db76e33d7c65b1f2c5bdef3fe7bd6758cbdb967a0482f3c2546b65b68"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_linux_amd64.zip",
+          "shasum": "0438d7714ea71bd56a26c8dd844d41f6bc5728cd518346ea87ce9caec19a143e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.0_linux_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_linux_arm.zip",
+          "shasum": "6c17ca5904f615121ad7488f56943dc3d63b3341f190aaffb25b6f4e131d094d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_linux_arm64.zip",
+          "shasum": "ce502e071e9747166b57676bc4a6e2fcc0dd173acd2d2155f29a6b27e71bc8ea"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_windows_386.zip",
+          "shasum": "3cb4783237b0298d5233677e7f314d2b31eb02369086a3a8b9387cd0192de484"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_windows_amd64.zip",
+          "shasum": "26ff8ca28dbb8d8de75b8b411768a0a85c53e22a39542ba20a1fa86b75e61505"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.2.0_windows_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_windows_arm.zip",
+          "shasum": "da1dc9c8e2a3f4ab7f54f7a75102ddf6ad3165519888f27ac2793bc3ba2ca7a7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.2.0_windows_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.2.0/terraform-provider-rcp_1.2.0_windows_arm64.zip",
+          "shasum": "26bd76a08ce26a274b0668961bbab3ecc5a69543e03f0cba6f236b747c43b860"
+        }
+      ]
+    },
+    {
+      "version": "1.1.10",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.10_darwin_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_darwin_amd64.zip",
+          "shasum": "36839e345b8b03a068c870d9635a229d94db5ae7ec5fc42e809ce5b50f34eba7"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.10_darwin_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_darwin_arm64.zip",
+          "shasum": "d0701b36cd690c5fd5ec38afe99d921350bf9e87472d997f5a1215d819b3e2f0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.10_freebsd_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_freebsd_386.zip",
+          "shasum": "f8cd45b12807eca7d1706f35e86d1eb903e99a201d82022fda56b66fbe1a616e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.10_freebsd_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_freebsd_amd64.zip",
+          "shasum": "7f788ebc841d0d952293195e66116f918480a96f81a554b4d9e03db269751ba6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.10_freebsd_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_freebsd_arm.zip",
+          "shasum": "2a0a9af8aa1ed30945deb3315b1c8369eaa417702add1d7908d7218c384d2eb4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.10_freebsd_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_freebsd_arm64.zip",
+          "shasum": "28bfdbcbbb2a9d9ee5b88d2c280d4d0b6d59a1d970cd1f697d49380298a38b64"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.10_linux_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_linux_386.zip",
+          "shasum": "0153605dccd74e8ce0232890fcf5335635e0863f53997f6a0d5d198d1d95fd6a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.10_linux_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_linux_amd64.zip",
+          "shasum": "5c72a3bb2e7749e2c51d7b0638ed5b635a04a574bff2354252a083e51e9565eb"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.10_linux_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_linux_arm.zip",
+          "shasum": "727cba039a7998d86eb3bcd01ffce82d7d951b0dd0a5db03bd1b4f3e746451f4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.10_linux_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_linux_arm64.zip",
+          "shasum": "aac1f4d508af414696e92dda0e4b27cd32d84d49033f24c0367852d1b4c65a04"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.10_windows_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_windows_386.zip",
+          "shasum": "3b0815e98466bb442b87140735eef22186cb251c665ef2c9b147b58c5fbff3fe"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.10_windows_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_windows_amd64.zip",
+          "shasum": "b6d7aa1f10ca8761ccd7abe85b48c6708329cf3386ec5900712d7d65cabe9591"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.10_windows_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_windows_arm.zip",
+          "shasum": "a2bcc7b7370427118adc1d2d98ad046828e76dd04737a60cb821abb240249f0a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.10_windows_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.10/terraform-provider-rcp_1.1.10_windows_arm64.zip",
+          "shasum": "4ce243f814c8d3ab9d81ffe1b1c3da933454aafb5d304156bd96ea80334bd3b5"
+        }
+      ]
+    },
+    {
+      "version": "1.1.9",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.9_darwin_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_darwin_amd64.zip",
+          "shasum": "7167317b54b5ce4e4d9cb683614d5f5986b3b62cf43f340f1fbf5ac043715f93"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.9_darwin_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_darwin_arm64.zip",
+          "shasum": "78f48943c5c7296f2014813a0474b61c75dbf4c4977edc0b8c155203ad7da5fc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.9_freebsd_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_freebsd_386.zip",
+          "shasum": "f9e71fb8f949d94e64fc6678751105a7eb0413f6c9f1eecd0a39d1907fe4055f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.9_freebsd_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_freebsd_amd64.zip",
+          "shasum": "2c21c428518931eb74628ecaa128f05e795ac29f62e1ea649094ba397a13c3bf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.9_freebsd_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_freebsd_arm.zip",
+          "shasum": "b3c4d62ecc33d0e708305ee180f5e20c772f17686ae8ccab4ae28c5810f06dc4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.9_freebsd_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_freebsd_arm64.zip",
+          "shasum": "aa5130198031d1272a2be232ed6c25dec1178ae76e13827171b8a0d3e99ecae3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.9_linux_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_linux_386.zip",
+          "shasum": "c444425e899b440486115756cb477e23457431a2af9615675a5e15f4d664809f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.9_linux_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_linux_amd64.zip",
+          "shasum": "a1fcea5446ed79b7fe9be776c592bda993e0828da49041f07b63c433d1f75796"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.9_linux_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_linux_arm.zip",
+          "shasum": "c57a2c8f66db1d4b88ae07ce9e202c993fafa7ab7a3c4cc0cc7847ae3cfdf807"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.9_linux_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_linux_arm64.zip",
+          "shasum": "4519fa73c560d2c3ba53760b121e398ec598797c78cc5dc93de33173f0906afd"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.9_windows_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_windows_386.zip",
+          "shasum": "36a645605c5acdc3be361537be6291b86f5656113a88f2c1fdfa191054e10139"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.9_windows_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_windows_amd64.zip",
+          "shasum": "c136d18ca14961f893826b2ed4dfd62dce38a6d5e0f6dd26c76861e6ffd4a89f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.9_windows_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_windows_arm.zip",
+          "shasum": "4463a216c1b3291fc2523ddfaafb4fc607c79bf4853bc627406c26a509641fa5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.9_windows_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.9/terraform-provider-rcp_1.1.9_windows_arm64.zip",
+          "shasum": "db9c3690d78ec66ef8ac86da71fc2d2d5ce70edc48c49d1591340d55eb273e73"
+        }
+      ]
+    },
+    {
+      "version": "1.1.8",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.8_darwin_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_darwin_amd64.zip",
+          "shasum": "a86d2e30514a6654bfff0d2b2340a8c0b11422ada22fa406cf352235dba1888f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.8_darwin_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_darwin_arm64.zip",
+          "shasum": "399a172bbde1af37674a767127071bcf249085ad648b7ce1d5ad61c444c07e25"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.8_freebsd_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_freebsd_386.zip",
+          "shasum": "6784c3efb85851d22fa3f8804f20579537f9682ecb675abf23a1f49a4f91ebc2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.8_freebsd_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_freebsd_amd64.zip",
+          "shasum": "dff31be762e1c6fd1ec5bd441a6890c50c3c73a23a464d4166468f6a692dfb32"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.8_freebsd_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_freebsd_arm.zip",
+          "shasum": "1d913c6c1b6c33bfa834978d47d7b968608411eb607b25a700a3f987183cdeb5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.8_freebsd_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_freebsd_arm64.zip",
+          "shasum": "ed4098ffea38fb32b4dc88cf00804bd4b0dbddb412784b5875f201f3313ced26"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.8_linux_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_linux_386.zip",
+          "shasum": "74c018b198ac800c3f3081070692fc0c2e1b966ca410dd5311748e38b67f580b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.8_linux_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_linux_amd64.zip",
+          "shasum": "05024b1c73822db69ce7b73ed15dd7dff721717b905c3172bf52bc018e2c97ea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.8_linux_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_linux_arm.zip",
+          "shasum": "cb88ec977c23c49f7bf1b5d07515ee31e1e1f28ca64640d6a1977216591d6d2d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.8_linux_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_linux_arm64.zip",
+          "shasum": "a5033ccc0c489a7147b23b6a77b59e8965950338b4c592aead49eb8d7a90a391"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-rcp_1.1.8_windows_386.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_windows_386.zip",
+          "shasum": "d5005c3dff6a203280139f8cac3fc612207ec072296dfe339402aaa096a3dd12"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-rcp_1.1.8_windows_amd64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_windows_amd64.zip",
+          "shasum": "3cdf7f15ceaf2c7ad90dda1d1be42953958d64671c5303a3bfcccbdf88f15b00"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-rcp_1.1.8_windows_arm.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_windows_arm.zip",
+          "shasum": "9227b834c50170355232bf05134847461910f0290d0355090751a9ab2e19c9f6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-rcp_1.1.8_windows_arm64.zip",
+          "download_url": "https://github.com/rustack-cloud-platform/terraform-provider-rcp/releases/download/v1.1.8/terraform-provider-rcp_1.1.8_windows_arm64.zip",
+          "shasum": "e307144537c8543054c90d9f6fc5eeea5eab39990f8ec9e14cc2fdbb17967bc6"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/s/sbercloud-terraform/sbercloud.json
+++ b/providers/s/sbercloud-terraform/sbercloud.json
@@ -1,0 +1,2961 @@
+{
+  "versions": [
+    {
+      "version": "1.12.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.2_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_darwin_amd64.zip",
+          "shasum": "d8feadde4b152ae5e7d1889d3c56cdc7a36e59c1e11e320fd3c9d5ff41894c11"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.2_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_darwin_arm64.zip",
+          "shasum": "1da4aa6c43c6025dc7229ab521339a81b9dd715dd123212d2754fd4b310afd77"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.2_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_freebsd_386.zip",
+          "shasum": "64cd062a11c1d67ed2e1fbba4caf13e7f1101a07faad51ce8ce002a728767d23"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_freebsd_amd64.zip",
+          "shasum": "795f82c509a2205d1196f82e69415bfee96f28a6aea749e91309cb7ff171278d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.2_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_freebsd_arm.zip",
+          "shasum": "2140f932e12dd55f8cea23da0e9e5597544d87a02cd2376798edf65a8a7ddbea"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_freebsd_arm64.zip",
+          "shasum": "d6962c0a5eaa9cdcc77f37f9c61af25cd6a2220ca3ff74311063e594332409a6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.2_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_linux_386.zip",
+          "shasum": "016764ea0e080e60938767699b26cd21835efc3cf08f8bf7635b1525fb2e9425"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.2_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_linux_amd64.zip",
+          "shasum": "bc5f40f678223a9c0c98fe716389ff1f9661edcc261142c8d131f9488d2e9915"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.2_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_linux_arm.zip",
+          "shasum": "7447e813a33772705dde7496d81e0b06177e679c03755177be9488f00d256a9d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.2_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_linux_arm64.zip",
+          "shasum": "5c084231f0fd96d4fb113286c551bcbe39c2ba4992246829595b0f323a5ee4f7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.2_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_windows_386.zip",
+          "shasum": "3d665bb389179c34c83ca6e9ca3ef2f0b178d1b2f57754022a84b797816974bc"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.2_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_windows_amd64.zip",
+          "shasum": "4e20268de83c2ef943432e2bd79772b8d1d9ea72a708d265497b5a0fa4129942"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.2_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_windows_arm.zip",
+          "shasum": "6c4243dd992a2853eccd696548184daf845c22b7b0913db7d50642316bc10a0b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.2_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.2/terraform-provider-sbercloud_1.12.2_windows_arm64.zip",
+          "shasum": "3fd62e46a0f404bc46f0e6910a7526a5ec3cafdad45153c536e55e4b0f1c3c6a"
+        }
+      ]
+    },
+    {
+      "version": "1.12.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_darwin_amd64.zip",
+          "shasum": "a4ac32848bd4671e29b326b3980adcbc11576212ff8348ba781c714d6d438d77"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.1_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_darwin_arm64.zip",
+          "shasum": "8757d95d9d58e2e5b6c331c43b6d0b9b2b9f43dcafd670cf252660c2ded4b872"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_freebsd_386.zip",
+          "shasum": "d032a83a7a7610709930ae61940563973221707b3382b0681d361e0b0f90466c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_freebsd_amd64.zip",
+          "shasum": "e8372b453d4349734d3e23290c272e385747dd4a2a3d3953cdbad79d309aa17a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_freebsd_arm.zip",
+          "shasum": "2cfee40e7d3b03f6b92431ebe22c542350eb4bb15a363860a7e37f9717649fb1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_freebsd_arm64.zip",
+          "shasum": "af900261cd32fbe8e6912ccf8be612460bc2ecdeb4c4565bbab3c92b6759b1b5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_linux_386.zip",
+          "shasum": "81fdd5ba4f05b2e65448314c621d924f3b8cff8bc0082007fe40d9c46e8b5828"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_linux_amd64.zip",
+          "shasum": "206d8c2e4d7d9622d48d6a67b91f746371bdcbc0887dcfcfe337453b21d41511"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_linux_arm.zip",
+          "shasum": "bbcf838ec78288968ea83c66f2f5ae54c7ab30f7863684c0e6d16643b616030f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_linux_arm64.zip",
+          "shasum": "e08678f6730e190072625f4ca0560d8fee3107c85ef05aac67e3e44b31f865a4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_windows_386.zip",
+          "shasum": "f39bac4f0e3977b9bdf4e939b1b78e41f3155895c80a343a41957ff263c246d8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_windows_amd64.zip",
+          "shasum": "765932e25b247f83fce5ca1e31d10d83b2630bb2ea297499545ef773f73b8057"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.1_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_windows_arm.zip",
+          "shasum": "5554b539d8bf86647f1895d80a0020f6c7392e72d9a73ff5990a488f14593813"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.1_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.1/terraform-provider-sbercloud_1.12.1_windows_arm64.zip",
+          "shasum": "1af35db9f5e580c96e17f9700dd59865424f3c603fde910dcd06c913ec909c07"
+        }
+      ]
+    },
+    {
+      "version": "1.12.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_darwin_amd64.zip",
+          "shasum": "175394ecfc9d068d8a63fd79361294e4279793dbeb5a19d80b353f533791262c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_darwin_arm64.zip",
+          "shasum": "54bb39433e8490ec9c1edee2c79591865e24599481d56e66090025a1a2070832"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_freebsd_386.zip",
+          "shasum": "2bcd0edbd9e435e0a1485e8c86a400a12d834375fa12c17c7875bc147c95f821"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_freebsd_amd64.zip",
+          "shasum": "fca5a7f2ac5b9c5c24091a68613ce06819ca2771bd6f4e7c264dcea2c8ea343c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_freebsd_arm.zip",
+          "shasum": "c1ed422a2f9584c41f37d0b356678130b6c46f6820faa0742ed8c982460d4bfd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_freebsd_arm64.zip",
+          "shasum": "9df0706d83daac27f9d402f6b83673bd578f2e47c9f24226c78419de38fb68ee"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_linux_386.zip",
+          "shasum": "992e46716da48cd5f182aaa8749742ca041fa2609f1bb6773af6b1e930160335"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_linux_amd64.zip",
+          "shasum": "07d27520af92db5f4458d54f591f20e1edcfcbef573d3bdf893a38affd08819b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_linux_arm.zip",
+          "shasum": "706b830ff5cf23f060ef8bab48769e7537fa9c0498f6daad493ae58a7f3308e7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_linux_arm64.zip",
+          "shasum": "cfd6df47844b9242e43e779ac82e85e9feecb5aab0789c1e692cb27ced6c62ea"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.12.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_windows_386.zip",
+          "shasum": "8eee2279c0b0b43a18cbe9a543e99f1162b018dc73f712a80c4177012e49c743"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.12.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_windows_amd64.zip",
+          "shasum": "23bcf054402bceb6ee30c3b40545602973cbf28281f04398c394ec922d4a88a5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.12.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_windows_arm.zip",
+          "shasum": "f5f58f75592880c3e734e790aeb2fc88c25e61eff6ea3e5fc080afec98c1f68b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.12.0_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.12.0/terraform-provider-sbercloud_1.12.0_windows_arm64.zip",
+          "shasum": "edaeeeee1115dfa2367b1fbfa3ad5fe59a6ec9d51cf38e2cef83dd74de945054"
+        }
+      ]
+    },
+    {
+      "version": "1.11.6",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.6_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_darwin_amd64.zip",
+          "shasum": "47d2a71fa77442fb0a578477e6618ce4e0a809fc9eadcfe2c740e851aed37335"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.6_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_darwin_arm64.zip",
+          "shasum": "2c6624aa55545d19079a8cff6f4fd02b24a53d65b0c69cd30f74474176e4cd10"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.6_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_freebsd_386.zip",
+          "shasum": "cb73a0ee5407530be7f43b8d715b2b820cbf0dbd98876bfc8e78a4414a6fc7f5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.6_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_freebsd_amd64.zip",
+          "shasum": "5fe92e04cd9e0e635422bc31f89a3a2b7daad85c5f79de09867733ee5dc0e4ab"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.6_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_freebsd_arm.zip",
+          "shasum": "39ea431950f8fd2733b73730922e7dcefc5209bc2724980ffa71690e10552ded"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.6_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_freebsd_arm64.zip",
+          "shasum": "a605db1fd06cea516c69eabbe198d593fac16fa41e966beb5ff90b74e66c74f1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.6_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_linux_386.zip",
+          "shasum": "ab0593e1e38879df094f7d597ea3a6ceee7c1fefcce8c0773a94d7a1f27d0149"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.6_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_linux_amd64.zip",
+          "shasum": "b3562487d2d14832893ae1737784b63e80b9a49560120fb3a4146c62bf34ba95"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.6_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_linux_arm.zip",
+          "shasum": "1b62b1c42a6e14fa5b1093a20cd108f4cf7a27f4b09938b15bbd88c4cc036bb1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.6_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_linux_arm64.zip",
+          "shasum": "d86450bd6ee991cec64829b67ed3e7dba2de84b64627c53c8fe23589f698e63b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.6_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_windows_386.zip",
+          "shasum": "dc123d5e4fbb7863e2641d17b676200aec1d74ddc0b51df51a39f5ae8e138ede"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.6_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_windows_amd64.zip",
+          "shasum": "fd9e6f19bd7b11c636584f99536a01fe47847655dbcf3868d7fe68eebab89e8c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.6_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_windows_arm.zip",
+          "shasum": "407afd158be9ccc640967db914ecf9333c52c509d01d68b2eabc55c9a2fd43ea"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.6_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.6/terraform-provider-sbercloud_1.11.6_windows_arm64.zip",
+          "shasum": "f2f88cefb2a902aeadb516ca2fee01f44de3216279df4ae56dc1cab594d95f17"
+        }
+      ]
+    },
+    {
+      "version": "1.11.5",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.5_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_darwin_amd64.zip",
+          "shasum": "d14d7ec4f76ae4e77274399d4f35369fca84e733b18bad4d810d4d25b557791f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.5_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_darwin_arm64.zip",
+          "shasum": "bedfb3e0e5766c6e7f1ea1a27b1cc3881e5abfb7b37b25e93b203af4a58a61c1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.5_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_freebsd_386.zip",
+          "shasum": "b5648cd5a4f5e33ebb6a75d0a98fb5dfc1561ab5b009ca2f8a227b6e1749cf9b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.5_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_freebsd_amd64.zip",
+          "shasum": "ca53105711e3b9f8533f7b44d80f808cdf5c08012520a254bd0aa751d45bc80c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.5_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_freebsd_arm.zip",
+          "shasum": "7833a0420805f619e142b2912b9888e5bce2e103926e9d7972ad69c0749d6e0f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.5_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_freebsd_arm64.zip",
+          "shasum": "78e9a15b117769c2141c9d62ba915b653f8c7f04b665e667a2004a89223001b7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.5_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_linux_386.zip",
+          "shasum": "155e1d2c89b13178a5d189a60c8f4a1094c51d09adbd4211d088cd29cdff51ba"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.5_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_linux_amd64.zip",
+          "shasum": "739205a13cc5692bf720dcbaccc05bc283a6374d139e81a8933a4927f7c92699"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.5_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_linux_arm.zip",
+          "shasum": "72ec39be2db04de2de270219d2cb82e961ebfc22b332f9ad2d7cc3cb5a3bd03a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.5_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_linux_arm64.zip",
+          "shasum": "f9fb6faf55636631f8f011dff21b873f630368db4341806f96dd9ae1afa1870e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.5_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_windows_386.zip",
+          "shasum": "4050213b88316dc886ac58ad56e312de40e345c12df8e4dec948f09c9c567e36"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.5_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_windows_amd64.zip",
+          "shasum": "bd5f2d51eccf38acbcc757752cc87148a04908d80a942ebdff08bbf4201683e3"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.5_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_windows_arm.zip",
+          "shasum": "6f1ee3f1575205bb240eb5bb09a0a0b03569276a1a9eba288715ea9c37200cbf"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.5_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.5/terraform-provider-sbercloud_1.11.5_windows_arm64.zip",
+          "shasum": "680c7c7910e054d82aa321f154fafeb537d4af39588af13fbceaf46f309469f7"
+        }
+      ]
+    },
+    {
+      "version": "1.11.4",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.4_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_darwin_amd64.zip",
+          "shasum": "5fb2baece006a74568709c7de4dbeb1254ad5b4a9d843c9afbcc660d41f26333"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.4_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_darwin_arm64.zip",
+          "shasum": "0c84be92b773a406f2b3b0cfcbea0de2bd045f6fc4d451d30f237563e4ebf751"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.4_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_freebsd_386.zip",
+          "shasum": "75c4caa1e151a517f1b43f9ba847bb041632f12e756ac4ed3317ed16791e2b7e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.4_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_freebsd_amd64.zip",
+          "shasum": "9bc9c789ce2719602397138f99fe7d4797a0a310f8c0a6d27a7e5026282e5cdc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.4_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_freebsd_arm.zip",
+          "shasum": "369350891085d6fbae7f9ae48928f69b7149dd0197cab25065a8820f6b59ac5c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.4_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_freebsd_arm64.zip",
+          "shasum": "761b5169e69eb186c49f7459c529711a6de97d266b6c736db3297b79e153097b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.4_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_linux_386.zip",
+          "shasum": "7a5b0148430aec252eb29e54df64f710da4d8115725bd3567dd99af09477effd"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.4_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_linux_amd64.zip",
+          "shasum": "fcba7ba4f14aee8f4dd0db850d66a90cfd7bd90d0ec3a3b136a5516db386a29e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.4_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_linux_arm.zip",
+          "shasum": "fe89fb4bfed1be567cd85737fc16fc1c1614bb9cb292df1746a49e61fee8dbb6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.4_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_linux_arm64.zip",
+          "shasum": "7286db6e3cfcd86ca2cee0ba4979e8f069d66b79698c2a7b9457f8f94f34566a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.4_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_windows_386.zip",
+          "shasum": "c4164f3db43289d77ff0f674caf2b281f3905dbe1ee1c321d9926bc9b88a172c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.4_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_windows_amd64.zip",
+          "shasum": "01d871f6919a8d85e67e3912a24d07fac596d84aee4006db69e7f47c3d336af8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.4_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_windows_arm.zip",
+          "shasum": "c60362e7c37a2fb6ea746be14a8e862f15a850c375abdaba86395987f7555308"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.4_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.4/terraform-provider-sbercloud_1.11.4_windows_arm64.zip",
+          "shasum": "807db1dd6556661c6f739d362bc32e883362a1e577327da11e1036069256b955"
+        }
+      ]
+    },
+    {
+      "version": "1.11.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.3_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_darwin_amd64.zip",
+          "shasum": "96e44e5e59af9a10782b95cf1cf3ff4ae2d577df93d7face5f1f5c400da17348"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.3_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_darwin_arm64.zip",
+          "shasum": "e714bf097bad931dde3cfc7b67b94f44b7c0cf97b02dae50ef38b7fc857a2810"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.3_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_freebsd_386.zip",
+          "shasum": "a18a4a714408978ea7d83723c0ec8a0ded8c6a933e95969dc636bcfa1f6e4db2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_freebsd_amd64.zip",
+          "shasum": "e5e9cc5b4f5ebd28a96cfe97f1d0039dd0e47a299cad59040b08931291fd313d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.3_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_freebsd_arm.zip",
+          "shasum": "f4fddc72551488920f2a0e4bf30941ec6dce9acfd75d82c274879764bb79a09f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_freebsd_arm64.zip",
+          "shasum": "173c7cb43afb1c6b70037e68e7733142d29ddcac7d88046c669327ab9ede2548"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.3_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_linux_386.zip",
+          "shasum": "20f7d8556065116412312c521b6e3ac81ce76a3c453ba40cfa335aaec441b6a7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.3_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_linux_amd64.zip",
+          "shasum": "3421309c35731f93449f95d117aa6700a4a007265bf93a098ef0246d4caf800f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.3_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_linux_arm.zip",
+          "shasum": "cb36bb9b3b676662bcf3b2f86975a382d346d30dfe45a01e84345783ae66aded"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.3_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_linux_arm64.zip",
+          "shasum": "d3091650dc0aebe57acb1d6697cd18d9af798cd977f48072cf160742988a83ac"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.3_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_windows_386.zip",
+          "shasum": "055653f878f314d4de1f2a7939e17d739145203845b7775b0c8d3e2dfdc8aafa"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.3_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_windows_amd64.zip",
+          "shasum": "d66c2975a63f1712639c5c8a12559253ce31bc53af5f1ff3ac128d353e8d080d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.3_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_windows_arm.zip",
+          "shasum": "b83f8b1e1e9942b8e5c752bd5e1622a2a180be622db02285e83a612e9ffdb9f5"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.3_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.3/terraform-provider-sbercloud_1.11.3_windows_arm64.zip",
+          "shasum": "1b2f3c508af4d276d33990b5b9d737c4caa9be2b33125aea5c12f37b15f43461"
+        }
+      ]
+    },
+    {
+      "version": "1.11.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.2_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_darwin_amd64.zip",
+          "shasum": "28eeb64854cb157bac59c7819f4c48d6cfb4a76b606500ba5882ca83b52c71b2"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.2_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_darwin_arm64.zip",
+          "shasum": "b9b1982af20b6795f3e7a0358bc0cff20422bb74f1eed20269ff9417aecdedc2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.2_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_freebsd_386.zip",
+          "shasum": "62ebdfa6828063cf598dd85c84f3b24bbff3f6d38242f2ae351eefe37fb98531"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_freebsd_amd64.zip",
+          "shasum": "17dab9f4f7654eaa21a97057dfdb10e922c54802d390c59246a245e045240bd6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.2_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_freebsd_arm.zip",
+          "shasum": "04dddae7df3053683cabab299c12a91b444dd975562221281d7bb5f75e2c3f25"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_freebsd_arm64.zip",
+          "shasum": "b8472642bc942d24b64c334cc59d3fcc7a7454ceefb28ac3dff5b3f640dc68fd"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.2_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_linux_386.zip",
+          "shasum": "b94e853253d8c2ff62a87f471ddcc9e5d32f650838f350fe34fae8743d7a03f6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.2_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_linux_amd64.zip",
+          "shasum": "87e24da7068ca90552139caff4909dc954791b6ecc9aee6b1ad357eb6b4b9485"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.2_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_linux_arm.zip",
+          "shasum": "2b9f85aac6929ba18d546da39dba6efee053146d23c981d02b44feb5c376984b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.2_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_linux_arm64.zip",
+          "shasum": "6ab08105cb1d82046c70e85bf18d9f1f20e61fb5a12afc63486080b19f9987c7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.2_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_windows_386.zip",
+          "shasum": "0c7b7e1288dbbe6d65b32b3d741576d8865eae6e1726fb9701509a058a593899"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.2_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_windows_amd64.zip",
+          "shasum": "12d7b470f7127f783423b820cae858cf4d7b39e19174001562607b628656e06c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.2_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_windows_arm.zip",
+          "shasum": "da8cfeee0c9d96afd2aab0327e38d8ef10451db2385c5e12daff7f12c50ff97e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.2_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.2/terraform-provider-sbercloud_1.11.2_windows_arm64.zip",
+          "shasum": "4892131cb30a7f736e4cbd122d12250450b83ebcab4171a42f926242cce465d8"
+        }
+      ]
+    },
+    {
+      "version": "1.11.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_darwin_amd64.zip",
+          "shasum": "29292c14ec10cca9c2403db02303950f805c82379cc8eda50c18ca46dc5a2841"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.1_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_darwin_arm64.zip",
+          "shasum": "c3b2a991f1954234d7872e98e0af1a3b0ad25e0da0a7870b6af070fb7b33b025"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_freebsd_386.zip",
+          "shasum": "ae18cfcf43eb8cd6a8e1cd8058bdf847321b3517f6d5f125f48546fcf2f3da1d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_freebsd_amd64.zip",
+          "shasum": "8f7db29f0927cc37ae32478569003ecd103f74458abb08d6a01f2753e1af31ce"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_freebsd_arm.zip",
+          "shasum": "c676b142286d7b5f9ac1c0e923483aa522f302d7430300d5eee6180c0d7b3832"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_freebsd_arm64.zip",
+          "shasum": "823dbfd6ccf1c5d0e35488785533d96612d40ff4be877ad6c2ea5390f1e96bf5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_linux_386.zip",
+          "shasum": "280d19ee4c3227f2e20f8d763f56856316e7f34cd99957927ed90ab221c24a03"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_linux_amd64.zip",
+          "shasum": "d48c72ca33147f3a328e8a8886a81a848e71b916131067c617d4a219745124b6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_linux_arm.zip",
+          "shasum": "5f99f33ab7d0b5ae21025ee84ea2342e7f1a86623472fe63f1a3af96cdaaaa47"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_linux_arm64.zip",
+          "shasum": "cb2bae654b0cfc5f4c7bfe0df56c3a619660cd07817a4d9ae47e51600c9c122a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_windows_386.zip",
+          "shasum": "cc72d662ad35eb120ee764889d860561145ef1fc63033cc3bbebfefa305b3609"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_windows_amd64.zip",
+          "shasum": "effe81b078b54c9941c9162c0d7b60a2e9c66af2546f98ddefff0fcae1b3a1d1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.1_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_windows_arm.zip",
+          "shasum": "8d6750892cdd12a48c7117d5ef5760dc62765af4afe13f4083f015417f8797c6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.1_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.1/terraform-provider-sbercloud_1.11.1_windows_arm64.zip",
+          "shasum": "67109c441b9945c3fa19a35c92e691e43bc4d6963914d87b9e7dcef7414411a0"
+        }
+      ]
+    },
+    {
+      "version": "1.11.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_darwin_amd64.zip",
+          "shasum": "b037fbf4ba38e7bbff3079c5a25e2c8cbb66767ccfed7fd8d7f989f484ff4d93"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_darwin_arm64.zip",
+          "shasum": "41e1417429e7f5adb1e35bbe46f0ad96226883dfe046996d91740a03685d501a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_freebsd_386.zip",
+          "shasum": "719daeaa7449f106c164b50a02886eb6706e3d74b89f99837a5f9ca3589d93fd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_freebsd_amd64.zip",
+          "shasum": "02d46000084c386451a71ee5164bd5775e45985efe17829d09a70b31b734eeab"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_freebsd_arm.zip",
+          "shasum": "aa1c4b61bc9490305c27bd1b612f1588ff77ac52093bb0466aa1082c4170763a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_freebsd_arm64.zip",
+          "shasum": "5c9998c76be86b4ccde052600890e3c786e0c499e60181e533befa89f117473b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_linux_386.zip",
+          "shasum": "cb8080ca31847a5981ab99844e3e7b08f355cc34c1df518ffe1bbf53201e731c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_linux_amd64.zip",
+          "shasum": "60784047e4730639c8098a7a121d16aed3cb71189d235241e36382d6657217db"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_linux_arm.zip",
+          "shasum": "8afa1c680c833c0ddec119565965c80a406f703805d98a331394987b9c00f522"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_linux_arm64.zip",
+          "shasum": "60949b47159a6b5b5f8d82692ed1e4ccd89819092d70a12f0b912df17975414f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.11.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_windows_386.zip",
+          "shasum": "40af01f4a022c644c3ee17398a44bb3d85a9d7a7936969564d5c04c585346607"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.11.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_windows_amd64.zip",
+          "shasum": "3e41110c6591a8f496ddf02e1ecf0bd76e83c1696e653582e499b9e589b71db2"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.11.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_windows_arm.zip",
+          "shasum": "db1c7fb0f0e518a6568e3d8d197ad4f334baf9a08074eb33dcb8cb957dce339e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.11.0_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.11.0/terraform-provider-sbercloud_1.11.0_windows_arm64.zip",
+          "shasum": "cceef8941167af84c372a8e0e695407407f43c2ead31974d035d18be31bfd919"
+        }
+      ]
+    },
+    {
+      "version": "1.10.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_darwin_amd64.zip",
+          "shasum": "94de0b6c1c2b4abaf1998c66381cc77718f4a8616037f9446a8e0e363dc1318e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.1_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_darwin_arm64.zip",
+          "shasum": "98959b60897dfd06500844c351cc8ecd9ffaa51a40c24d0cf6f482152b837460"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.10.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_freebsd_386.zip",
+          "shasum": "41473141ec1657dbf2fef2b66ebf4e1e3fe5efea4a627a92250b612798b6bc84"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_freebsd_amd64.zip",
+          "shasum": "ac1117c08f0c8a6d50927b09a59e5e67a2d84e5a41e33970429f244a409565b1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.10.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_freebsd_arm.zip",
+          "shasum": "579c2da018852a0b26b52e2c553855aa0c43c371252fb1bfc57f7920033d1dc3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_freebsd_arm64.zip",
+          "shasum": "1dc3633c334129bee4ba2501e93273e9e97ba3f56c28634493d73c07221aad40"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.10.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_linux_386.zip",
+          "shasum": "9d8d7185d5326983feafe2936215a4af0ec90a4ac8abdac1550387974a4ca370"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_linux_amd64.zip",
+          "shasum": "08a155ac742f40dffbd90b8c0298def54569ad1f321e22b32bd5f0f0a00699ce"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.10.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_linux_arm.zip",
+          "shasum": "c21af5383febf00490cbaec326dc902dbd95fb3d7336fd3dec60ced44ad9672c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_linux_arm64.zip",
+          "shasum": "13f8780dd077bcde914300ff5c78db4dcabe4596f45305377d2c304b27dfad5b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.10.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_windows_386.zip",
+          "shasum": "0a61cb765ff4565ee7135c7af32c9a0373159cd23d9edaffeb085e843b8b751b"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_windows_amd64.zip",
+          "shasum": "e414cf1409f414ebaa3a16ab26bbb130a2921aeb65540e9040ece8aee29b5f62"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.10.1_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_windows_arm.zip",
+          "shasum": "5a1ae1625fc65dd3079635e2d30433e674e175f46dd93d6d6e5f0273ad02c414"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.1_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.1/terraform-provider-sbercloud_1.10.1_windows_arm64.zip",
+          "shasum": "10d7d78ffe69f9f049bb34908ec72b716e6e90703ecdf29577369aa36ed43b24"
+        }
+      ]
+    },
+    {
+      "version": "1.10.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_darwin_amd64.zip",
+          "shasum": "e968fcf61a44650a036de41d1052c243b810962df58022a1329885d7f304d8d6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_darwin_arm64.zip",
+          "shasum": "2c16d5cc1a054402b198bb697f1867dc78d0095cbea32679988a2fdcf861fbd2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.10.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_freebsd_386.zip",
+          "shasum": "2b583c2f41b3f9b830ea6e8a419d1884e4b14e15f3ce9a39c3afa0f1adf364e6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_freebsd_amd64.zip",
+          "shasum": "7409cb3e156bf7a0dbcb3096e5f441e849c03841d53bcaf32f83f476eea82c14"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.10.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_freebsd_arm.zip",
+          "shasum": "d43e2f2989c3dcfd8bf0087ab2cabbbb5b1bd68f2f3d038015f15578d75671b1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_freebsd_arm64.zip",
+          "shasum": "20deb33d8cb648216df7763cc997c7cb34f762c0065d71f32b08287014401392"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.10.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_linux_386.zip",
+          "shasum": "f5f09ae4b5428f6b873266f99085bdf257f8b92e27de73f0d548ab5a78ef8534"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_linux_amd64.zip",
+          "shasum": "155c35ddbf1cef4352ba579f19230067238676bf57c8d4a180201cba05c9c632"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.10.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_linux_arm.zip",
+          "shasum": "3adb6c7bc500c39ed2ba7e297849ca119dcc01c8a2865a1b01aa5aa509a646f7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_linux_arm64.zip",
+          "shasum": "9086f495930dcb0a1631e489ed17e2d116b14a071cd7b9e7f8ff8d7c960ab829"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.10.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_windows_386.zip",
+          "shasum": "bde1d4a606d29e2bef45a0254fe02564be5c5cb785ff536a450214214292b679"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.10.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_windows_amd64.zip",
+          "shasum": "4081245d2b1b9827c14f5f26e0be38caaf6b702c55f262c0d4a476316a86055e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.10.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_windows_arm.zip",
+          "shasum": "4ddb887b6b6d0324b792a8b6065c573df0d2fe280adbf952263d8b04277b0e92"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.10.0_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.10.0/terraform-provider-sbercloud_1.10.0_windows_arm64.zip",
+          "shasum": "9ece351ad053e8c1f8ac6f5ea1dde4902d6bc5c2c442d7e9528c63f0b661fdee"
+        }
+      ]
+    },
+    {
+      "version": "1.9.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.9.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_darwin_amd64.zip",
+          "shasum": "84f3df24efafcb06a624ef7c4379b4f56ddbf5a23f0d2885c88a76c29edee443"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.9.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_darwin_arm64.zip",
+          "shasum": "b901cbe26dbc1bc481fd62adb91d8f79ab4494e22ed5d34ca0ddb2f264de65a7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.9.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_freebsd_386.zip",
+          "shasum": "8b917e16b5fd0d8387c0aa1489cb025456afcebe0ee8bbb124c7ca64c981b2a3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.9.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_freebsd_amd64.zip",
+          "shasum": "da8daba6ccb7c227226ba5cdfccdfd206d560e14a36dc9601b78b290c366da5f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.9.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_freebsd_arm.zip",
+          "shasum": "c79b97123ff852fd8da1cb702dc57678f5a7848ab604c168cda80bc5f9d62e45"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.9.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_freebsd_arm64.zip",
+          "shasum": "a26c16dc2203ec25f0ee38ad293df2ba58f5cedc01b8f8edebfbe5b0c4b987cf"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.9.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_linux_386.zip",
+          "shasum": "8bac8cfc8e3ea4c24de12d68778919db4a9eafccf542ef007303a0f90ea563a7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.9.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_linux_amd64.zip",
+          "shasum": "8ce274694f8cf272cb66db9a7eb920390ab95d403d07fcd77fc266dd34539f03"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.9.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_linux_arm.zip",
+          "shasum": "b44dd7cda484502835c19462a0353a2c9ef6881112d9dd0923178ee1bc688722"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.9.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_linux_arm64.zip",
+          "shasum": "66d3a39f0146cf19b0a1da86c94fd3e439e74063aa5a8d6b6baf61448eb4b6c1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.9.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_windows_386.zip",
+          "shasum": "fd9bfe220a7566880738707d10fcb8eb7bc6ecfd3782373626e6ec60548e8001"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.9.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_windows_amd64.zip",
+          "shasum": "3459b32b20f35df3aa2fbe2c3cbae62809a6fe3803d5c7bce86ec45a44d74002"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.9.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_windows_arm.zip",
+          "shasum": "ae9da758db20101bbdc94f91214875b6c4664eaf1322d15ef677c44b1fc28cea"
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.9.0_windows_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.9.0/terraform-provider-sbercloud_1.9.0_windows_arm64.zip",
+          "shasum": "495931c45c2444536db41c8c7dde16086407f65f8480a417baa6971738f4ce07"
+        }
+      ]
+    },
+    {
+      "version": "1.8.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_darwin_amd64.zip",
+          "shasum": "ffbbd14849bc8735f3b65b5532753b74dc07d3975f9b0cfa870ea8c887488a8e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.8.1_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_darwin_arm64.zip",
+          "shasum": "1309ed5dced68ece21fad03cb0ffcd6656ced7832a58cea9d8fca2f556240171"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.8.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_freebsd_386.zip",
+          "shasum": "6b836c28befb376e55cdaf287deee770a9153b78f6e67c0628d6e50053c56af7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_freebsd_amd64.zip",
+          "shasum": "dac4f1fd4f6ff518b29af156137f57e64286fc1744f28e96ca42182648b4722b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.8.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_freebsd_arm.zip",
+          "shasum": "adab0bc0e1fcec29a9eae46a7aa94edd9072d4473fb33219281101f218f0a659"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.8.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_freebsd_arm64.zip",
+          "shasum": "cab7db3d975cca8c890178dd77118102826fe6092f916315bd712e2c61bd42de"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.8.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_linux_386.zip",
+          "shasum": "9efa54c8e9f5d93a7556a49b787d1e4aa5f4c96943e892326907f59551757cf9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_linux_amd64.zip",
+          "shasum": "bcd0155a134e3b9aca17ea6898b8653c59a1b8ffd08b46d62e6f947eda28883f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.8.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_linux_arm.zip",
+          "shasum": "fbbdae23ec0553b8463e59de7cdfcaa9e580d74bd1e6ece891a44d6acd87155d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.8.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_linux_arm64.zip",
+          "shasum": "151e14f0f3c600f2cc2b0c1ba7476ef0956f8257da1248a98dd9227d285914ae"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.8.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_windows_386.zip",
+          "shasum": "71e68fccda0860edc8ac93fbebd983dda8a89eada5b27d640af2e73a6d9251bd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_windows_amd64.zip",
+          "shasum": "788d1ff8e0831e346a27ce3f9146a62dff46db4cdd6c7dc4a826b4f010db001b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.8.1_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.1/terraform-provider-sbercloud_1.8.1_windows_arm.zip",
+          "shasum": "473ff6f08fa762cf89122f29b106d9fa9c337970689d6428147269671b1e5e99"
+        }
+      ]
+    },
+    {
+      "version": "1.8.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_darwin_amd64.zip",
+          "shasum": "0b9de85fdd90bdcdc37c5a2ae6fbf166f486753728ae4e4537b6e91d8c6c27f8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.8.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_darwin_arm64.zip",
+          "shasum": "b0af665c0ed04ec1c6b9948b744e460409770e0b7560d48e80fc995da1bb820a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.8.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_freebsd_386.zip",
+          "shasum": "cffe130f1783feaa5d7355eed781feb0c570bdc08baf03f36c2543dbe88774d7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_freebsd_amd64.zip",
+          "shasum": "fb13fa4d267e07fe6be41a2b7682079fcd709b9ff3d15d9bfc7ce8ae92f872d9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.8.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_freebsd_arm.zip",
+          "shasum": "b6fc2a38030bdc75acb3dca1a8cb88cb494ab61c485250cecf7e84437c1ee4cd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.8.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_freebsd_arm64.zip",
+          "shasum": "555f8c2824c7db9ac559beacb2f9135da276b527da893ab2d01f4a1244f20a9f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.8.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_linux_386.zip",
+          "shasum": "662da64244c990d1e9222b6f897601989a7cfab5f3dda763d634b83f7b5aa800"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_linux_amd64.zip",
+          "shasum": "279efe9154cfa48b15371663c24528177bab0b6c7b700aef00c702d6f7a1ddc1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.8.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_linux_arm.zip",
+          "shasum": "dc3c0c2f8f77d229fff6b24b389d4a1949ef2d784dc98e79efcc5544db803f4e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.8.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_linux_arm64.zip",
+          "shasum": "9db2813cc41fe5c626bbf03dd7afb9d524cc1956502f50f0dfff4a3246e5816f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.8.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_windows_386.zip",
+          "shasum": "1639edd10ff0421b65ae5419189e77c32f9b4ec9da18cfee23b0588bd944664c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.8.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_windows_amd64.zip",
+          "shasum": "c6c786cb98ce848e46a460c819c57031182b5d12814a91e2f9c24b3ec4822d66"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.8.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.8.0/terraform-provider-sbercloud_1.8.0_windows_arm.zip",
+          "shasum": "b11a3a83ae32e84ddc752ae8665fee3fbd2f69ce0c6b0d8a420c081d42d5ec18"
+        }
+      ]
+    },
+    {
+      "version": "1.7.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.7.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_darwin_amd64.zip",
+          "shasum": "ba038f7508e07e2d3d6ced6e1d8ecd338e1d8fb3ef1cdcd9c6b03f41b346678e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.7.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_darwin_arm64.zip",
+          "shasum": "755d12bee62084c5d3997431f5aa8813b772ec733cde56d0099b2a68c2c87cc8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.7.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_freebsd_386.zip",
+          "shasum": "7fc47f5f891fab2b1a50d1e816818a25d52f75b5c89fab7cb314d9f7524052b2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.7.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_freebsd_amd64.zip",
+          "shasum": "f0c1ace56e14f9c6344f96ee0959c88e8a6b28d4637b469adb2ec96c2e3e7d1e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.7.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_freebsd_arm.zip",
+          "shasum": "690cc1093f882acf6bac8930d27672f4902797ecc8ba6c94d588aeab81e275b8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.7.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_freebsd_arm64.zip",
+          "shasum": "0bb76414c46a0dc4a28f01f0dfdf834970a9143e5d0406ccd8df115cdd3ae71e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.7.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_linux_386.zip",
+          "shasum": "6898cdee484bd0e4e3da50d24eba57609284f0077821bb0eca15aae6a85a54a8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.7.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_linux_amd64.zip",
+          "shasum": "b8e6c74343d507ebb2c1889e958f38536df8576597772edde120bcdf8a50abb7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.7.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_linux_arm.zip",
+          "shasum": "cfdc22e9ba37aba15ddf5339d278d63e8902ff31d1c0c5a00121b45bc6b9bf73"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.7.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_linux_arm64.zip",
+          "shasum": "229d57b89f7f5d2b3f371b799323c9ef19fe17396509439584d61bcf820776d4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.7.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_windows_386.zip",
+          "shasum": "61fcf13bdb509b7b3fa43ae2d7a329310a3c90831308e005cb39de938e380ad7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.7.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_windows_amd64.zip",
+          "shasum": "12850c1882a180b4fbc1e45f1fd098e72913991dbe32c258a25fbbfe27aabc91"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.7.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.7.0/terraform-provider-sbercloud_1.7.0_windows_arm.zip",
+          "shasum": "48ab177ef7557fc97bd4771cef6df642ca469646139c8accea7e9821ea490c58"
+        }
+      ]
+    },
+    {
+      "version": "1.6.3",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.3_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_darwin_amd64.zip",
+          "shasum": "9e990561fb82d5e6b92e113d42813bc2f02f428ae357a9600dd09216872b8139"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.3_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_darwin_arm64.zip",
+          "shasum": "37887ddf5493dc2dde6fb56f765b6953a8cd02c66e2c7d44aafd7f6dc13471ef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.3_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_freebsd_386.zip",
+          "shasum": "914207350196ad4e348f39b2645f4232dc135d4795f1101a52fa6eb0794557aa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.3_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_freebsd_amd64.zip",
+          "shasum": "3761e34b9bf7a8ef8951f35a1bf1ac35994d9d821311896cad2fd8880fb6475f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.3_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_freebsd_arm.zip",
+          "shasum": "c640dc6a1aeb018aa657e60b8d311fafa7ea66739d7c2e0fff1c35447790b2ee"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.3_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_freebsd_arm64.zip",
+          "shasum": "f92abe85feb6d2e10a44c716ed48f94d102c67240ad5904680fa99402d421f12"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.3_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_linux_386.zip",
+          "shasum": "f8b94d38d581f25cdd067f41d721a237b1e14a1c56370811337bd18352e4e135"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.3_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_linux_amd64.zip",
+          "shasum": "11322c4aaac3007ddbc9a0cca336842eaffccb76faf7281d3f38c95e816a61d9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.3_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_linux_arm.zip",
+          "shasum": "5a879c63f97c4acbf23f8e1e4f957f5a680ce79a9fe83e003d1c27693af5b2b7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.3_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_linux_arm64.zip",
+          "shasum": "3e529655bc58c06fec49431c319365fe072472d0a45ae67c451876364b7f476e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.3_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_windows_386.zip",
+          "shasum": "7ac1ca6f8e8413e9b68c9224e597aa7f3099575df7e131796d749081a2bd7e25"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.3_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_windows_amd64.zip",
+          "shasum": "344653572ffb7e76ccb4d150f3f330cf81f5342a9f73c5d88ca258a5d329fa60"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.3_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.3/terraform-provider-sbercloud_1.6.3_windows_arm.zip",
+          "shasum": "0aa9bf900a03e70139fdc5d5d09edc654490b5c061d914e2e1747335743b8a5b"
+        }
+      ]
+    },
+    {
+      "version": "1.6.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.2_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_darwin_amd64.zip",
+          "shasum": "83805ec68de55a6dcab615ba6d5bb0b0de05f6fcc46d7644a1c947694976de5d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.2_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_darwin_arm64.zip",
+          "shasum": "f7c5b0ff476aa8f87792b99b77c9f005c1ba18fb05b46a93037705d24cf7b2c8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.2_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_freebsd_386.zip",
+          "shasum": "8eff92cfea9189804998c6126526a4fab9c24f77911e8ba331d98cd43e6b0af7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_freebsd_amd64.zip",
+          "shasum": "091a0538fc37fe51e59b98e0730aa693fc36538262ca2d7aaa7c6b52e4979000"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.2_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_freebsd_arm.zip",
+          "shasum": "c4d4ce531df568233a4caa54c381088ce668f859b20bd2d3e84a76b27c134c8a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_freebsd_arm64.zip",
+          "shasum": "a5cf69574c3ef5a0c914cf01a152b58da36d2d2b9d152e9f7741926aaa7e3d5a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.2_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_linux_386.zip",
+          "shasum": "38938f8a410f651821ad9e3d00f9f42f49b70a81e0217691acce7a700a3dc703"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.2_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_linux_amd64.zip",
+          "shasum": "dba8d65af01c9bd4b83a9e2604749a1c8abe725b661f003125f8aa3d7e9cc657"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.2_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_linux_arm.zip",
+          "shasum": "f11233476a7df5f8e621051c89dd79fb5ff38187cc990550fc6d4c6f19be6607"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.2_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_linux_arm64.zip",
+          "shasum": "20a72c76361b09efe4708a4592f4668ba78b738a78eb2b2bf9d26915020d8ea6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.2_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_windows_386.zip",
+          "shasum": "c386aaa64ceb23d992a1cb5b4427581d36bb59d29e79aaf7ff6a8c704253ffce"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.2_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_windows_amd64.zip",
+          "shasum": "f1b6569770473698451498ddda9a838ed0a7ae33cb799c4c556e0ee775d03154"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.2_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.2/terraform-provider-sbercloud_1.6.2_windows_arm.zip",
+          "shasum": "cfb024aa295b2ce704fa0a1d43b01726504c4f8b289e8e13da55420974dfd616"
+        }
+      ]
+    },
+    {
+      "version": "1.6.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_darwin_amd64.zip",
+          "shasum": "b197ee2d23e592c92e157f8e50c6cd54d9520c5a583e115b1b61391919766dad"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.1_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_darwin_arm64.zip",
+          "shasum": "619548275d0abdf129b5fa6f3266d5383b457e263d86311e05bfcd2e10a386a1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_freebsd_386.zip",
+          "shasum": "6260a1a71db8fce4c8024b0d488b4f71d87006048138553dc8f16f60b338191b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_freebsd_amd64.zip",
+          "shasum": "d82363006bffae76d8562675d2b4ad81a6ba33387f7a6c0b4d6de37e9eb1d435"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_freebsd_arm.zip",
+          "shasum": "036271d26fce522472b6f9560699501718d0ead3fd4af2217225a53f1747d9a3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_freebsd_arm64.zip",
+          "shasum": "f86863c6524881ef8b60a31cb9311b5437e6e87ebc6d696c98b871c1d233efeb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_linux_386.zip",
+          "shasum": "ee35e770b9f81d475dccb25ef37db5cd894b7c430712193e2f2261d1d653f319"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_linux_amd64.zip",
+          "shasum": "66f2928fb612f4fed3568e6b4b97d03c9db634054e5a0d919d5a3c2d4cd8a002"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_linux_arm.zip",
+          "shasum": "9eb369ef5e64e03740bc593a0ceee26f716f30aef365bd76e51f78119430e7c4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_linux_arm64.zip",
+          "shasum": "176a2c4add20bb5ffeea7979b28de297b4a8ebb243846607510fbaac4acca959"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_windows_386.zip",
+          "shasum": "eb9e866ecc0f3194080e7fb4c318ec1f6ebe433d7865af03490f3210c6028456"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_windows_amd64.zip",
+          "shasum": "03e8e8c9dd7e43954c7e2f143423b3c140f22ed504387627698757a732c69e1f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.1_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.1/terraform-provider-sbercloud_1.6.1_windows_arm.zip",
+          "shasum": "5d604818586ba008364efdb90b25642ff9f4b24f4c3cebd3ce591896b74b9713"
+        }
+      ]
+    },
+    {
+      "version": "1.6.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_darwin_amd64.zip",
+          "shasum": "486dc1efc78b60c669b05ca6b9c09c12d057ea3867b9a434caa077156f3c985e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_darwin_arm64.zip",
+          "shasum": "79df967501137f1b3d94f6d8b35530e08e0d76e278a7967503341918cd18d228"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_freebsd_386.zip",
+          "shasum": "955293282bcaa2e5fdaeb01c1e32e5917ede435c521a1e06deeaa503d802df3d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_freebsd_amd64.zip",
+          "shasum": "04784d160c4c28ab53fe42f7b1b8a5b0db1e6f45bdccc01562802b0867f5a830"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_freebsd_arm.zip",
+          "shasum": "1174a8821029a0d92d0dad16923fc2e852be53b719aa236fd620c6b5c83bf7c9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_freebsd_arm64.zip",
+          "shasum": "95837d8a92a9d0d90fe5e0a9e3721c3e392c5aaa0897294c07df98da08ef0e42"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_linux_386.zip",
+          "shasum": "8ef4cd5fea403bb69cef40e118b542e4c806503c07e6f256a407722e7486734f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_linux_amd64.zip",
+          "shasum": "06e7ed4f8c9c4b0812ccffbe894ad88985f94c8e9a8f15cd506da49400b997b4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_linux_arm.zip",
+          "shasum": "9f23203af11b199e6a6adb352509f97d1e9613602114734fb114dc43879c00c7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.6.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_linux_arm64.zip",
+          "shasum": "af6564c3cdbac36b61dd57165cfde097cdedecdcb396a9d6475d397d2fb2b52b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.6.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_windows_386.zip",
+          "shasum": "5536ebcb36775fd5cb5b369849091076a7117d44e19867bfb21fadeb95fe7eb6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.6.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_windows_amd64.zip",
+          "shasum": "771202c6a660a3a2f389ec31aa6d163c840da6be87e92551edb6b4c4944724ec"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.6.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.6.0/terraform-provider-sbercloud_1.6.0_windows_arm.zip",
+          "shasum": "2d573113fa9e03408a6f2dadf7b3a09e538e63dce67d986d5686d6db89aa6bb1"
+        }
+      ]
+    },
+    {
+      "version": "1.5.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_darwin_amd64.zip",
+          "shasum": "f305bfd6d3bb95e8453ca5a3874d03fa0bddc93785507fe39db616b824ed0c66"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.5.1_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_darwin_arm64.zip",
+          "shasum": "c14125079f19957227ee85e179b8e6c091051f2212f0c2bfd2a6d13cb76473dd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.5.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_freebsd_386.zip",
+          "shasum": "7ba714a622a45be17b483130d700685421c18fd3096fe4829e6637a4ea11a9d5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_freebsd_amd64.zip",
+          "shasum": "0e56f288f386de400fff79b20c11188b7116c3567b1935d4f4833746ba390568"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.5.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_freebsd_arm.zip",
+          "shasum": "98dd63be82d5e2217db0b8b6c9a63117f5f55eece4ffbbee43d66f126c7deec7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.5.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_freebsd_arm64.zip",
+          "shasum": "0b47e81f1081ca75927cef6234331caef8f367cc6651d6eafc1d6687327eca91"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.5.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_linux_386.zip",
+          "shasum": "e70147ffef5ad95f8a7cc75cfb1558b22bdaf0eb9bf58e65f8d80b86b3c43537"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_linux_amd64.zip",
+          "shasum": "60540591b570d3cc33d85372e3555128e0dbadc5b1b7ad4e4994245993dd067e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.5.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_linux_arm.zip",
+          "shasum": "7585a0f0b52731cb18cbc704d9eda1b19e942baadd80a3a76c0b7183edc56036"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.5.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_linux_arm64.zip",
+          "shasum": "5abdd9c04ed8d7564c4f9deb2c1d547ac85b43667d83784bc8daea8c514384d9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.5.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_windows_386.zip",
+          "shasum": "851f232e2ccaecdc3eaca8d6aebc89cbeeb4be690b3231938caf223c2d03720e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_windows_amd64.zip",
+          "shasum": "eb99b16a50f7a21d56cd95f44b6bce426af7416a2b4a20791271e37fafbcd05f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.5.1_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.1/terraform-provider-sbercloud_1.5.1_windows_arm.zip",
+          "shasum": "105486d7cc86fab44056bf601c0638c4ff02bff9a43d7a9b8ed202332d5f974f"
+        }
+      ]
+    },
+    {
+      "version": "1.5.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_darwin_amd64.zip",
+          "shasum": "76083fda005c10097f0e54e1d45ede8e488703c990ffdf1bef42ede572f4bbd1"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.5.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_darwin_arm64.zip",
+          "shasum": "5cfc8a4304b08afb6c056de71a8308ecafe5a1af8e920014bcbd0d8149b0c724"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.5.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_freebsd_386.zip",
+          "shasum": "90fb2e90fbbaaca5738dea7dd7b378fdb528f461fec0f01fd4e27fe2f9bfffcc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_freebsd_amd64.zip",
+          "shasum": "db0ca5cc55806b97434e2f544be6d94b557505a7ceda51588086806d2886d4a0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.5.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_freebsd_arm.zip",
+          "shasum": "2f4dceb69e053e22d74f247089ec546187fbfdc4cd07270468efb8da8778ce7a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.5.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_freebsd_arm64.zip",
+          "shasum": "4cfbf8e564eaaf28565ee402e72a210179e20208b0811bef792d2ce3aeae58cf"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.5.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_linux_386.zip",
+          "shasum": "0ea1510cc910796f7d44aa163e214bf39d66b93c1cead34a2cddb179fd82c427"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_linux_amd64.zip",
+          "shasum": "1d1a25f9603f1453fcb9f842aca6ef167728091ba0278954ce9fb037896deaae"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.5.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_linux_arm.zip",
+          "shasum": "696250bf5d3237bd5fb86c6814d4a7327e07836c40a71d7ce4b6082a65e91ded"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.5.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_linux_arm64.zip",
+          "shasum": "0f3d6f03b28f5468b31e7e6730a7320cfd51085ff1748e1cf312ddf236b26dcf"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.5.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_windows_386.zip",
+          "shasum": "707dbeafdb630c6f79fb990b709842afe2adcbd3b384518964de351e68fa3f86"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.5.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_windows_amd64.zip",
+          "shasum": "5f0ca17fd06af271d46d60f8f88fd1b865aa5b8de01dd9e048b23d732463dfd0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.5.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.5.0/terraform-provider-sbercloud_1.5.0_windows_arm.zip",
+          "shasum": "2510e07d60aedb021a4f38df008b464e330f2b9aa9ddac4936e208d47b26a50b"
+        }
+      ]
+    },
+    {
+      "version": "1.4.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.4.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_darwin_amd64.zip",
+          "shasum": "d207f8017d2209f2c1f645e6ffe6d4ff1bc48b466d87edaf6c359a434d561dee"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.4.0_darwin_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_darwin_arm64.zip",
+          "shasum": "2b41936d5d2fee6759dd29cfa9d34b56cbcdf7e8a3702bb6423c3468a75005aa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.4.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_freebsd_386.zip",
+          "shasum": "d3b7304caeabeec08ba5c8c66ebfaf98d15f4480dba5d1fae3cc12e5290b2c77"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.4.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_freebsd_amd64.zip",
+          "shasum": "847b8041ac5577a01f8baf1e5eb13195a098628e9b0c5fd844305439c02e42b6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.4.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_freebsd_arm.zip",
+          "shasum": "d81cb2cd91a0c8118762b2d2ef027ac2a0a17569cf776f587e2aa9635bedd9c9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.4.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_freebsd_arm64.zip",
+          "shasum": "1bfa7e8ddb83872be90ef9191edf0e198dccf53d15845ca5a19d78fb41518225"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.4.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_linux_386.zip",
+          "shasum": "8391099361bded6445cfc945ec1b5c6b27197e143d8ec1d4fef8f5989ecd6133"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.4.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_linux_amd64.zip",
+          "shasum": "4c310fa3c04b48692085dd7fa6a39477c599ed6d9791756dea3f694fbf7d40d2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.4.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_linux_arm.zip",
+          "shasum": "4af18f15267eeb8fa61d298a233870df151faaad5588d263a34bedb07c6baa02"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.4.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_linux_arm64.zip",
+          "shasum": "dbbfa224db1916974e88da76c85161c30579abe49b4fc0d7500d0d41f382e70e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.4.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_windows_386.zip",
+          "shasum": "f8472fb1a6831b57b28051c397258acdb716367215cc9e7f2203fddb4f07a360"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.4.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_windows_amd64.zip",
+          "shasum": "2c4dfaf62e925d4bf555b4421f1bc8e58b324aafc584b2efe7838fe6353e743a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.4.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.4.0/terraform-provider-sbercloud_1.4.0_windows_arm.zip",
+          "shasum": "05b905d726705daf28249c30c2ccb41780b70e643bb21f7557541953ebe21570"
+        }
+      ]
+    },
+    {
+      "version": "1.3.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.3.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_darwin_amd64.zip",
+          "shasum": "4abdadbde014be7af404846db81b3b3dd6a504566acfad2f395e660acb9e7b4a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.3.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_freebsd_386.zip",
+          "shasum": "a5c0499fb0cee99df1b1901e1171545e56c11829c4104a2314e3653400cce412"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.3.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_freebsd_amd64.zip",
+          "shasum": "78274e0ed884abfe66ad112df24eb3c53b51d3cae65ab3d8389fc9cf292d7cf9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.3.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_freebsd_arm.zip",
+          "shasum": "e249aa75bbe2ee108813bf952a0249fa75c656958403d531bff2f62c3575bae5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.3.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_freebsd_arm64.zip",
+          "shasum": "0068fe068c802dc8f0586d4404568cd8ec2370b1332ddab04a4abbcb1be0f87b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.3.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_linux_386.zip",
+          "shasum": "1128636918b3ea3bf8c22f4a648cf0b72dcc9b7354b8a20bc1b50514b734fe19"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.3.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_linux_amd64.zip",
+          "shasum": "d45d87fb961c0d5a50d18e9b01eb98d25fdf4a1014def4a83aacfe75d917cd66"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.3.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_linux_arm.zip",
+          "shasum": "8955c3a66ced76762bc2ba7888b1286552b94693d100a61bc10ca5924889c421"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.3.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_linux_arm64.zip",
+          "shasum": "d3b566f985c8d690244b9855fbc2e942d036774a9524c558a50ecaa138249446"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.3.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_windows_386.zip",
+          "shasum": "19ecc0419c75ac439c88eaca7714481a5d3fcdf10acb15e3fc5603e7d095767c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.3.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_windows_amd64.zip",
+          "shasum": "d6775d014e172f28c195c3a9d102bf89b811dc1056db78abcad22f1f62e890b3"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.3.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.3.0/terraform-provider-sbercloud_1.3.0_windows_arm.zip",
+          "shasum": "a3a888b5bbaa35cf6677978ed07e60ed5d067a7b64310d72d58f9d7350c18ab7"
+        }
+      ]
+    },
+    {
+      "version": "1.2.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_darwin_amd64.zip",
+          "shasum": "af4c78077a2559e52b3c4eebc1515b056b9128c6910d8ebec1a38701eac41fb3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_freebsd_386.zip",
+          "shasum": "df67a9ec87407048f4095abbe36a2edab1d1a5686002a4049929a6c78d324c43"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_freebsd_amd64.zip",
+          "shasum": "1306ed56ce7bfd3a6000e675555e266cb5fef87dfbd58636e6af6521bcc1ac54"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_freebsd_arm.zip",
+          "shasum": "a747f32571427f8972307eadfd9f47a1587e3a154ffa9c917ee529fbc1b1619c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_freebsd_arm64.zip",
+          "shasum": "2674e140bb85eb4af3af3d398aff1e779d135ccf0a7858c57a3f7eb293edc5b5"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.2.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_linux_386.zip",
+          "shasum": "a3f92eee8c271aa884a58a7390dfd1b8b5f1bdb599cd3e463b345f8f8e39f4db"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_linux_amd64.zip",
+          "shasum": "144cac9860d1d84f17181362e66932366ec15e0b6728335a5f84cdcbdbff0cb4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.2.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_linux_arm.zip",
+          "shasum": "b97fbc3fd80e49b8966e74ff1ae9258c0b60d612c1036e013f490b4f757379ac"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_linux_arm64.zip",
+          "shasum": "ae03c352345462810bcc36cc68a0166bb13c9b1a5be7d3639d4dbb3d3d4630cc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.2.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_windows_386.zip",
+          "shasum": "9a51ea40f65165f49c2b3f8b08f4c30a6cba385a046371948b6f78a794142c9a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_windows_amd64.zip",
+          "shasum": "941f1ec5d33bfd30824ef59da21d40c290df85a173ba5f7975978b064caa895b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.2.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.2.0/terraform-provider-sbercloud_1.2.0_windows_arm.zip",
+          "shasum": "fbf89752c55869e9e21dc082fe2e08d85ade424c9d19f08139d2fbd5a2444633"
+        }
+      ]
+    },
+    {
+      "version": "1.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_darwin_amd64.zip",
+          "shasum": "74e1e3fc95f094e4ea9ca4a84f3d4b393514e4aa33a337604a1ca39044e50c9a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_freebsd_386.zip",
+          "shasum": "e017a6ec02ded6da5f74bbdabf0bff0618b07767f503d1a61add9022dd87b323"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_freebsd_amd64.zip",
+          "shasum": "ec2b1757d399a913224938b6993e9e5ae92b33f37124f14a820830c26845953b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_freebsd_arm.zip",
+          "shasum": "fb939d3e9e2a92b852cd5ce516d461d61d9f03ba4b7f8d59e25366c3b3993190"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_freebsd_arm64.zip",
+          "shasum": "094412d1dbe86001af71736c24f88f7b78143a2ef37c882650d6df24ab81b68c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.1.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_linux_386.zip",
+          "shasum": "112e4c02f18b2748e7f235f53936ada26af38ec52589561328ca7b6df3041b99"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_linux_amd64.zip",
+          "shasum": "98ef96826d0838911cce61da4b77ba01b31e0d2783bf67c612048e64ad6cd263"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.1.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_linux_arm.zip",
+          "shasum": "e8fb2aff821465aa71ae5ed31822a3507193c6a65c96ef1136ec654b0c20976a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_linux_arm64.zip",
+          "shasum": "7019d4edc830f811aa6e3e296e2209387562e8a3011550b0b1fc6716dc4b7a71"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.1.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_windows_386.zip",
+          "shasum": "980d2101e8bb0cea528ddf6df695367160c5755c68ec15279ced00161d3b79ca"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_windows_amd64.zip",
+          "shasum": "f63e733abe19e644f803204576255a83da5498681a585145901bf49054e82455"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.1.0_windows_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.1.0/terraform-provider-sbercloud_1.1.0_windows_arm.zip",
+          "shasum": "3e5a0ef95c44f5f4fe58db9541976fa0ae2d99b7cc23d4d6ad95c088825f883d"
+        }
+      ]
+    },
+    {
+      "version": "1.0.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.0.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_darwin_amd64.zip",
+          "shasum": "f9ec51565b6b13448d82b7b45e4ab1d3df8d186c3bbb05a4ea17ede23c092e98"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.0.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_freebsd_386.zip",
+          "shasum": "7691b276498e7f009be6f8caea9ce53781ef67eb9014b19e1620efa59e917f3e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.0.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_freebsd_amd64.zip",
+          "shasum": "b29af47d3e3cbb8fee438ac1600e5ce57b01e79ae728af7558de1bb07c9d90e7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.0.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_freebsd_arm.zip",
+          "shasum": "ae5f10176d211ba715069775e00ea72d47ac9d815aaac9644cc92537096f57c9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.0.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_freebsd_arm64.zip",
+          "shasum": "75660ceee24edc07eeebace40098b26e0b032d313be72f6fb270dab738a6120b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.0.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_linux_386.zip",
+          "shasum": "638264352da52e8e0d3a94327853327266adb53bfba2f13319d8626647a7d61d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.0.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_linux_amd64.zip",
+          "shasum": "62bd68c72ae8b7a61a2de6b69750cd574c48cd095cb9b3f56021bc772444f271"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_1.0.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_linux_arm.zip",
+          "shasum": "e690222ab9804c25740165e36c7a6fbcc931eb8815c70cebdaa174205586fba8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_1.0.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_linux_arm64.zip",
+          "shasum": "b2093506078c04943b829ff9526cc3c949fcdd89e37b40e67ed5edb10470756b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_1.0.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_windows_386.zip",
+          "shasum": "bbe273a73af224984e6bd3921ab0c659e10823e016425bcf54e48e039518e3f4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_1.0.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v1.0.0/terraform-provider-sbercloud_1.0.0_windows_amd64.zip",
+          "shasum": "3297eca997a23e63af37d0090afba1a8e27cb39952aa72629a15c073427cfd47"
+        }
+      ]
+    },
+    {
+      "version": "0.1.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.1_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_darwin_amd64.zip",
+          "shasum": "c373d60a5f86bd9c9433e8641194abd984ddcc4a1cebf3a31380d11b84075cfd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_0.1.1_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_freebsd_386.zip",
+          "shasum": "51e11a177d7beb3f572d7361ed5a18518dcfde31e11572768d8e5ebea94b21ed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_freebsd_amd64.zip",
+          "shasum": "ee5cf607b2a0baf19dac5d17978a69e2dc7b76a2883b9227348af93f3173f26c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_0.1.1_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_freebsd_arm.zip",
+          "shasum": "27327989172304d5a0012faf01f0a8ebe5ac3d75efb27c6f7cd12d22d3bc7d1f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_0.1.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_freebsd_arm64.zip",
+          "shasum": "8b65dbbb47361ceb7f8400cdfecac7a632c6cb5d1754af6f02cd2b904be7ecae"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_0.1.1_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_linux_386.zip",
+          "shasum": "e756e0645d29470ecfbfc09f5326a970a04b67b5fb0e40ad99476489df0277c9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.1_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_linux_amd64.zip",
+          "shasum": "fd939ba82fc9f871c2cc601272261d7cb98e0b0ca16aab530784dbd93ef8797a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_0.1.1_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_linux_arm.zip",
+          "shasum": "1fca95c478ce0e4a9f4b5f1169094735583039e0f424348dd70abc5754a0d44d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_0.1.1_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_linux_arm64.zip",
+          "shasum": "3d360b4da85351613b513e12502f4f83e288a5118003edf3ef093851339b15a8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_0.1.1_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_windows_386.zip",
+          "shasum": "1650657d89f571d9ffd7ededbfcb93ddf6dd749beb1ae9654cf8c1834af0e733"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.1_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.1/terraform-provider-sbercloud_0.1.1_windows_amd64.zip",
+          "shasum": "cacc25d31d5ba16ea235564f1a17599fdbedbda54955be16712c24e00a3129e4"
+        }
+      ]
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_darwin_amd64.zip",
+          "shasum": "e1526b631ac67ba85ba85f53a1e5d2508909859f8b1597659567aa7434a2857e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_freebsd_386.zip",
+          "shasum": "329dc429055c13f83c6921654f1d7f0a971bb5ad78d1ec64d745e336158e9bed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_freebsd_amd64.zip",
+          "shasum": "ee7c119e463af96dee6c418145ab39e2e5318378e9750c67ce2bc090686116f9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_freebsd_arm.zip",
+          "shasum": "01f23ff5507c941bf52d94edeed9892eca855801b42f807fb5df4c7b12bac20e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_freebsd_arm64.zip",
+          "shasum": "cde44e2d9fea6d97c61e401ef94ed5e390f9461181530083101b31eeea1312c7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_linux_386.zip",
+          "shasum": "ffdfd2bfeb39aca69da1e68226379c6cf5912f6f50f52c92d3880cfe173065f8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_linux_amd64.zip",
+          "shasum": "058a743db3f0ded5620d8544ad0cc06c6299d974f09b22a9df168a5f3a08e974"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-sbercloud_0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_linux_arm.zip",
+          "shasum": "7cf4e41673d86d058c9b6a5deb5daa28d3b1a918f951778750e81475085e3c22"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-sbercloud_0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_linux_arm64.zip",
+          "shasum": "c482ecef171872c896ffa5de02c4e0abf375a66b2f3b84173b45c4fbb7ab93bf"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-sbercloud_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_windows_386.zip",
+          "shasum": "d227ec2cab89d17e9c95001c4fa924ee0c90263a349ff259a55b9c540d360bbd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-sbercloud_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/sbercloud-terraform/terraform-provider-sbercloud/releases/download/v0.1.0/terraform-provider-sbercloud_0.1.0_windows_amd64.zip",
+          "shasum": "9b72bc040c77155f1289ba665df1a1bcfeed976af12dc1fc515305bcecd3dca4"
+        }
+      ]
+    }
+  ]
+}

--- a/providers/y/yandex-cloud/yandex.json
+++ b/providers/y/yandex-cloud/yandex.json
@@ -1,0 +1,9208 @@
+{
+  "versions": [
+    {
+      "version": "0.127.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.127.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_darwin_amd64.zip",
+          "shasum": "8d8099a5a1038b4cb15f140d5eabfc5cc2ac9fee0a183c572ecb4965c9fbdf05"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.127.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_darwin_arm64.zip",
+          "shasum": "0791d3d9373d05b31501264ca0f64b6f60055ca39193fd165ad43b7c87c5c8d1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.127.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_freebsd_386.zip",
+          "shasum": "3f990a840999e46bb3ee9bacc5b91e0e1c681ffc00b46fd68faebb6ebe75239e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.127.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_freebsd_amd64.zip",
+          "shasum": "a2d43a331fc97ffe0735c411ddb86b7a80649d2eaba9b3bf557d8588d101fc28"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.127.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_freebsd_arm.zip",
+          "shasum": "e7b4720add3457ce54f6ba5146d5e49e1481e4922859534c367ad29082ee08df"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.127.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_freebsd_arm64.zip",
+          "shasum": "f2000a129c8bfd742c221c8c693d30992163276701679e7c33aad8640928a6c3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.127.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_linux_386.zip",
+          "shasum": "7696d4a82eb1e68e67246e25f787178deed709604140eed27a3b8d03cca74b97"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.127.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_linux_amd64.zip",
+          "shasum": "c1faa0b8df609c4f1600d1c90b4c99e7ccf594859a7de91a0855a0cf4dbead46"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.127.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_linux_arm.zip",
+          "shasum": "8cab8ea3f664991f01b17016b6cd815d27d740c7d17904305119c1a2048b4776"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.127.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_linux_arm64.zip",
+          "shasum": "359c66db78163320232db69ef94b5327bc1adab661edcde93dfd370e1ad3f1c4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.127.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_windows_386.zip",
+          "shasum": "18465fc57492b8f50a126f6189198d79f08445b252242987d9b40be58ed1297a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.127.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_windows_amd64.zip",
+          "shasum": "f0c80d5e13ba98fb9f89ba5967d07ab7718a879b9f1734bd213c23a07574c6a4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.127.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.127.0/terraform-provider-yandex_0.127.0_windows_arm.zip",
+          "shasum": "cb4bb98befea9a2bd684097a9f957748a0e9b77089d303e95389ec2f4817777c"
+        }
+      ]
+    },
+    {
+      "version": "0.126.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.126.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_darwin_amd64.zip",
+          "shasum": "fee53bd9a9581dcb4a64cdc22802d7d5051c16c28c73bf3cf61e5a913e0b99bc"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.126.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_darwin_arm64.zip",
+          "shasum": "8a7b67f506eb47edb40b7f14607bf7b7f2e357dbfe76a90d93b3443aa90c9338"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.126.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_freebsd_386.zip",
+          "shasum": "9e546a1ef9ccb381ef2c17103ecfce27097e99f78f08a723a686a2e5ce50f0ea"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.126.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_freebsd_amd64.zip",
+          "shasum": "1a4c7d8767acd6a2f85a7a5db90b1edf1c6cd4768314d80c289034bf42d2c5ca"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.126.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_freebsd_arm.zip",
+          "shasum": "663e373b6d708bf4a324c899de309f212908d00a836d414a0836ab6778f7d6fe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.126.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_freebsd_arm64.zip",
+          "shasum": "35c1535e41cc8f131cc60db7bc8f3f401779873aea1815516e15a17dba884ac7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.126.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_linux_386.zip",
+          "shasum": "e5a54757a4ba1c69c4855fd0ad7dc7014f49c5f74a2582db3ae1f9a9a0280d58"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.126.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_linux_amd64.zip",
+          "shasum": "34bc1ff8422cc75e27454bf6be84f1983ef8a39dbcde96a8ebee1f7320a88d70"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.126.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_linux_arm.zip",
+          "shasum": "d86866c16575db163606a0cdd52a4ace8f520bbd1b040e732d21998aeb2cdfde"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.126.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_linux_arm64.zip",
+          "shasum": "b39f94ceea4b2554df072791cbb3e6b14dce2c1271571d70ba91596d4d311b11"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.126.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_windows_386.zip",
+          "shasum": "1a9db3e772dd1aa4b15ce02cdda897fa8bb6ba823c39b4d82f178cb51973dc84"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.126.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_windows_amd64.zip",
+          "shasum": "677fca53caf617236a45c24926051edbd0cfa8bca35ee06ec610cc0f1e4a586a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.126.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.126.0/terraform-provider-yandex_0.126.0_windows_arm.zip",
+          "shasum": "9df358dfc609acb519ce5aa19c828e089cf7b2a20ef59df82e7812a5719fec35"
+        }
+      ]
+    },
+    {
+      "version": "0.124.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.124.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_darwin_amd64.zip",
+          "shasum": "39b2d87706083452a8fb4c23651675ceb082db19dc910241203b4c4f8df67eba"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.124.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_darwin_arm64.zip",
+          "shasum": "17be572fa329ad546b1708241bb149ae36a9ac45433a9393d41d3734b6f727e5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.124.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_freebsd_386.zip",
+          "shasum": "ea2ba95a83b56cb9a0afd5b6eb2bdc76852895cfe0691d1aa058bd4b522007d7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.124.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_freebsd_amd64.zip",
+          "shasum": "cf1d647d79aae345fc2e6a29f244c76b132ac2cabc55a9d3981423cbfa9c4781"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.124.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_freebsd_arm.zip",
+          "shasum": "a08c125eee4db38589671171bcf147bb77f18e888e31c3ec008c443757ffee42"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.124.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_freebsd_arm64.zip",
+          "shasum": "139f0c8df8be9b6355dd9834e7c3d7c254e327aac7853e8c8df2d74003de8fd3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.124.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_linux_386.zip",
+          "shasum": "8d6b2d55790887aa5246e14541cb14c15394f0f00b8af378c0b29993edfbf83a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.124.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_linux_amd64.zip",
+          "shasum": "a470107fb2e9ad0796a87aac31ac63a5112fc6df1db8ee710a3e266e00d4f5a2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.124.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_linux_arm.zip",
+          "shasum": "8c8defecd8c1f0c6629c31e951fbd2c3008ebe4efc1ae18b60ead40d59aa5f79"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.124.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_linux_arm64.zip",
+          "shasum": "af230937f24ac3263295f8dee276e93d18fde03bb01925254542670080379362"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.124.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_windows_386.zip",
+          "shasum": "4b73780e07b136b883fc136d31a1628839728e5930390846ee7983f7a5ed5ba2"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.124.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_windows_amd64.zip",
+          "shasum": "8dcb4b4289e2032e12ad79b63994545bebae5ad234ff33ef9e3e017de340f97f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.124.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.124.0/terraform-provider-yandex_0.124.0_windows_arm.zip",
+          "shasum": "065860a2231b9c2ae079814f34b143862b38ddbb435320d655632728a462455d"
+        }
+      ]
+    },
+    {
+      "version": "0.123.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.123.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_darwin_amd64.zip",
+          "shasum": "4c0fcefaee8c4bd5afc44654fc43eea082ac2e48f3e86a9c35f0e6d470fd4b40"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.123.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_darwin_arm64.zip",
+          "shasum": "f069db9f7db11c519991231e94bfc743f209e85e5754037decf802f353682e85"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.123.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_freebsd_386.zip",
+          "shasum": "25fc205d344b469b7cd7cf2d626f56aaad925e142536c50c0c61d6ede948a98d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.123.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_freebsd_amd64.zip",
+          "shasum": "89e2f1d9a598823cab7a92eccea2c0dbfa6f935306f0b56c47c25d06bdb340d8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.123.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_freebsd_arm.zip",
+          "shasum": "b865b950ed0d12adadde1196437e0b95f9999750e688a7310e9b9064f69290a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.123.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_freebsd_arm64.zip",
+          "shasum": "383b0e65315bfdc36851cbf048bf2f82bd22aa31f3d3213b4241c0020a68dda9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.123.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_linux_386.zip",
+          "shasum": "5e45b828a3574ef120f5eb26b0c946ca0aeeee56ac42e0fa43a4d682a7a9ebc0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.123.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_linux_amd64.zip",
+          "shasum": "b1dd3421d0b5f6d7242d816db3889e32de73658910ef14dd96e9b86914b47430"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.123.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_linux_arm.zip",
+          "shasum": "ad570b71394904db96cf6e2e7102ce51316e418a70bca85b3f7dba1096425273"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.123.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_linux_arm64.zip",
+          "shasum": "5e69668d0dc3e70d876b21924b5e08d4829061ba1e4637499d5dbbb2a31c8f93"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.123.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_windows_386.zip",
+          "shasum": "fc10e98e4f7c709c09dae6fb7afb244add7b25414d4d37baa3f6f0c6b1a54db7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.123.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_windows_amd64.zip",
+          "shasum": "d9c25a377e3f5799dbcacac373866e455748ab50e8822f2c50d4f6abbfbc6a7d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.123.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.123.0/terraform-provider-yandex_0.123.0_windows_arm.zip",
+          "shasum": "ca1835d73f4abbf31e6441e88c2e435a6a0d9f8c2e04cec82c98a8a6bc983670"
+        }
+      ]
+    },
+    {
+      "version": "0.122.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.122.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_darwin_amd64.zip",
+          "shasum": "01b469ce7f0d9c5c963cafcfbc77c5627c5b8c1b895841d6e1bf6f61fe4ea1f8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.122.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_darwin_arm64.zip",
+          "shasum": "3d14693ccad5efa0160c2db81e0b7b996efb2df8f1f8958d3ec9f6e8f0cffe79"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.122.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_freebsd_386.zip",
+          "shasum": "c2dd40bd04d0a1c3473ff0716f6e6583073e82329a8feca999c9ff1658cd85a4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.122.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_freebsd_amd64.zip",
+          "shasum": "b3fb460a0b72406b2d745a12d491bae5b3a8e1059e9b57b8aa582dd26accdff4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.122.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_freebsd_arm.zip",
+          "shasum": "66786800eac59c466013642ab198c9f63d358efc7afd894678178e9aa82be401"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.122.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_freebsd_arm64.zip",
+          "shasum": "cfee208c19f9e4f6be86530b966851180291aaaf6202ab9513adc4351b4d614e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.122.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_linux_386.zip",
+          "shasum": "957180b4aa6944636df3531004eeea2a254ed0437ab19ee35a0042ec506d4a92"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.122.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_linux_amd64.zip",
+          "shasum": "2dea222286104b5a7951e92559a23afae12966c49c0bbba0cb4006dbc4b58ba9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.122.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_linux_arm.zip",
+          "shasum": "85d069fe4f363d3de7a17154e99dbc0f2766ea9b017d36a5f35eb8cb7bbd20b3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.122.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_linux_arm64.zip",
+          "shasum": "dada208e65016a842da16eadf22d09fd91531137025dc4be2c4e27e4564bb8e3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.122.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_windows_386.zip",
+          "shasum": "ed172411a94a76da12adce5ef9168453cd7eb6b9f0ce0b101028599f96eab81f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.122.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_windows_amd64.zip",
+          "shasum": "0b686a1358fdfb49884e08dbe748b5d88e7127b43583efb645ee166b8f033fa9"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.122.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.122.0/terraform-provider-yandex_0.122.0_windows_arm.zip",
+          "shasum": "54efbd854bd8956f0b4a465c4d92ee14eaeec10f00970919b91ded6b41379efa"
+        }
+      ]
+    },
+    {
+      "version": "0.121.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.121.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_darwin_amd64.zip",
+          "shasum": "35f926348d80517aa6881d047c1ca9922f26ee90c8c7f33ab5ff482ae56f363a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.121.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_darwin_arm64.zip",
+          "shasum": "8c7f21b4b0717df40328818d6a0df117360b37e089dc9b5217b92f60d2da68e0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.121.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_freebsd_386.zip",
+          "shasum": "7a49d86f0a57c8238688bdffa8ca213e0d7176e5a8be7c1b268b7cb073330d47"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.121.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_freebsd_amd64.zip",
+          "shasum": "6e0465aa50bbe5ba835e64ad5e61af9cfb8109b759239ff0af3f2e10854cea1b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.121.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_freebsd_arm.zip",
+          "shasum": "2c5b6cd57da156d30d860c88255568ba2bc9c0db7a33a42ca91e4aeb270123b3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.121.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_freebsd_arm64.zip",
+          "shasum": "75820ebc38d903ad888121f18eb7c7a66de227165ee014b92325db1288460716"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.121.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_linux_386.zip",
+          "shasum": "d85b79e3c609b7b5641bc6af4ddfb2063a57245457fa720c48cfae79157b82d8"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.121.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_linux_amd64.zip",
+          "shasum": "095bf41971ca46cfa045b3546125be69541981ba1109fd6ae118c5e253b4982b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.121.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_linux_arm.zip",
+          "shasum": "d824b607f669a0360b644857bf7937457e46fe5e445b0cb87dcd66a8ae347028"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.121.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_linux_arm64.zip",
+          "shasum": "ac9decaf5852b75caf53850525bae25ea277ebea03bef161ecda35784b7977e4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.121.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_windows_386.zip",
+          "shasum": "b33f0b8e60b4d2949687bc2f66f1a7705c6eda9892ba305de88df07394c11e0c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.121.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_windows_amd64.zip",
+          "shasum": "c28942609b4b1169e104e4894c9dfa3f1d08bdbc52473ae97daa622f1edb0f73"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.121.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.121.0/terraform-provider-yandex_0.121.0_windows_arm.zip",
+          "shasum": "c7d175372f43cf79faffd62f15fc93150ca06c3ebdc95fba8b74d80cc387bae9"
+        }
+      ]
+    },
+    {
+      "version": "0.120.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.120.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_darwin_amd64.zip",
+          "shasum": "f2b26a3482491084e94d8d10120b1d0db5a20591784dc55fab38445c4c8e233e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.120.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_darwin_arm64.zip",
+          "shasum": "06c83408f452c4d5fa299049133acd6ab026ef4b1cc808f8009c0e48b8127fe8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.120.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_freebsd_386.zip",
+          "shasum": "6a2501054a6fbe4c7aef1bb5d02e9e93b08847480c3f33d1472afb3ea4447985"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.120.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_freebsd_amd64.zip",
+          "shasum": "6ea2ce399660532dca5ad3f07b23678d213d1ba083f14c0931bc4af9501139b7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.120.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_freebsd_arm.zip",
+          "shasum": "ce1b4202c6f8f81160173167de6da668ea2ae7b62ac2109217ed218119354ff1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.120.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_freebsd_arm64.zip",
+          "shasum": "ab1a27cce09a7b6a13eade042949f390ec3879963daae7c6a95283f196e4f9b4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.120.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_linux_386.zip",
+          "shasum": "c6fd2f760dd0699d650d7286065f91b83c00bbaa5b2ab431346d4e8aeafad0f4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.120.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_linux_amd64.zip",
+          "shasum": "8a23cf04aeec36499cd0bc241c7d268306c152e3f236e2969c2ba9b79b688162"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.120.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_linux_arm.zip",
+          "shasum": "cad98c0f6429f78060db23fd5b1c7f8a80480048a28a94f0963bf40447804964"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.120.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_linux_arm64.zip",
+          "shasum": "b78dea4bb025d487ed56bb6a0fb596e60e381da9dc7275b51fdd6af7be374e81"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.120.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_windows_386.zip",
+          "shasum": "e6f13b2f679e6716ad9bbc198b374e241fc7876f5be5b7c6114ca99de32c30cb"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.120.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_windows_amd64.zip",
+          "shasum": "54d07351375158989caefb56bdadaa31e62f480e49e40ef4175fc191df92f49e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.120.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.120.0/terraform-provider-yandex_0.120.0_windows_arm.zip",
+          "shasum": "9952e7774b202c91b6a023545e9868ad889c991198d1803b6c455cd8b975d749"
+        }
+      ]
+    },
+    {
+      "version": "0.119.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.119.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_darwin_amd64.zip",
+          "shasum": "2c8cebdabe88f7fce232fe81d86ce6c6ccaabf2f9b82db1bd1fac6d05f6f849b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.119.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_darwin_arm64.zip",
+          "shasum": "1965ffa0a8e527b73e62da764f78d8895b2403289b194e9056376c00bb2be391"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.119.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_freebsd_386.zip",
+          "shasum": "8c21bf839bee057fc6ef41e1cb7f77e235a8b03830b15db7f40babbb2c784620"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.119.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_freebsd_amd64.zip",
+          "shasum": "852c985de2b30c8476c4c673c92b92064b522c33cc109fb9b4909d9dbad15d00"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.119.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_freebsd_arm.zip",
+          "shasum": "1dbc9edd64b7d6be83e06bc607f927d4710d4c6fd3e93276538c8bbde1ef1751"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.119.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_freebsd_arm64.zip",
+          "shasum": "0beaadd6cffb836311419fe8e1738b8ca5999975bc8609b8ca50bfafa22782fa"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.119.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_linux_386.zip",
+          "shasum": "4cc77b21cf3a2b3f9298b059d21b4bc7a6e74bd460eb909e3dc6cd24a7a08d1e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.119.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_linux_amd64.zip",
+          "shasum": "0c89f56350f8e3b013ace889cdc40fdd3af184256be742a7b5c70519c1c40ba8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.119.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_linux_arm.zip",
+          "shasum": "f67d1da5977815bab1883b012d2eaef56a6807f7f8d59df5a0aeedad217a60f3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.119.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_linux_arm64.zip",
+          "shasum": "e67bd20e480fd871c3807dcc316104a291e2d7f12b332e3bdfd111cf8f5a01f3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.119.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_windows_386.zip",
+          "shasum": "a6c4befb460e8b411be0121c9886c17bf8bca5f13fbd9d0a4115fcd8ad1d5572"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.119.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_windows_amd64.zip",
+          "shasum": "e58b50efe80e1da6e8f7e9fa9c81b0d43ae5d948ff768fc91b1b2745d5a78207"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.119.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.119.0/terraform-provider-yandex_0.119.0_windows_arm.zip",
+          "shasum": "a3287a13a84d30fc9625a83763df19fce3985a5e4eca31973a67bb1e6a79c62a"
+        }
+      ]
+    },
+    {
+      "version": "0.118.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.118.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_darwin_amd64.zip",
+          "shasum": "5a190b2a659c599ffbfe177d18d7e727d8b4beb875d10d460c8e26e87cbd781d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.118.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_darwin_arm64.zip",
+          "shasum": "252cc88acc776f99caaa421889fae4b6aa8f998a7075e380f172e06ac81a6303"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.118.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_freebsd_386.zip",
+          "shasum": "6644985c4d61eb5914dbdcb44041c545abb2dce39473c443dbfcf8b292d75cdc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.118.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_freebsd_amd64.zip",
+          "shasum": "9338f3c746c1c36963c21c8c2a70d3e4dbea17b5c1f3eb134948280fad013e89"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.118.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_freebsd_arm.zip",
+          "shasum": "6f51bd59220d8c3e937db0068aeabf33a12d8975dcc2c3edb15a5e02ea378666"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.118.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_freebsd_arm64.zip",
+          "shasum": "5f32176b84be209140d7bd6b054ca381cb6ee12afd8183dfd80ba95ab7cd79e8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.118.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_linux_386.zip",
+          "shasum": "6e9c3ec2079396e19ae04d9bff66941b03ca8ab65d5317c50ce5b7e1af668f3b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.118.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_linux_amd64.zip",
+          "shasum": "181d8c14af174086137053cb78f41f44c3cb273509b48a5dfc6b2cb9cede6e39"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.118.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_linux_arm.zip",
+          "shasum": "0dea587709e2b974a2fc10ede995f219e09fadb02d02a6943900e8a60f3cf772"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.118.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_linux_arm64.zip",
+          "shasum": "3f8321e4c695f5b7a3f1e9479e1daec82dfa6f29efdb2adf688f87677caba0f3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.118.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_windows_386.zip",
+          "shasum": "3ec870a0a67e99ec1f0f61f7ba74bb3b21962cc40f6d46fe933835e448e750e4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.118.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_windows_amd64.zip",
+          "shasum": "f9b815d50ee67afcb9b24494305ea13d9caa97d375edd61fe0cf2feb9d555e94"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.118.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.118.0/terraform-provider-yandex_0.118.0_windows_arm.zip",
+          "shasum": "ef85f2bb63e7175894e2df237d6047007e418c647b0441f54ff885ed2555ac41"
+        }
+      ]
+    },
+    {
+      "version": "0.117.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.117.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_darwin_amd64.zip",
+          "shasum": "c3d2612cf0666e635308ffa89fe0fa92936c9be94780384689a576200f68d4e6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.117.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_darwin_arm64.zip",
+          "shasum": "91aafcb98745111f2b64054c3d09e885362d3d5d19feb48dcf550f9940c45438"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.117.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_freebsd_386.zip",
+          "shasum": "cb3b036ae0d1ac2c33ba0c7e6270420ae480e570aeeffa93cf3670c9416b8452"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.117.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_freebsd_amd64.zip",
+          "shasum": "6b68c431284bf42fa13073cc5dc309cc749e967047b4f8ea0303f11817df1abd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.117.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_freebsd_arm.zip",
+          "shasum": "2996715a13dc12739685108aeaeb24bc554d4dbbb485570bee4298ee05b07a58"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.117.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_freebsd_arm64.zip",
+          "shasum": "87a10b42e6af13064606974c027d69841b48c9a081944a1935221d7987f2a271"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.117.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_linux_386.zip",
+          "shasum": "45c9183cf78ec8e1121a24007bc2cdc36e6ddebeaac28f8af1930fece670c9f4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.117.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_linux_amd64.zip",
+          "shasum": "748e8aae07b9115629057da6a722bb00b468f4f937fec99e51244f7d785df4e3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.117.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_linux_arm.zip",
+          "shasum": "899e84eb4c7fa34a42734fa5026a318e3b041ab15bdcdede77c38281816c5f99"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.117.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_linux_arm64.zip",
+          "shasum": "c672551ca7846135f204561739a14305c235bd075a4f058a5cb72c246c7fabab"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.117.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_windows_386.zip",
+          "shasum": "50e7896a506d51daa20887ab4944e856c5f631f8ea81c7e4edeb4901771f51ef"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.117.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_windows_amd64.zip",
+          "shasum": "c0ed19e95275aa05112e01cfbf2f16ba99283a258e5c541f6e1a6fee3bbe04c9"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.117.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.117.0/terraform-provider-yandex_0.117.0_windows_arm.zip",
+          "shasum": "6cf1675f28d785d01cfa50923a9e7283326a95f6760f7d893bbafcf758fd8858"
+        }
+      ]
+    },
+    {
+      "version": "0.116.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.116.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_darwin_amd64.zip",
+          "shasum": "6cceefd8c5ba87ff7c3c3e957cef9394a4fab0d797d57a58fd7373d0eab02de9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.116.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_darwin_arm64.zip",
+          "shasum": "cd845874c2c616c7eeb81c7f647a06d264f68373d828d9e6e403aff385354d3c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.116.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_freebsd_386.zip",
+          "shasum": "9898d480a84af73fe2362960a135ca476e423475717c199264a8fc7efe6cd6ff"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.116.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_freebsd_amd64.zip",
+          "shasum": "bf52e93f5b3d55ba454a236d845214479c59f3e7396e727b1628d4914d1c23ef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.116.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_freebsd_arm.zip",
+          "shasum": "37641bbc04b9e2d860647243ca2bd8f1497ffcaa0a1f3edd1bf2667f9467ab50"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.116.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_freebsd_arm64.zip",
+          "shasum": "014156a7e3bb9fd7f1551137e9071828ad1f52416aacb00384447f5a2f7a938a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.116.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_linux_386.zip",
+          "shasum": "f9ee70985d2a3540e9a1354793d42b1c74c1698ce24a1fbcfdd5fe9d925358ff"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.116.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_linux_amd64.zip",
+          "shasum": "e7b0c0e815bbe87edfe768ecef3b768cc334ff1398c914fa2a857ccf2edc23db"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.116.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_linux_arm.zip",
+          "shasum": "55c5c3b6266de95a2a46afa2d4c6624e875eb05889a44347035f8bcc6da1efe5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.116.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_linux_arm64.zip",
+          "shasum": "d32ea9ae4be97484fa9fd31e2de41173c3cdca789906411ef3c47e083a69cfdd"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.116.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_windows_386.zip",
+          "shasum": "41b3bbe45d216c3542f2a522bb610141fb111c6a0bfa15c56410292362467917"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.116.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_windows_amd64.zip",
+          "shasum": "ab8309d1986d71e1923af65c89327ec27e11eec0b3cf764e1adc14de877a5174"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.116.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.116.0/terraform-provider-yandex_0.116.0_windows_arm.zip",
+          "shasum": "1a7e55ffface1a7807c901fa7a62d177405654dfa140c8909f0760473d758a46"
+        }
+      ]
+    },
+    {
+      "version": "0.115.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.115.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_darwin_amd64.zip",
+          "shasum": "496078d36d196e582449e4f30fe1e35aa93cf32a767503a654119488ab8c992e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.115.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_darwin_arm64.zip",
+          "shasum": "2f4d7b3bd62bc6395fed8cad3a6b76ea45a35a94941bbb4c9727c8c9abe98f1a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.115.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_freebsd_386.zip",
+          "shasum": "bfe38b444776eaf93b91478f454ffedbfb486045ee345b1a094777f6062dca5d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.115.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_freebsd_amd64.zip",
+          "shasum": "7ad0964ef7bb9a22ca1aa9d9f04c7346701fa12463acff421ac508ea5e065b54"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.115.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_freebsd_arm.zip",
+          "shasum": "906ed04263b6f2b9ef29165c731310c263fed01aedab6c117db2c9d6a079466f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.115.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_freebsd_arm64.zip",
+          "shasum": "04dbc94db14f074610fb948d155f05b9fec26a95137949fc88c3d53c4be60674"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.115.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_linux_386.zip",
+          "shasum": "384bdf74be3f07ca672dc9b2de1bd585f3d4e07d42421915ddb08f6f7978b87b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.115.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_linux_amd64.zip",
+          "shasum": "916cf9e71d3f862567287ab536c9cd7023af56fb01269f21df0b1741bf992eac"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.115.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_linux_arm.zip",
+          "shasum": "f306c4e504ea9f394b7b13408e2d5fd40de7bf6f97277295e525d32e0456dc3b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.115.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_linux_arm64.zip",
+          "shasum": "0fd0b1bcde072d8faf26bd12b4d150c8e967934c2b2f360d405ec5ac5ac41c8d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.115.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_windows_386.zip",
+          "shasum": "6173dd28fdd69d9f9b24ed16f5d850d02cf5769415a46d2123ef84d60e5f240e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.115.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_windows_amd64.zip",
+          "shasum": "028671ee72ac4a0a48b729a1a76e44e7a89a8b0daef169b5f9d948de72de2459"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.115.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.115.0/terraform-provider-yandex_0.115.0_windows_arm.zip",
+          "shasum": "739d5bece0d33670dbd94a9b94da02db0dd106da201a0e9521dfc6fc50c6fa01"
+        }
+      ]
+    },
+    {
+      "version": "0.114.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.114.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_darwin_amd64.zip",
+          "shasum": "ed0556b8ea1cce4c991bcb236248b233b79e9feb4dc837e22fceff8a5bc146d9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.114.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_darwin_arm64.zip",
+          "shasum": "ca5b5acf8dea987b2c70f8012ab69cce1bc7e6a1831c6f2aa262000f8a405d12"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.114.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_freebsd_386.zip",
+          "shasum": "9065cfa3b4948b51a576d9af08aee315aa3bfd4fee7e60e3f947c52ce95295a9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.114.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_freebsd_amd64.zip",
+          "shasum": "a57f46c300ddc3f8c3dcbfb3ea558eff595fd23e39a0e4dcf83bde9fcd038244"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.114.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_freebsd_arm.zip",
+          "shasum": "a690a4be75a84e9525c6a8e78e1e9870aef224d5825bc71924f28bf39cb3a2f9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.114.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_freebsd_arm64.zip",
+          "shasum": "e8a11786ea790bdc49e0ee91f947ee9adff800bd79177c5f2e142112af15d3fd"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.114.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_linux_386.zip",
+          "shasum": "8789b1716e5b0faf36ad25429d4375e85d4da76f8c343148d33fdfea28558cf3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.114.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_linux_amd64.zip",
+          "shasum": "63fb13a45d567d3366424bc457595726e110def6a27766005f41651ef7c0e75e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.114.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_linux_arm.zip",
+          "shasum": "e22b66bd9fd8ce48d1b016704806fd2c3d84d8f20215c85fb0ce35dad826bf5e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.114.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_linux_arm64.zip",
+          "shasum": "1167929f2a889f9b22ab08dcd10d649b1c96f574c2c782974f6187cde4c5d45e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.114.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_windows_386.zip",
+          "shasum": "489382396aacfa254bda283a1adcb337a6fca9ce248fa0115153108dabc2acae"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.114.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_windows_amd64.zip",
+          "shasum": "6a74f1cbca2d7bd6507f7daa36278f514bac5166d36eb436f8eaf6ba76259891"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.114.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.114.0/terraform-provider-yandex_0.114.0_windows_arm.zip",
+          "shasum": "37735343df42e31c8e0bf845a12056ebd2aecae154885b56ec5638ec47734265"
+        }
+      ]
+    },
+    {
+      "version": "0.113.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.113.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_darwin_amd64.zip",
+          "shasum": "88b54563c19a080f6999948b9e944c7f0a1c57e0838e79376d3d599aa9151571"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.113.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_darwin_arm64.zip",
+          "shasum": "6f0c5cc0bf6aa351ae120591e40d5f75d4b21bc34e294a065a8ed3b9453d7f9b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.113.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_freebsd_386.zip",
+          "shasum": "d84303b91d002a3d7ec8a87ef00c504fff7f68dd2969547f9f03eee9196582fc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.113.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_freebsd_amd64.zip",
+          "shasum": "38e10767190f10e704e885b324ea7330282aebbbb8fa7fa52d0107ff86ceee9e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.113.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_freebsd_arm.zip",
+          "shasum": "c7841dfb796a09dca987a7a5d19bc670d8089f69a89d4d9d71846fa00f049ed9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.113.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_freebsd_arm64.zip",
+          "shasum": "e3b1ab333092df571cdda58afd1b65d1778e9e9bcad68843e84763ef6795c87a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.113.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_linux_386.zip",
+          "shasum": "0f89b546cecec3a7eb8b55d4a54a6fefb73f84796644aaef45c73a7207784094"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.113.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_linux_amd64.zip",
+          "shasum": "b9fd5b6fac9eeee3447baa588bba0ffa87eb03b1c01a434434be6fd581d01acd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.113.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_linux_arm.zip",
+          "shasum": "2a8143bc554a9d812ff58c65eef7a83cbd32e0df29e179101d97e5bcc766a3f1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.113.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_linux_arm64.zip",
+          "shasum": "2a3278c3603d96671a5dc719ea18ab94b66f542ca8d393b02adaec8300693ba8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.113.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_windows_386.zip",
+          "shasum": "ab116e482849eb8b9c4fc8f87f019fafdb76c4297f6232f48d5ec4937d6a1fee"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.113.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_windows_amd64.zip",
+          "shasum": "66a4bc11ce073fe84e766a444ddb15b87f3540eea3c501fb048bac5eb6d6f077"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.113.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.113.0/terraform-provider-yandex_0.113.0_windows_arm.zip",
+          "shasum": "dd0e424bfd243cd52bc150eabacbc488d571f1b36b2c23c853c58714ad517c7b"
+        }
+      ]
+    },
+    {
+      "version": "0.112.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.112.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_darwin_amd64.zip",
+          "shasum": "bd2ce15f0fd8533d2665c5a33486a9e997ae074800e15903df109b8ac15b221d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.112.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_darwin_arm64.zip",
+          "shasum": "27dedc401e1a51aadc54d893f6745451f32e284c0b31f7126a76353669bdde37"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.112.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_freebsd_386.zip",
+          "shasum": "508f9892dd22efdf24b97b99341f02f84e2224eb39941ffc74484e13a0b78881"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.112.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_freebsd_amd64.zip",
+          "shasum": "a9da433926e1ebcb3c080858a1fe5096046536d0afcdb4c61d141472fbefbc95"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.112.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_freebsd_arm.zip",
+          "shasum": "270f4675f31665b48997aba6fd5a6094a3f324ea9ddb4114540e108e73df2e97"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.112.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_freebsd_arm64.zip",
+          "shasum": "5ecd93a79d2269400329b6119838177b847821d9aea054b9763b54edaf2013f7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.112.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_linux_386.zip",
+          "shasum": "a4a47c3afcf876b340a97f83aedae6841d5d35b8c52bfaad42435874f3184eb5"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.112.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_linux_amd64.zip",
+          "shasum": "1d547cd53a52dc7c19fab0bdd92147cfd45ae5204401424c870d4ee2cbde49e3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.112.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_linux_arm.zip",
+          "shasum": "c6a71881d2512a2b224956cb59cb84dff9d1399f87f006918b0e0efbafdc9636"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.112.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_linux_arm64.zip",
+          "shasum": "61e0f23835ab70bb6f8554b4e6cdd08abb2b659281fbde3b98cce26188fb6f7f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.112.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_windows_386.zip",
+          "shasum": "680e145e31fce5ad7b6bfd5b91df79b8f6c71998f4c965b3aebc94cf4e5caef6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.112.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_windows_amd64.zip",
+          "shasum": "d3f2c44d7cab001da8a0af6fbcc8993296110cd252398462bc050df98f856e10"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.112.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.112.0/terraform-provider-yandex_0.112.0_windows_arm.zip",
+          "shasum": "9c6197d55b7b90a1536f1e5e6c1678df2b8ab88d7bb8db6990d5143a18596573"
+        }
+      ]
+    },
+    {
+      "version": "0.111.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.111.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_darwin_amd64.zip",
+          "shasum": "768f358aac1c6492a141e5517a11aff11c2bea462c4230b7095a1393ff2fca6a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.111.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_darwin_arm64.zip",
+          "shasum": "11c5d0adc306755234c1fab226a77e2cb6389a7fffc052c1c8a68264900ca053"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.111.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_freebsd_386.zip",
+          "shasum": "10ed36af92e91675ccaa4ef6885cba80f2c98c7ae39097116167f568589b7188"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.111.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_freebsd_amd64.zip",
+          "shasum": "a614189e2efeee169a8a78d86cfd6aba1475ea88bba66802f9b6cd275b02e3a4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.111.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_freebsd_arm.zip",
+          "shasum": "55efec80fc5ef6b87477c12ff84a9deca1d9d147dab0229dccb2c170ae96fc11"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.111.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_freebsd_arm64.zip",
+          "shasum": "9ba97a7c548e99b42e5de2cb549ddf33003944c5a8bf584701469b31fbdca2a2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.111.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_linux_386.zip",
+          "shasum": "6e2f3599df26c04e912b1bec3da7557f7f4a6ed4d63f774a0453d902a9eda92a"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.111.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_linux_amd64.zip",
+          "shasum": "5d38859f4fc8c9869735f6be4d65abf8395685b6e4f422ecce12eef6d2a514ba"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.111.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_linux_arm.zip",
+          "shasum": "bba75039aa6e44bc5ebcb98eb231ef528cf47a546e6c3c0478079ed3dc40bc59"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.111.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_linux_arm64.zip",
+          "shasum": "d90951ec4e9a4ad4fc175372920368dbb57e6cd2cbe7b3ad3a1b8387427626cd"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.111.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_windows_386.zip",
+          "shasum": "d475eca348065b442a588a0eb050a621896ea925ef099910b2490eef1e91cc68"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.111.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_windows_amd64.zip",
+          "shasum": "4045339c440950cc972397bb366994dea89c439d5a32ed590d2405fbab97c633"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.111.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.111.0/terraform-provider-yandex_0.111.0_windows_arm.zip",
+          "shasum": "9f4933a61ea019fc6859df5bacb9e24547b1abb25307c257b850b6dd1b64bc94"
+        }
+      ]
+    },
+    {
+      "version": "0.110.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.110.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_darwin_amd64.zip",
+          "shasum": "63dd51556fede7b2324460772ec4fec150665a1c5432fbe49f6ed739d3dcc7a0"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.110.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_darwin_arm64.zip",
+          "shasum": "95324c07cb393270bdfb392d2484c9dfc1f897aa630d04203dde0cea05d04067"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.110.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_freebsd_386.zip",
+          "shasum": "afbdede2be99b16ef9949541f55758821913f287955e26f0ed10ff640baf8770"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.110.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_freebsd_amd64.zip",
+          "shasum": "0d95e90c1b2435083a098fb5fd745dcf5f0f8f2d930cf66acaabc02860c03286"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.110.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_freebsd_arm.zip",
+          "shasum": "f64d1c1b925e012e9dfca1d821fc5b9cc68e0e765b84ffdae2d0069bb791131e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.110.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_freebsd_arm64.zip",
+          "shasum": "2002541cde23bb7902ae07e0796832e9eadf3ebc1bd4890504f384b17bde8bbe"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.110.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_linux_386.zip",
+          "shasum": "467c85f21287807748c0955b0867328c66f1507e5c0c90ea258fb5ee247569e3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.110.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_linux_amd64.zip",
+          "shasum": "eacfad3495a60c4d69ea9105a742c38fa263b45b75a25d685b0bfb90f951fdfe"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.110.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_linux_arm.zip",
+          "shasum": "8d1b5dfbee80d244991619082c8fbd5ea4c25ed0f498a56d57597e6f664a40c5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.110.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_linux_arm64.zip",
+          "shasum": "b54f29a8c8c93745230f0645e712402b5d974ffcf204aa44ee0c2d5afd9a890a"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.110.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_windows_386.zip",
+          "shasum": "cb273400d179ca8f8b77f0bbc98e20081b662ed1dea427d62ecbca33771dbd58"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.110.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_windows_amd64.zip",
+          "shasum": "820cafdead995d946a673ad26bb6b06fa7c41b707e76ffda800bc54877d5c7ea"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.110.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.110.0/terraform-provider-yandex_0.110.0_windows_arm.zip",
+          "shasum": "982af04c80df758fcdb3f0a01dd53f04f3a65699d8417ffe47a8c17058a600d4"
+        }
+      ]
+    },
+    {
+      "version": "0.109.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.109.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_darwin_amd64.zip",
+          "shasum": "71836435314f696a7aa6a9b535bb996dc95baaefa9c9d5a11ebb880f9664ca84"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.109.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_darwin_arm64.zip",
+          "shasum": "64cd69657855a720a9c0f4f5fc1cfe81952bf38677855a51e0b3c4591d192882"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.109.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_freebsd_386.zip",
+          "shasum": "400d47670296420b1f2e8fa5eea39e4ae80a5da3c6bc1a01385e5263b9404792"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.109.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_freebsd_amd64.zip",
+          "shasum": "942151b5b0e90ee2fd7909bc8fa9f5b06ff1d5fc28fb4583ed12bbec98d9b845"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.109.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_freebsd_arm.zip",
+          "shasum": "07124d6a47ffc33d56ad6725ce3dba64239d16886a31f59f404e87f4b7d4ecf3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.109.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_freebsd_arm64.zip",
+          "shasum": "bca657d795822285bf185c15803cd97d64da81716c5e5bb536ee3c2eb7157362"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.109.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_linux_386.zip",
+          "shasum": "b9016ac20dc8ac706c969903376bc53a5783431ae2d9dc0297236debc8e46370"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.109.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_linux_amd64.zip",
+          "shasum": "741559682c0d124c75b2af966b3d1a7a38abc2021437c6d8ac5d87439c49c5d2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.109.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_linux_arm.zip",
+          "shasum": "63605ebadcf43da84f9a34869ad72227f84809c23613ebc548f4b849172513d1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.109.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_linux_arm64.zip",
+          "shasum": "8cb93973b434d2f7894a5cb00eb25a690e711b8e7610d243f8db93087f2c7e8b"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.109.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_windows_386.zip",
+          "shasum": "df010faa3ba2d07886049aa155682260b47cf9d63cd3c07a6cf78c396b19f870"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.109.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_windows_amd64.zip",
+          "shasum": "4ffe6f7d46ed843fb0952e91dd49ed1c7236e14c3b673be6582173b49c2d012b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.109.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.109.0/terraform-provider-yandex_0.109.0_windows_arm.zip",
+          "shasum": "6f0e69e8464c5a81f3576769361d0acc9fa44d781861d7f630cf88ffa8fcea24"
+        }
+      ]
+    },
+    {
+      "version": "0.108.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_darwin_amd64.zip",
+          "shasum": "873abd3a29f5a6a6646d6fc28c26714737617e14bb758385f908ae339dc5427b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.108.1_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_darwin_arm64.zip",
+          "shasum": "fd10ef98bf911b224aff8f8a0e78db36820752f73c6df0023da3cd3ac3c9648c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.108.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_freebsd_386.zip",
+          "shasum": "c0f22a4b8901aa3a7d83a7477767aa5b501a68f6e68bf74c8596e17d50a62655"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_freebsd_amd64.zip",
+          "shasum": "2340d4978c8ba99869dfab12fd0339973242dcfa36f6b173ea9ba82eb673443e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.108.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_freebsd_arm.zip",
+          "shasum": "28ab6b9c91df6cfa58c732d7aa84ae8c60b9d5ca9f6e47db8bda014336f71b94"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.108.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_freebsd_arm64.zip",
+          "shasum": "e1a8b15106f05cbbc5c1a516241320f1eafdccebf4aae72809a42731b11379f3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.108.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_linux_386.zip",
+          "shasum": "2f57177c623aebbfb0c9b09b18833c10bed6caf407ae72bcb6379db2a6f27343"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_linux_amd64.zip",
+          "shasum": "57438a0222dc104a8ebfb998d179750c8b1676bf31b40840cb244b4057fab739"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.108.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_linux_arm.zip",
+          "shasum": "a02062cb07ab22f38faa45c8c9fc2b959cadda5160fd84858d730417f35eef6f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.108.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_linux_arm64.zip",
+          "shasum": "afbe6fd70e8e5376bc9c2b98eff114f1be7e355a97b8c1f176987b3c33e81522"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.108.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_windows_386.zip",
+          "shasum": "e16ba3032ca06e415e11cce79d83856f0889b9e4fe3fe83ae25513cf6e47919e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_windows_amd64.zip",
+          "shasum": "0c2e12c1c49672d4fd2c650b97fe210431fac8e6a89137637c35fa3d48baee2e"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.108.1_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.1/terraform-provider-yandex_0.108.1_windows_arm.zip",
+          "shasum": "140c630580ddf5097e87764236ac02540f640e5e02449eb344db8382036d6b85"
+        }
+      ]
+    },
+    {
+      "version": "0.108.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_darwin_amd64.zip",
+          "shasum": "52e73474d3fd3b4c75254d115a745a60b3c4d36d114cf40251df830765cf6fac"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.108.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_darwin_arm64.zip",
+          "shasum": "b87f5df0741a4084a109dccce8a6498ba4d602d1ef50947ca9445d5cafe8e540"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.108.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_freebsd_386.zip",
+          "shasum": "1b07ea94d78939ed4a40a1dcf784bae83fd0e70240052beabd9b5a727a0bd63c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_freebsd_amd64.zip",
+          "shasum": "b9964712d2c19c22328467ffb2c5e3ca5554313a13e82313f008875c5bb436f1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.108.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_freebsd_arm.zip",
+          "shasum": "11a8f8eb30002b98f73cdc0d932ed83477a7701e9f7f7a7d304fb8b197257721"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.108.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_freebsd_arm64.zip",
+          "shasum": "df126a7f857ebfd470d77e1718e362516b79e915da12aef81ead2ac9cc955437"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.108.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_linux_386.zip",
+          "shasum": "ef920a27e834a79905bfe344aacbba2515c6b094a831b6fe241c1454deb8841e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_linux_amd64.zip",
+          "shasum": "18183ae543fb5c083c47a11df408b53f9ce051de1f2db8a6d6c4bbb5beef28f4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.108.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_linux_arm.zip",
+          "shasum": "6ed17f2ec66664736f8816067b294691115080f2fca2b3974ee44b67a052cfe4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.108.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_linux_arm64.zip",
+          "shasum": "60cd1cc35df49dc3b41c62aff6402ef9da501b07133643b2b1a347c5bf01e9bf"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.108.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_windows_386.zip",
+          "shasum": "8c1a0b297a09c2c6349a85e6908c80b659bcd7753b3996cad76e88d74693ea7e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.108.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_windows_amd64.zip",
+          "shasum": "f4830c815fa12f28066cbb68016fc414a8e7da720a8de328147ce492290aeae0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.108.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.108.0/terraform-provider-yandex_0.108.0_windows_arm.zip",
+          "shasum": "f290d1dd9af5d5fc64e91beef8a75450f084f36ac126a4c819029ab8ca13a43a"
+        }
+      ]
+    },
+    {
+      "version": "0.107.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.107.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_darwin_amd64.zip",
+          "shasum": "f4fddeed49c1d2f3bfec6c7330427588a5619e7b76357de3804a9b0b9efb4f30"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.107.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_darwin_arm64.zip",
+          "shasum": "2637cd56b3bebdf2dbf25494b488f543be81c723b7d4fc031a12ee032f4a3288"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.107.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_freebsd_386.zip",
+          "shasum": "432fe2b5fac127ab4a9f026fb24d18f631d077318338c4ae8ce231199d9d9986"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.107.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_freebsd_amd64.zip",
+          "shasum": "10aa9b3dcb177edc3b5284ddd3812f0cc1b7010d8b612e856f4efbaa10aafe30"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.107.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_freebsd_arm.zip",
+          "shasum": "35cbfa759b2ca762a6286d473e5c6bbaf4ff2c945c4a2725cedf48bef80dde1a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.107.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_freebsd_arm64.zip",
+          "shasum": "2746e53fec26c7dba5024308cde17b905396b5fb25af78c3cfc6298eb27f2725"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.107.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_linux_386.zip",
+          "shasum": "fea56debe67e481de5f938c84404e071a14907c695d2c21888af08c3e6214fcf"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.107.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_linux_amd64.zip",
+          "shasum": "cac5c5d547fc64b736fd4d83d025e85385a106925b60e3ab20df3b0fcf093eea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.107.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_linux_arm.zip",
+          "shasum": "3574c42a35cda9ebd6b0f9dd2cb9a707e6943ecea20a83f8c2ae8d93a78e3411"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.107.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_linux_arm64.zip",
+          "shasum": "23d275523e5112c96a758d5bc2ad91c9ae012b028b9979044326688ca76f0d47"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.107.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_windows_386.zip",
+          "shasum": "59ea1bd6d966e3525d31fb8348b530f99c0d72a07ae17bc3ccf90c0432e0d3d6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.107.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_windows_amd64.zip",
+          "shasum": "b2d1864bea1051e5d20bfc76206fe4524f9bd717c33c12f780040318c8591ce3"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.107.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.107.0/terraform-provider-yandex_0.107.0_windows_arm.zip",
+          "shasum": "0c7e9a22d8ed1d1a23d0a9a14d12f9cd4545f75d49af04f43b4adb8d02b5d4dc"
+        }
+      ]
+    },
+    {
+      "version": "0.106.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.106.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_darwin_amd64.zip",
+          "shasum": "b455793971a36d360262842b3471d7ce424f72065688126c00267378775d4bb0"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.106.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_darwin_arm64.zip",
+          "shasum": "68369f25a8e14490cf9dcd150c734889bd9d700ee80cc9ef0f75da17a977ccd8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.106.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_freebsd_386.zip",
+          "shasum": "c11df5737ef55b41ab50bb0ca2788139770f2224dbd5f1f7e04a24f0b5d3286c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.106.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_freebsd_amd64.zip",
+          "shasum": "05e03d8878bb8f837838245c9893a55bdfb2f8728cd93b1feb600661a6a9375d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.106.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_freebsd_arm.zip",
+          "shasum": "d3b2262205523e82600f676fce9821d57dda25afb192093807d8b4dc238a197f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.106.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_freebsd_arm64.zip",
+          "shasum": "5c9227ac77100c227af655127b8012c8e0003f7e405b5806f5a6bf0f24d4b889"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.106.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_linux_386.zip",
+          "shasum": "9f959ce009dfd60e73bd02259bf76b0d7b5d2d8621f227f575df85399382c75d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.106.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_linux_amd64.zip",
+          "shasum": "7e7163e09418c5c5828b87dec83c5cc3c52e317e10aeafa147952148d84d14b0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.106.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_linux_arm.zip",
+          "shasum": "90f582ea13c5faa442fc4aa103253f1df4a00372a125ab4ee90d6f1222480a16"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.106.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_linux_arm64.zip",
+          "shasum": "8f5e67ef9db3b0cf07cda98efd1c4bc36a93113909f8f6782ecf6f38246e0628"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.106.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_windows_386.zip",
+          "shasum": "2c44f6e53b4b3dfc8b424d0fe1ca17d71302160f2201e42f0af7f934f7d5576c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.106.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_windows_amd64.zip",
+          "shasum": "9e2a3dc9e6b1851b2623bd064a7411f465d93c710106c3843f4118a867bedfde"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.106.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.106.0/terraform-provider-yandex_0.106.0_windows_arm.zip",
+          "shasum": "61653f881393336424dd4cecb4d2c0c4fa2fafce8bcfb0fd9e5213503f7656cc"
+        }
+      ]
+    },
+    {
+      "version": "0.105.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.105.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_darwin_amd64.zip",
+          "shasum": "8c5aa58179d57d2556a2dfad159842c63a79ce80a3c21597dd177818ddff9d7e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.105.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_darwin_arm64.zip",
+          "shasum": "43f750d8427454501d952f8b6bcf1f08a7f5e00ce712abb2f6699f6576d7c13e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.105.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_freebsd_386.zip",
+          "shasum": "cbcd379caa783675b5f44a9aaaa39fcba1fd2c300940cfb05ae2e71a938ffa31"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.105.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_freebsd_amd64.zip",
+          "shasum": "b09d1401dead539eaff294540cf9c51cd50bc8ccfc0b3ecc7da42e18fbc651b4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.105.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_freebsd_arm.zip",
+          "shasum": "023701a75f02b8f5cd7557f3c8e10f93dbd29844a485d33cc9b2c1f386f334dd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.105.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_freebsd_arm64.zip",
+          "shasum": "eb40d277a951c807e6d5ffb87ef2b1801e43ab095e39b2787fde96c1931f5466"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.105.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_linux_386.zip",
+          "shasum": "80923aa07025fff9e180b44fbf10f60232448ad43fa3d4f9f6302650f41debd0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.105.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_linux_amd64.zip",
+          "shasum": "abe65a58fbaa1b409de506db301eaa3ee8df3bd9e738ec276381bc2e36149fa4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.105.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_linux_arm.zip",
+          "shasum": "f5597f348ddd3678bc212ea55d87767ac0867cebf2e9c14ac8b47a7d638777dd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.105.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_linux_arm64.zip",
+          "shasum": "6f0abec6896a08953ac1989a83c85162035388767ebcafe6fe537737dd74652f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.105.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_windows_386.zip",
+          "shasum": "8d07537f3fad81157c563f149a28fafa368e14090aa30c9006db49aaa66fd2a4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.105.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_windows_amd64.zip",
+          "shasum": "8acfc745b44399f05213b8bc5c94cf46e41ba880b54d9809a0bf1a72971c5df7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.105.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.105.0/terraform-provider-yandex_0.105.0_windows_arm.zip",
+          "shasum": "3aa61656197f3b7b208e9dc98c1fc88b05c612aba4be05ec45793a08f4e465b3"
+        }
+      ]
+    },
+    {
+      "version": "0.104.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.104.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_darwin_amd64.zip",
+          "shasum": "d10834fe7c8a6acc6725cf92ab8a22238624457145e0a7c450ceb4a472e521b5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.104.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_darwin_arm64.zip",
+          "shasum": "05bcb4f2ce023e15e357e0117f313ea9df23995d0461decb8003e10eb0adf101"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.104.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_freebsd_386.zip",
+          "shasum": "e8fa9bf51db0a2d9e4feed9095a6f7a402059655223676de5d29247662f0567c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.104.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_freebsd_amd64.zip",
+          "shasum": "491ac0437e29cfbcb8aa041127bafd5dcaec4a0e9c70bfee4ff1b30d20fda5a7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.104.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_freebsd_arm.zip",
+          "shasum": "b27d078dc70960973cc495cc9b1f71acc60d4a121d4c9f44b3595c767ea975c3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.104.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_freebsd_arm64.zip",
+          "shasum": "57e2e26d44243fd8ed9dea7e19cc040f6677be5ed9cdf60be352d6cb832f64f4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.104.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_linux_386.zip",
+          "shasum": "1f1bbf222f3268afa00a8f8257773d3432a971c002aca68d775fe28a30a00513"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.104.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_linux_amd64.zip",
+          "shasum": "52705407657ad43283f5dc77bc579054fce3d920c2875eaf215b32de6c54c8f2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.104.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_linux_arm.zip",
+          "shasum": "accf6ea063fd6eebbf3b6d2aa6f6cb488a2467b62a2c60f97d05c639f7b0b4d7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.104.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_linux_arm64.zip",
+          "shasum": "557e958942065cfe3b7143bad0c1cc28b66570a35b5c087c30506bc9a3d8dd90"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.104.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_windows_386.zip",
+          "shasum": "cf9a87156c000ead7c6e925a56fe5790a8cee355f63e76a8e6daa49a27d2c617"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.104.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_windows_amd64.zip",
+          "shasum": "d6694c50f8673cb98f046bf1bc1870cea7c5f9f62ed5031ef4a6a9822e336fe1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.104.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.104.0/terraform-provider-yandex_0.104.0_windows_arm.zip",
+          "shasum": "c3a6f3cb611d95346265a12f1a2c49e02709e2035eb22fee31d6da51e2fdabb2"
+        }
+      ]
+    },
+    {
+      "version": "0.103.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.103.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_darwin_amd64.zip",
+          "shasum": "20b3fed3a84bcce2afdd2d7ea1ecef4e5d0c294555e953e48e23d7ca4089557a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.103.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_darwin_arm64.zip",
+          "shasum": "9e0d704421b73c124f2dff843d7dcf188831703342190b1c31c0fa6cb00f55ee"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.103.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_freebsd_386.zip",
+          "shasum": "af271a67cf7a5561acff8e3e4066f5a7d7dd428b2f5424dc18c2870ed7d15c40"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.103.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_freebsd_amd64.zip",
+          "shasum": "fd407956a8ed72a1e26c8451c017b98f06278c7253be76173da3aaa34aba6b08"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.103.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_freebsd_arm.zip",
+          "shasum": "a6a47fd8d203605152a6ac6508691b924e10c2d210623fb617ae61e37bacb178"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.103.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_freebsd_arm64.zip",
+          "shasum": "c0eadf36b2f519bc014026cd4841fa2d4d7c1cd89ff0f7fbc9d481f348bcc4d7"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.103.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_linux_386.zip",
+          "shasum": "470f73a978b86234b33613558d5199d74c4e82e7bf427a61429c43e3bebe16e2"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.103.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_linux_amd64.zip",
+          "shasum": "b8967e08874a9983a634df338623eb81c822fee5dfd7592b6c12ae97e0aa0a6d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.103.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_linux_arm.zip",
+          "shasum": "5de302a5cb223f34a603dd64501399c46df10940474b6775a7fd7526527f0b3f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.103.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_linux_arm64.zip",
+          "shasum": "0ca5cb59fc599d99d458e3efa055b30bf8e1daa43d2fcfbabac3430eb2eaf0ba"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.103.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_windows_386.zip",
+          "shasum": "0492fb9613d6044996e26b44a3956db49e67ec33ee8788b09df2a79d46950da7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.103.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_windows_amd64.zip",
+          "shasum": "01eed9047ba9eb0998811f5e1c0331ba10bb428d2085df52f05d71dc3b061edc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.103.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.103.0/terraform-provider-yandex_0.103.0_windows_arm.zip",
+          "shasum": "f04e7a46d4d53a3dd47d43039f4c574bd61590247f5f10ecfda318338e64da3c"
+        }
+      ]
+    },
+    {
+      "version": "0.102.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.102.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_darwin_amd64.zip",
+          "shasum": "bbbbf10296adcd6cb475928cf50083d56c8c57236219b55d4dda31919b080e38"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.102.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_darwin_arm64.zip",
+          "shasum": "768b0fcfed7f9dfe137a48f42cbeb24863495021e3fbd33c1ae5ab07a1864c91"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.102.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_freebsd_386.zip",
+          "shasum": "208ac832ebfd88c4ae6b6a5ead18f9e8bfe1e8515ba6acf93fb0e2c7f8bf0db9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.102.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_freebsd_amd64.zip",
+          "shasum": "b726ae874e82545ac07acb378e3e4c9816a12d691fcebd1729d1d9158dd927b1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.102.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_freebsd_arm.zip",
+          "shasum": "ec36c00cd161bc39cc432fbda891a1357d9b8b25dd457b5af49e3c543bd8b6a5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.102.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_freebsd_arm64.zip",
+          "shasum": "73856299e90ce3293af3560f87af51c5eb7d0284ac00b6095f13777483807b33"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.102.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_linux_386.zip",
+          "shasum": "8b82682c53ce3359068b1db37a1668184176edb46b903873496dcad29865974f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.102.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_linux_amd64.zip",
+          "shasum": "15d0b3b6ffdc21f65fe536b516010e3f609299489ac6e62fddfe5fd18174c99f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.102.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_linux_arm.zip",
+          "shasum": "4f31635a8c068a09326ebe872fb6bc429e15ff9932a4863bb750093fe90f773e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.102.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_linux_arm64.zip",
+          "shasum": "fa53ff78300065388930ac1739c56dd64d2f046506b8d098ef62f727c210732d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.102.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_windows_386.zip",
+          "shasum": "e7c271454cb6fb1db558e7f337087217ed60281f0d458fc95c427eba6f69695a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.102.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_windows_amd64.zip",
+          "shasum": "2926e596970e3c3f1bec51fb3846062128abec9771d9d1c67cb6f68de1197327"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.102.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.102.0/terraform-provider-yandex_0.102.0_windows_arm.zip",
+          "shasum": "f809dda86eb6c693abf1df716a5e25a2a7c3bbe9df4a0eae677155638bea4325"
+        }
+      ]
+    },
+    {
+      "version": "0.101.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.101.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_darwin_amd64.zip",
+          "shasum": "d6f8454014846ca347dc71491b5f382ef4cc6d290340b33b126a79dfc656901e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.101.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_darwin_arm64.zip",
+          "shasum": "40f921ee26e99f4185430b6c7eab80e550ce10236a1f6a41af7cd533ea8d6218"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.101.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_freebsd_386.zip",
+          "shasum": "96b75463b4898c62065754d9c4d6eb7e78d0403379de2d4132ee6e529b8113ff"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.101.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_freebsd_amd64.zip",
+          "shasum": "848fc04482acc30573aac9f2a4ed0a1bb957b0f07beb93423d6b8182ca843c19"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.101.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_freebsd_arm.zip",
+          "shasum": "b52339d790c90234ea1184ba85cfc3a5d0302cd1715b856f00d9db5ba7df0d92"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.101.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_freebsd_arm64.zip",
+          "shasum": "3e16a0e4ff45ae508b9faf96a07cd7d818cf341cf1b072588a8f6d6867d0a546"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.101.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_linux_386.zip",
+          "shasum": "d4c1562df10157b09c345eaa1aa52d6e6b7cfe6254cb80dbf4651719366417f4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.101.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_linux_amd64.zip",
+          "shasum": "871f712d4dcffa4e81b9de832a72ecbc8d26c2733cdeec7c0dbc3927a944b50e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.101.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_linux_arm.zip",
+          "shasum": "27f5dcec43f67a526af54233f83535e647b0b644a681c03039f2d44e1e3ec0cc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.101.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_linux_arm64.zip",
+          "shasum": "1f80289341ead5fc85b7d57f9d5b64c4e6410390e1e6c51028ca111836401029"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.101.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_windows_386.zip",
+          "shasum": "0ff95cfa95e6916e75dcab520cff747166412714ce0cb84be1aa596a992528a9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.101.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_windows_amd64.zip",
+          "shasum": "cf6e8e954a403432be2102d0cf0dc9165b7ca4413347f5f85fe60fb4b34be4b8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.101.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.101.0/terraform-provider-yandex_0.101.0_windows_arm.zip",
+          "shasum": "fdf87ac40c0a1031966c2a7f238d00eb03b143b75748ac8f46462672e6c19285"
+        }
+      ]
+    },
+    {
+      "version": "0.100.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.100.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_darwin_amd64.zip",
+          "shasum": "0b2e77841333899f016ed0d392f32a89632ed0c5b2d2e08872f279d482e509d7"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.100.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_darwin_arm64.zip",
+          "shasum": "a2bb9c377b882753b021ece480dea944ad475e9558ba647937f13e28c61b6f36"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.100.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_freebsd_386.zip",
+          "shasum": "bcf63064d31b92e7d2551fe936dff5d5c50d95ae36832619bc1e58e0daf9d2db"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.100.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_freebsd_amd64.zip",
+          "shasum": "b515a254b2d2e6c76b9746cd190413afc8159709e2ca6e0ca6b2436048728372"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.100.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_freebsd_arm.zip",
+          "shasum": "cf91f53a5254b355279f8843db0d5061ce37fae087f21b8fea1d8c4d5ed17ac1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.100.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_freebsd_arm64.zip",
+          "shasum": "5742c5d561c2e12f8b44dd431d7fb24a95f69326f037303ab19a50a86b57e518"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.100.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_linux_386.zip",
+          "shasum": "62a3de7b1e35af2cc48bed15e27a7e1ccd89c59ff203ba5bcc6766186da93c3f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.100.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_linux_amd64.zip",
+          "shasum": "eddbfd8498948d556faf2a8dbf068ba7ce5c846d0cbd2d83a9c6feb59a897c14"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.100.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_linux_arm.zip",
+          "shasum": "1afcbd81c7f9dccc55b4fcecf2e5d78510c18660a36525feb8c9e2cd40951a18"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.100.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_linux_arm64.zip",
+          "shasum": "f0bea2311b568463fdbec6e4d316c0e97fe8ffdecd217c61befb848c1157c1b6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.100.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_windows_386.zip",
+          "shasum": "252b33f8d26dd787ffe4be60a4f702421352b92c283e06608a5bc2e1fddcb1b3"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.100.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_windows_amd64.zip",
+          "shasum": "62bf10be016f8dfef936a3a9d755088d39a3a170110850d1e5ff9a1fdb500294"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.100.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.100.0/terraform-provider-yandex_0.100.0_windows_arm.zip",
+          "shasum": "7c45f63c5ad17150f019c25807f823e98347af867e94043b57207ccddefc7cbf"
+        }
+      ]
+    },
+    {
+      "version": "0.99.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_darwin_amd64.zip",
+          "shasum": "6bb08c772a48a216ace02b5a5c613fc6328e7217986db738a9a3aed4e4bdc76a"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.99.1_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_darwin_arm64.zip",
+          "shasum": "777a61b389b5017cf80df7fc78d35ae7b594d944a0e2fe02c21b3956b050470d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.99.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_freebsd_386.zip",
+          "shasum": "97f125199d201064213a524d87d7f90220e2f80053cea7d2ebc6909aab17e816"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_freebsd_amd64.zip",
+          "shasum": "57df1b9cf43758175dea26ac9c6533fe1a21d82a0fe4a234b838280fbfb7adaf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.99.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_freebsd_arm.zip",
+          "shasum": "95953ea85e44a0486f9ea6e4a82e6863e9f38e1755a9641f6b76a993e6c8af27"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.99.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_freebsd_arm64.zip",
+          "shasum": "476d0b4afe43933271edbffb690706cc60e4faa7273fd10ecd140801a59e7a44"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.99.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_linux_386.zip",
+          "shasum": "dbf865a1c5758e7c080e5fdf1e452e934a40c68dfa497a6a9fbd5fc7895e5a3c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_linux_amd64.zip",
+          "shasum": "2ec2898c8d3dbe416ca181c87c8e020253ba6cf20394e1e05e33503d40b6963e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.99.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_linux_arm.zip",
+          "shasum": "891551293cd81eaa27bf8d22f70fbcc86431316419b8645f1f11af261cefe73a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.99.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_linux_arm64.zip",
+          "shasum": "c48972228521050d036f4193a310611db90c324af41dc3fb97f2931b35b8e4e8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.99.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_windows_386.zip",
+          "shasum": "902fdc7726b2eb930b09400021bc980cf5f2961c28f9c01114d2d6a4843c8396"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_windows_amd64.zip",
+          "shasum": "6c3c6c1d7432ee682a7cec2acdf666b9a4ff5e919ffa60654c271c8a6a951c53"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.99.1_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.1/terraform-provider-yandex_0.99.1_windows_arm.zip",
+          "shasum": "ab7403ccde1e7aa4b87b1b247b4d0935939c2d6d49bca8e240d623ab0e605511"
+        }
+      ]
+    },
+    {
+      "version": "0.99.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_darwin_amd64.zip",
+          "shasum": "c79ca38cd31a9a8e6f5714d6939d73c7f51d61aa3d917c67015e60449b7be115"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.99.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_darwin_arm64.zip",
+          "shasum": "f61523ed1b0972e64e4cb40afc46fe9da44e3241ae5b847750b59ee2fe12047a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.99.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_freebsd_386.zip",
+          "shasum": "a4c2972dd6fb55fafd74c9745d81350c6c6ef5571967c7cd79a43242ad73edce"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_freebsd_amd64.zip",
+          "shasum": "9f1772351336bc2f23edf50d4b137fd26004ffeb6d4c7dcbadf42afe6f9dd429"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.99.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_freebsd_arm.zip",
+          "shasum": "9122d0c4e72cffe65323e0b3c4278acb7b6d2a09bbb08b25a5e3bc97323df045"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.99.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_freebsd_arm64.zip",
+          "shasum": "c0fb511aaeeba115b486e387211473626a7b302887f4f732ad08baafa5f43fb6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.99.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_linux_386.zip",
+          "shasum": "6df604f3f55cbcdd32d7fdccb7a202817b58f3836e9c28c3f78d8f254a23c726"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_linux_amd64.zip",
+          "shasum": "dc5616030be005305d4bb122ea9b7829795a3aa6bfdd2ff810779abd38618af4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.99.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_linux_arm.zip",
+          "shasum": "1605ce54f70cb353e4dea68c75b652e2a4f3190c19434cea829d813a07d8cc1b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.99.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_linux_arm64.zip",
+          "shasum": "7a4dd143b46c86436b5282867866fb8833c64dae33142aac36feab6f143b1e40"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.99.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_windows_386.zip",
+          "shasum": "8e3af009b6d28434c1eba1845cfaaa74acb2ebb4e7a2fd25e2fdc2af2ac7b1a7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.99.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_windows_amd64.zip",
+          "shasum": "c47e05cee84d16a10a84454b0abf0f168714cdb55ccc2a170f1cce4582f8d048"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.99.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.99.0/terraform-provider-yandex_0.99.0_windows_arm.zip",
+          "shasum": "191c986d5efc502769c82df9148c8006948a0d7c67e978b8801b1b03b3dd32d0"
+        }
+      ]
+    },
+    {
+      "version": "0.98.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.98.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_darwin_amd64.zip",
+          "shasum": "b410acff06227e1817e93c8c0307cbf800c6b57780d344c234a5c6bac651ad8d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.98.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_darwin_arm64.zip",
+          "shasum": "50e45c5697231e18708eebe4d010a521f2c685c6bc4944cbb8c518b7048a72f7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.98.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_freebsd_386.zip",
+          "shasum": "852e13ef400ca7208bb88c5ca44fa50b959f6029b5bcf360f97c4090104abf3c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.98.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_freebsd_amd64.zip",
+          "shasum": "185a2f7a0be4088efba8aab7fa10911d980f196e2f9b7f839b6aecf0cb347887"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.98.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_freebsd_arm.zip",
+          "shasum": "d67d0fbaec9e7ca1909b6551267688520936c446e9643c32fda94579626fa35b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.98.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_freebsd_arm64.zip",
+          "shasum": "fd00447c8e6df452ced3b0c0017d16ee20e853cd2f64f308a673ef686ccdb081"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.98.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_linux_386.zip",
+          "shasum": "0be1432d6ff998cf5a199dd8a32afccf78634098635727f94469b41012d51b23"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.98.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_linux_amd64.zip",
+          "shasum": "135652718d31b9522614a5a1b8290bcbaae9a18240af3918423ce4ff92a9ebb1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.98.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_linux_arm.zip",
+          "shasum": "4d06bc631c8eebf545f2dd3a57e515ab8ab57ecd8709cacb507e0345d05024b8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.98.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_linux_arm64.zip",
+          "shasum": "7819efada1d6c605e66fb32cd4a4962c04d811515cc9657966bbad4fa8a106dd"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.98.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_windows_386.zip",
+          "shasum": "1876aa18ed8927ac4dce3ea5e76cead7e61ad92f8505375aefcf8f2b9595e2c4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.98.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_windows_amd64.zip",
+          "shasum": "7b9a3ec8e5ed578c0cdfeeee1ab55db63e8b9e3bd987f606481889eb93bab9c4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.98.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.98.0/terraform-provider-yandex_0.98.0_windows_arm.zip",
+          "shasum": "5c639c33b7f022e52d5eb63668b9ab82e85e32c482a759d83a899edd88a4d936"
+        }
+      ]
+    },
+    {
+      "version": "0.97.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.97.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_darwin_amd64.zip",
+          "shasum": "dca321f7cb0ce1313eb2ca7baf443c6893ed63c3015040418a7a61963553e6f5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.97.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_darwin_arm64.zip",
+          "shasum": "6b4b004a2bb9ed40eefb2e9600ecb21179177c189a7804922bcf450b59184692"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.97.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_freebsd_386.zip",
+          "shasum": "b94c807ea94f7a6229735645103921495f76240949a176f467c9f8cc8a503d9d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.97.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_freebsd_amd64.zip",
+          "shasum": "98f3952e5517d89d0f705f7b01a8cfe29e062f492f0b08c13f5967182076b3da"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.97.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_freebsd_arm.zip",
+          "shasum": "d6db93473a7547f2874e4490321aa810ebf23d5530eb756274ab0768c439e536"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.97.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_freebsd_arm64.zip",
+          "shasum": "24f53c3fc64033b121679511f2ae51b3407817451bd209a446579513dc87401d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.97.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_linux_386.zip",
+          "shasum": "39f8fe0927a815722b95bcdca145c361c834fb43c7fc12ccbe00934b14f179bf"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.97.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_linux_amd64.zip",
+          "shasum": "21a0685a11d26eee3a2a4a1b681e4abba96e81d8e75bf012dff732e19e1b27ed"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.97.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_linux_arm.zip",
+          "shasum": "32f070b5d0ab09699763510c5c47f162e20cdc1b49d335ccbc6c4a3f2d55f820"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.97.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_linux_arm64.zip",
+          "shasum": "ebf0883f71f2906b6f285e45543fb010f9a3f1898ff54b4aca3b56b2432fe04c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.97.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_windows_386.zip",
+          "shasum": "265e53bac9a71dd50485d2163da53f3f91c4005cb8f065a81f1b50143dddc07e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.97.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_windows_amd64.zip",
+          "shasum": "7939c801d422cd3356af4a76b685513c6b620fe6352dfeb638f2fb052201dbd4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.97.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.97.0/terraform-provider-yandex_0.97.0_windows_arm.zip",
+          "shasum": "ec01011e8ca3cd1b21dfb3db3fd01829b8f84bc6212bae51c92f8fd6ed03d141"
+        }
+      ]
+    },
+    {
+      "version": "0.96.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_darwin_amd64.zip",
+          "shasum": "1ea72b25fad597f974b523f9086b98f1a0747937cb777cd210b2802c24a31abf"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.96.1_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_darwin_arm64.zip",
+          "shasum": "7c55bcfe008eec28f7990e747e69e795208a33b1f7c912183bf3b71a41b6afe2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.96.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_freebsd_386.zip",
+          "shasum": "a71c74477a4b21ec573a9af489987332cd5e41cac2be49a277274aaa4b33973c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_freebsd_amd64.zip",
+          "shasum": "91221ec94a01e4dbee6068ca035c740966f3de6faf326ad58b00c2d2b89d5028"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.96.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_freebsd_arm.zip",
+          "shasum": "0ee93870d989c75ec4eae4e8aa995f924d368bf8552ed815174b65332596079e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.96.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_freebsd_arm64.zip",
+          "shasum": "fa2db9481d7e0c99efd08953bf14f0e6d7da71e0da1a30221c44db780d48be65"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.96.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_linux_386.zip",
+          "shasum": "06541158300aac603a59e29c3ca25f94d914d3c2ca9907c6f4a8adf0803011a1"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_linux_amd64.zip",
+          "shasum": "966ed944b173aac67d1066f0b3e710c3a66e90f1357743e2a77567c732a87b9b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.96.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_linux_arm.zip",
+          "shasum": "9e9e8ce10a1e7e5316d227e123750044ee84f853526cc029dbfcadadcb865b09"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.96.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_linux_arm64.zip",
+          "shasum": "9b0f3d20645f9b7d4e86b11d506c7be22ae14a8ed53ecaacf69f9c5edef275e7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.96.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_windows_386.zip",
+          "shasum": "bc4c7830b9281c76178f4eee1226b06aebe630cc8ae6c1d0831f994cff74708e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_windows_amd64.zip",
+          "shasum": "208c088ace3bd037dfc5bc6ef04a0ee1109fe42c56784da0ac8500124e6ad009"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.96.1_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.1/terraform-provider-yandex_0.96.1_windows_arm.zip",
+          "shasum": "eb1a18dc8e419fa1a5edea6dab91c04e1247d15b1967dc4d60e8448af5bd11e9"
+        }
+      ]
+    },
+    {
+      "version": "0.96.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_darwin_amd64.zip",
+          "shasum": "b21c3f4524a26698bb3bc972fbc05b787826448626d308ce58ea31b9ca985942"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.96.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_darwin_arm64.zip",
+          "shasum": "648d160a16e96f6e8c655ecca2a9b6408104eb76c8c7e8952869c1b8df612ba9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.96.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_freebsd_386.zip",
+          "shasum": "ecaafef3134c00056af530efa12244596dac8997ba345df3e49943cfcdfa03d3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_freebsd_amd64.zip",
+          "shasum": "ac1dbf17e7bd26907fecd87667d9873c035970dccb78c20a47e73588d08cb83a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.96.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_freebsd_arm.zip",
+          "shasum": "32a59b4c28d65c2829f6905aaf9eb114f6f2a5b9579c30182d54ed46c1f81f82"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.96.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_freebsd_arm64.zip",
+          "shasum": "aff2eea4ebdd8b9fd1cf5d428732dee256e822a51756bf563e5bf7b0bf5970b3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.96.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_linux_386.zip",
+          "shasum": "2200d78bcd887176ea81d1ed56cef792a1878c3994d08f88a4cdec3b9ee97acd"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_linux_amd64.zip",
+          "shasum": "904dd25ec78369df8b5e631dbdb2c7fcf4748a210c5f1f157ec18ef6971d6b3b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.96.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_linux_arm.zip",
+          "shasum": "ae677ad8960ab6760160df497fbc0caff02ced49c7c506a7096dc25d3e810ce5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.96.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_linux_arm64.zip",
+          "shasum": "7130113f8cf29400e3e79bb567dbd9f44abb993292a212841f6e61be2422ea53"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.96.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_windows_386.zip",
+          "shasum": "ac8c9dd1b12f46f34f583599ea54e4ea99428a5e1e571bf015cafcf8b9647f47"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.96.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_windows_amd64.zip",
+          "shasum": "85f8c939e0e1038d1b7996e31f10814df1cfc04f0e368f38ba31fa07e15ca2f1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.96.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.96.0/terraform-provider-yandex_0.96.0_windows_arm.zip",
+          "shasum": "7ed3a3a5b4afea4eebb737cdfcf791d339330634e1bd589cf3e84eeea743a590"
+        }
+      ]
+    },
+    {
+      "version": "0.95.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.95.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_darwin_amd64.zip",
+          "shasum": "ca0219a4327c60c442c53a41aa146dc766ced692b478a00fed4cc01c3f3c58e6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.95.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_darwin_arm64.zip",
+          "shasum": "87746e7c706df5f913c3f7b7e16358b409691c473cd752cbca7ee33b5cfdb2fa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.95.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_freebsd_386.zip",
+          "shasum": "0eb60c4bae44008a00bd9a731849c79ec397b8cf28de4c4c30838705ee1dd1f6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.95.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_freebsd_amd64.zip",
+          "shasum": "021c589fdb629bcb782824801e992a3f333ad9ea1f671950130864b24b54e48f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.95.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_freebsd_arm.zip",
+          "shasum": "3491836fb60d43fe45860832aa120ce8a7f7f7b01bedbf70e23256bfed13995c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.95.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_freebsd_arm64.zip",
+          "shasum": "d0d4fda0735362256555cbe5e2944a78be251a65b1853fe56333fdff920680f3"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.95.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_linux_386.zip",
+          "shasum": "a22e45468aee2de201515d1dd8135471609d864148b96066edbf1f27b7881c76"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.95.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_linux_amd64.zip",
+          "shasum": "10bde2b7d722f1b3be72720b22451467684bee37be65953987f9fd3a3a5210ba"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.95.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_linux_arm.zip",
+          "shasum": "2f4bc8600830fb7ee7c9052449eacacd3ee3b2e8e0ab6da96261b680868c614e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.95.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_linux_arm64.zip",
+          "shasum": "97f11944832e59ea14573a53187e5708e39d92b1a37b8567e767f41bafe5e467"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.95.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_windows_386.zip",
+          "shasum": "0b332383573318dc131392761323e6b12099cdb0d8876f4c76aab3816cdc4d3d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.95.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_windows_amd64.zip",
+          "shasum": "e7d187f877b24b4f6958bfb300ddf8f8457c5405af4b64b2a887514ae4e81283"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.95.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.95.0/terraform-provider-yandex_0.95.0_windows_arm.zip",
+          "shasum": "af82e55ac5a0c98482cbc36aabcf377c64c4c265650ad15528b916051522a8b2"
+        }
+      ]
+    },
+    {
+      "version": "0.94.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.94.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_darwin_amd64.zip",
+          "shasum": "069c3bf926bce359f33b8c117b75219158d7ef5eef4b688390623df52ec2c44b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.94.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_darwin_arm64.zip",
+          "shasum": "7e50a02985d0e918dd62765945950908b1db0bd6823df623bb445a929da65aa5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.94.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_freebsd_386.zip",
+          "shasum": "7b1af8523fc8f54ec453d5127ed2cdbe7046d690868c672fd0676944b52b089a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.94.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_freebsd_amd64.zip",
+          "shasum": "a5b6a5dfb5cdd4da67cc50cd10026031df4353f015ff76c4c8fb4897d2f96e95"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.94.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_freebsd_arm.zip",
+          "shasum": "9b0a75d7855bbf3c4948868f581eefa16a597dc605581c4d1e0a72aacbe0dd53"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.94.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_freebsd_arm64.zip",
+          "shasum": "35940ae664c13008784befdce5a386c9a70f18daa7fa040e97f7bccf9387a036"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.94.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_linux_386.zip",
+          "shasum": "f4f83b82ff1f831a9ee02f76f63d2429e173186733362f50bc9419f6d06dda1f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.94.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_linux_amd64.zip",
+          "shasum": "f51e553c96b7d366f2a728a6f4d78d3f31c1791b7daef4c97d23c1a3411e85c8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.94.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_linux_arm.zip",
+          "shasum": "aaa8d18d127370c2eef4ad61c8bf583370de8456b63d89438d86b38d749132b9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.94.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_linux_arm64.zip",
+          "shasum": "09e424dc1c18a80d75f54c77d0b467ac0a5600351f1afaa75d8b42d876722806"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.94.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_windows_386.zip",
+          "shasum": "cde420e148a7f12ba148892307008772be45a6093b6f023193da2563d0885bd6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.94.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_windows_amd64.zip",
+          "shasum": "8fecfd688e0b85100918df27b98bf4283c4e8b2ddbec18270e6b67c9ce5da41c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.94.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.94.0/terraform-provider-yandex_0.94.0_windows_arm.zip",
+          "shasum": "5554fac766b882e946caa12c92bbc8884f29ee22e29d39fd8a66fd63c469ecbc"
+        }
+      ]
+    },
+    {
+      "version": "0.93.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.93.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_darwin_amd64.zip",
+          "shasum": "f3a1d623153d73561c3663d0f5390d56513ff4e56c33f0a3a7cc8becf0ec5c39"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.93.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_darwin_arm64.zip",
+          "shasum": "e754551ab8cceec2b6b059351d4b7089ddd54de70e3f33b75461edb49bf370e8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.93.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_freebsd_386.zip",
+          "shasum": "b910eb2a790bce2b823b8715e8118fc8e6b7553dcfedb04214863cf87bd6d572"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.93.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_freebsd_amd64.zip",
+          "shasum": "a1a511d91d61130d8aeeae44d00a4c4825aba59c987ae1431fdb73c5638047ba"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.93.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_freebsd_arm.zip",
+          "shasum": "daacb1b1fb0465ebadaeeae91823fc0d902929fae67e107a77e76c7c656fa2c0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.93.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_freebsd_arm64.zip",
+          "shasum": "a4a531f780bf43f7e4d1f1e17089b02b5438aed9b7f5a49dfdbb5fd28ce2df2c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.93.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_linux_386.zip",
+          "shasum": "f30ef42762d1cf3ebc3cc563739c12bc42d52abf575e316f4cd11f3cfa5b806b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.93.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_linux_amd64.zip",
+          "shasum": "6b07a70cf2b16c5eb332fd872a46726db40c864417877caa0a1793218526dc97"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.93.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_linux_arm.zip",
+          "shasum": "837ded649537a9c9e1414910820f534d3dc48b2bea14ddfaf8ae6be1d1b2cdda"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.93.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_linux_arm64.zip",
+          "shasum": "1b9a916c22da8fd455b1d73c983c1c9739effabbdc20aa3f55c6eb0b3db9c2b3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.93.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_windows_386.zip",
+          "shasum": "2dab0553b28922b03990b1577f1f822d439347c4c60a12681086df429acceae5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.93.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_windows_amd64.zip",
+          "shasum": "8459d4b17c07a117d9e78d0f8dcfb966f6a6a209cf077f430f38022b00d06141"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.93.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.93.0/terraform-provider-yandex_0.93.0_windows_arm.zip",
+          "shasum": "1bdcbcb07dc02346dc3527a3d8f5133bb9f7aa1bdbe3a0c96937bc655b70301d"
+        }
+      ]
+    },
+    {
+      "version": "0.92.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.92.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_darwin_amd64.zip",
+          "shasum": "73ad1dad0e6e0776a6b11ed463bce7fdc7f2c42d4ee2680cb0f0c51aa295aa0e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.92.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_darwin_arm64.zip",
+          "shasum": "ae2e8e16f064f777924e8686ca80078e7058d84010bfc0b14a03b314a39f3dca"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.92.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_freebsd_386.zip",
+          "shasum": "89a4f575b652d4b413a4c7779814c63f3001e60b49ac207112279343bc8180c8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.92.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_freebsd_amd64.zip",
+          "shasum": "1cf280e7775f1983ca460c448c8047edbbd494b6dca46881378f77a889a01cef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.92.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_freebsd_arm.zip",
+          "shasum": "a32200c168e45b034b928137b807c9bd7a84f602eb4f37a963443d2fae953cc9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.92.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_freebsd_arm64.zip",
+          "shasum": "978e0c3f4de75f5fa3ddd92d53e59e5f50c76073271d718d26859009d5b5c6ff"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.92.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_linux_386.zip",
+          "shasum": "9058730af803a8aa47e6c7f8c2b715246802091caeeee2eace9e129dd87571b3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.92.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_linux_amd64.zip",
+          "shasum": "8f8a1624da6f358faecc2244aec618580df87edf52729cebb208b39fc28cac6c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.92.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_linux_arm.zip",
+          "shasum": "2770fa0371e84976241efac5721b519e6a5037a7691bcf0fbe3e1ecf5a5614c1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.92.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_linux_arm64.zip",
+          "shasum": "5718e677762a23bf35777891b03180cea4bbe52d0a64d9cc3f0a8adfafad1ee7"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.92.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_windows_386.zip",
+          "shasum": "877f619cb283ac108f8f0e8eec29c9982e28d99dd898fb820bbad68bfa6831a4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.92.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_windows_amd64.zip",
+          "shasum": "b3c95c0d44865f18245c316714884f6bd10f6630567cb90b48a780c36546d4cc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.92.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.92.0/terraform-provider-yandex_0.92.0_windows_arm.zip",
+          "shasum": "3fc2ffe174f0f697e0bb60a8ebdd531691a6bee65d8ddb99c25061d64f98d9e2"
+        }
+      ]
+    },
+    {
+      "version": "0.91.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.91.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_darwin_amd64.zip",
+          "shasum": "b9084059afa263cdf6e8477742b8656517a0e43d2983a1a80c2fb671e22301b8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.91.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_darwin_arm64.zip",
+          "shasum": "d8d19c293f727b2ddae40e5e637b60a143e2ba11f1e048b97aa4be32e5c33d25"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.91.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_freebsd_386.zip",
+          "shasum": "35d6499910556e2240baf473e6198bd061762b23905a343d1f348c1da7f2a009"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.91.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_freebsd_amd64.zip",
+          "shasum": "4a0f10f692f0e53c3f2d7bb4eb3bb0ea69174526f7e5b6ac001effcaa8fd2b31"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.91.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_freebsd_arm.zip",
+          "shasum": "0eb744352ba5b2e66c9284c0d4277c4061eb159961dcad9bb11e7be8bf3f6c5c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.91.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_freebsd_arm64.zip",
+          "shasum": "cfe255359d221886a883df12722b7ef4331fe7b7bb314386842e5dddc18ec42e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.91.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_linux_386.zip",
+          "shasum": "78e29ec49b2eb606c57a14bf334b4c48268b2d4cbf02e40d19924f680b17816f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.91.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_linux_amd64.zip",
+          "shasum": "4ea8915e0ab3b4e9c2e6079cba259ae67efba2dfae1e7beacb87a894cbbfd465"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.91.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_linux_arm.zip",
+          "shasum": "db13a9904074856ee3ce73674287016dfd95501542f50c821166c937109758f3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.91.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_linux_arm64.zip",
+          "shasum": "1a9d9a8bd3f402c96dc951dbb311ed019740cc8ba5ec1bf530bac2e4adb789cf"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.91.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_windows_386.zip",
+          "shasum": "b5cc7bf8c53f0d985caf70b4fe32608576ee0f713ce6973b5f4da249d7b2bbd4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.91.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_windows_amd64.zip",
+          "shasum": "e6216c34d8c6ec5d317e16049a16f5eab5d9978678793d1050ec57af84b720ca"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.91.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.91.0/terraform-provider-yandex_0.91.0_windows_arm.zip",
+          "shasum": "1d9868ee308d65a0c1f8f0e5e5ae709774348e99b3ce704a32edea153bb7fe68"
+        }
+      ]
+    },
+    {
+      "version": "0.90.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.90.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_darwin_amd64.zip",
+          "shasum": "7e6b210dc961334290807525e8c560d2137250da42ff5d4a7c543ba94918d417"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.90.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_darwin_arm64.zip",
+          "shasum": "fe19be57b00e02675a223011a74d10abf6e380701c5004e32d5195db9612ae40"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.90.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_freebsd_386.zip",
+          "shasum": "373a1d893af3a5a8dd89d41b1ce8a8d2e45e445551e9d7a0c74992da24d1125c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.90.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_freebsd_amd64.zip",
+          "shasum": "c9ea87c91bf8e8f23edb9fb8297fdc8a08dd4d5ebb821053cf0da25015588fc8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.90.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_freebsd_arm.zip",
+          "shasum": "29bc85eab5e9f7b9a99b7f31722010dc13996b58df9af5102055eb98a5a5a7e7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.90.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_freebsd_arm64.zip",
+          "shasum": "051f6f563816df4bc3e40e6ab1c8bf0aca20f13a97c0ed46b564666dc631dfa8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.90.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_linux_386.zip",
+          "shasum": "87caebd701fcc740d2f584ba2917dd62f5527b2ceddc74344c4a72de3b457b23"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.90.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_linux_amd64.zip",
+          "shasum": "da10f2b781a98cadfe3ed8a7dafc466f97cd9d4d7d2569a602a4759479d24019"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.90.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_linux_arm.zip",
+          "shasum": "1bdd8001b82615f28708832daad3bd18334ff0f2f633a6d062ebc974344f25b1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.90.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_linux_arm64.zip",
+          "shasum": "12cbcf5c2d1e360e874ef2730a84d47ca7570c1b53735e0cc0792ae6983eae74"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.90.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_windows_386.zip",
+          "shasum": "7e55561ca3d91b8fc2b56589eeb740e2c59d1a16cd80fabd3846e2c63b742799"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.90.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_windows_amd64.zip",
+          "shasum": "c984409a3d862146268151b3ec8a0163d5cbbd574aea8da5831137350230a3d7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.90.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.90.0/terraform-provider-yandex_0.90.0_windows_arm.zip",
+          "shasum": "007202a216f4bf068273d95ef91078997e3fc5dcef9b3749cc3fbd2ac05e1a80"
+        }
+      ]
+    },
+    {
+      "version": "0.89.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.89.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_darwin_amd64.zip",
+          "shasum": "e9693981b5d4588f7b0b54025b82891d4afef6dc1f0406e3239b65d025bdccae"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.89.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_darwin_arm64.zip",
+          "shasum": "2aabcfa0f6b8905890706cd26dac0c4cfc8f015ef2f95617d5250b98d67a6d85"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.89.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_freebsd_386.zip",
+          "shasum": "45b65e84e37742c10e245a3ac8fcdc423af805aac4401b34f2726a433234b7c0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.89.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_freebsd_amd64.zip",
+          "shasum": "7bbd6ff1d4b323e22f4a45026c0110df28f8fa7ff28c818f061c2e26f12881a2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.89.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_freebsd_arm.zip",
+          "shasum": "0633413625f43bdf1e91047e0a12c4f01bb44bb1a1f30b8f51efdaf60b4bfe85"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.89.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_freebsd_arm64.zip",
+          "shasum": "88245834cb62549741f4a0fd446e3f8f2cc21086c3efbdcbfe08c2a2f6ecfcd1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.89.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_linux_386.zip",
+          "shasum": "d24320b28991721fc962dfe907598b89410a18bae88995bc9472cf12feffeb2e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.89.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_linux_amd64.zip",
+          "shasum": "14439c7d7b4597f72fa14716e6759d63bf1d0acdf6feae532017f36e54bb39bc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.89.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_linux_arm.zip",
+          "shasum": "0114e63d67846567743b9409f3add30507f35b93e72022da57d078b0949b7de6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.89.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_linux_arm64.zip",
+          "shasum": "31c7cb6ee2f1f2d4bd24b8f896ff5b5e540880a10cf5815232b77e6a73f8bee8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.89.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_windows_386.zip",
+          "shasum": "0cd84dc77e6e71351f90ee1a34baad2b712551d3eb64c17a6f75c6d4d8b48b38"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.89.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_windows_amd64.zip",
+          "shasum": "8f8d7b618c93cb8ab9dedc328e3b26164d32433b16096c2171199b6bf42ed91d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.89.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.89.0/terraform-provider-yandex_0.89.0_windows_arm.zip",
+          "shasum": "91c211b4e52127c38d9b445409a5478d25ce72bec3ec054491234afe52508127"
+        }
+      ]
+    },
+    {
+      "version": "0.88.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.88.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_darwin_amd64.zip",
+          "shasum": "36964a7b5970cee3adfe75ac83b4bd83c23dc9f7798f91f4fdce861ef5cf5b3b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.88.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_darwin_arm64.zip",
+          "shasum": "6fb6cff2fa6940f0b5fa37875cfd9e1c0d8a6a1f752a82e025ae1243ae8fda18"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.88.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_freebsd_386.zip",
+          "shasum": "6bb81e655a317bfe4f6a1286ff4009d0a5425464ef3cd73352be8f07c0b8a9e9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.88.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_freebsd_amd64.zip",
+          "shasum": "e27cb9525b714e6b2e0e940e1edc7e635ea92462c95da11e69033bdffdd47013"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.88.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_freebsd_arm.zip",
+          "shasum": "78d9fe4d5d6a8cb863fde25a44148529777a5cab814e09d0ff25ce31aa367b4e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.88.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_freebsd_arm64.zip",
+          "shasum": "b8ad58226fb3bcb59379de0d002b40af5d975cb966e153059ce5bd61458555ac"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.88.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_linux_386.zip",
+          "shasum": "7b558d28ca4603ade6193a46c14df1aaeb24055f5984c2bbd910545318b3195c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.88.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_linux_amd64.zip",
+          "shasum": "58b07c6f402fcfcd5b5dcc55d7ca15f9ce7607005a829a6ee6f88554da047dbe"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.88.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_linux_arm.zip",
+          "shasum": "64b930b788302614ef551e28d631f6b8c0ee0a8922e2b37b0aab15e8b09a28f6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.88.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_linux_arm64.zip",
+          "shasum": "01d493e0829bcee1658927cf70f9c131ce5abd66b8eef9073a90021909db5a40"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.88.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_windows_386.zip",
+          "shasum": "5e638c4ae5da44a8de5b06226fcc8d538f62ce7c1557817bce6b2496cc603458"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.88.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_windows_amd64.zip",
+          "shasum": "03b09109cb9ea387893520e77fa959b0c50d259832600617b3fb37c76763d376"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.88.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.88.0/terraform-provider-yandex_0.88.0_windows_arm.zip",
+          "shasum": "6a7de266d8abe2834a4779e6c13d0748629429215bfac3755274c3c1fe53a7b3"
+        }
+      ]
+    },
+    {
+      "version": "0.87.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.87.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_darwin_amd64.zip",
+          "shasum": "80d8e5c3b09a80673be3f3ba0cfc23aecc9add7ead2fb1e9d2432c9f184e861b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.87.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_darwin_arm64.zip",
+          "shasum": "5774d8ea48c15f92aba6d862a909a0a82a8aece822f7a983005fadbf41f5f03d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.87.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_freebsd_386.zip",
+          "shasum": "09d88b8c9da0ef33915f9123b04983bef6b21ca0bd23584329c82e8d4797fb4b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.87.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_freebsd_amd64.zip",
+          "shasum": "fedfe949f39be6410cc05231549f70f5c7fc6b45f9ee510700a84fe4fe8703f9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.87.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_freebsd_arm.zip",
+          "shasum": "15dd778d789199ceb9e9be8e30aaae7a6b1b27e166233e1146a0d5fb8411ce4a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.87.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_freebsd_arm64.zip",
+          "shasum": "5adb552b75ec36600a49db27470c96cc135472c430bf5941d3a2a9dd6346c3b8"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.87.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_linux_386.zip",
+          "shasum": "42722edd5ba73dc9bf61945d421b4f8a61d9e8a2956ac0a3a006939b810ca400"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.87.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_linux_amd64.zip",
+          "shasum": "d88597fbb268b766395b75a7a110011fd6ff78be378dff49f31575c2edeb1216"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.87.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_linux_arm.zip",
+          "shasum": "fae709617ed602bfcd3bd2aa7d5ee15aa371eb35fca3541ae29b0efa8e7ec7fd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.87.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_linux_arm64.zip",
+          "shasum": "a47d2ac47f5cd787be9c2bbb54f7bd3618604d7aceb7b82aa3474511a0e9f7cd"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.87.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_windows_386.zip",
+          "shasum": "504df36008217a63354ebe5bd67e5130ce0649c9c1a5ec1bce69cf17becd2088"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.87.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_windows_amd64.zip",
+          "shasum": "5943c5dfc7aafbbff7ae7cd6b6b80b1f0edf27bb597882f000fa043baa2675fa"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.87.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.87.0/terraform-provider-yandex_0.87.0_windows_arm.zip",
+          "shasum": "f357a2c967a499b3e3d1b42a8ab1adf9096c489cb23d4ead4859cff969045a98"
+        }
+      ]
+    },
+    {
+      "version": "0.86.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.86.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_darwin_amd64.zip",
+          "shasum": "bbe72dfa4c3b919fff7d3ab9ff182fb73a773783f62beb9214ddccae9d6828ac"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.86.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_darwin_arm64.zip",
+          "shasum": "dfa000660c8aeaf387a2563b42edad809f09a1cc34ccfd223cb6259b629c3eb0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.86.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_freebsd_386.zip",
+          "shasum": "926dab2862c4959cd03445acf618b0cb7d472d733e272cd43eba4e9caa460f70"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.86.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_freebsd_amd64.zip",
+          "shasum": "b4d88cc444b305c104d983515862c91f71041da4196a54cdb12d6b8c2204a180"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.86.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_freebsd_arm.zip",
+          "shasum": "31173ec932c06b981025a48af8e9d4fe561c2ec8ad71f291df29242433244dc4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.86.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_freebsd_arm64.zip",
+          "shasum": "9ab8c086b30c35acc562e46f944b08a84915b686a4f5a16386f9d0ea87085f4f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.86.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_linux_386.zip",
+          "shasum": "4eabf1633bcb15fb7673c408df16e5a536f8002392716d48197859640f3d1d3e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.86.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_linux_amd64.zip",
+          "shasum": "a8badd32f21be79b6aed9166e487607ca4890c3cfcc6254fcb19ab1f12729df6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.86.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_linux_arm.zip",
+          "shasum": "8332aa7c48bd0727fa7a7d7363703c6c329d73d8218b69d80dadef3eea4ef2d3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.86.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_linux_arm64.zip",
+          "shasum": "8ff6f26ed0c42b1483eaf7df6d8acd7235fe878ec100c5d213f34158b0d928d2"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.86.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_windows_386.zip",
+          "shasum": "de3cabc805dbf09ec5a1e327355cd537a57160370fcd4a681b6837667631621d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.86.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_windows_amd64.zip",
+          "shasum": "91ae730add17ed1718c61e0aa84c77c2e6614b195084d7b97925f183d9ea0387"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.86.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.86.0/terraform-provider-yandex_0.86.0_windows_arm.zip",
+          "shasum": "d1f138c1458f9e451d1f962eb478b6af16ca4135c1760d1a89b1cd2afad32fa9"
+        }
+      ]
+    },
+    {
+      "version": "0.85.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.85.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_darwin_amd64.zip",
+          "shasum": "0fa23c75f1d696ce7b56a42939e0222922780569f025b5a0c7a326283414567d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.85.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_darwin_arm64.zip",
+          "shasum": "a5d377280cf7d5dea1246423ab8ca016108aa549b437c64199972d12220e8ab3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.85.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_freebsd_386.zip",
+          "shasum": "6f77026173b578bbc948ba7e004b1202a54feb3c15a450aef16072d8e2a34544"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.85.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_freebsd_amd64.zip",
+          "shasum": "2a7cb6af6f52e52fc6127537241ffebdec94b6966e98b79577728cd39ee2f965"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.85.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_freebsd_arm.zip",
+          "shasum": "b94ea6cc2c8be7696fd6ff9b39f913bcd49fd402330f11a2c1365e0f6602abcb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.85.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_freebsd_arm64.zip",
+          "shasum": "a624da09899efe2576a9904aac1c70df1bd30e0f036657bf41e07653e077822a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.85.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_linux_386.zip",
+          "shasum": "4c906ebc1c39e693675a06a167b5c954d0658e03a9b41fb8d88db7ef2725c4f4"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.85.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_linux_amd64.zip",
+          "shasum": "940723bebff729cd9630a4efaa82e40b5f3272601d558190e1bea96aea86cf07"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.85.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_linux_arm.zip",
+          "shasum": "b618a6f50a77cd9aad146b75e750e2f919d6485ba83deb522937ccad0ff7b179"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.85.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_linux_arm64.zip",
+          "shasum": "7e2d3c83c3ac4d4e61ee3d34be39fd9f2bbba32493c0ade24c42143bcafb6efc"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.85.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_windows_386.zip",
+          "shasum": "87a9f8ed945ba3e20a8b465795629619aeb7f9fd5547ea1b5e9354449919f3df"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.85.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_windows_amd64.zip",
+          "shasum": "1485aa6aa8969bf5875ac81b4b76e6690cbfb7bee10431272ea10a87842ba245"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.85.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.85.0/terraform-provider-yandex_0.85.0_windows_arm.zip",
+          "shasum": "1f6821328e1266dd70d798735cfac6aa2e31ac3af42fda766f3691334c8882d7"
+        }
+      ]
+    },
+    {
+      "version": "0.84.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.84.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_darwin_amd64.zip",
+          "shasum": "c5938d84f1e7b351f8c0c8597cdc3045c2e1bc6ba1fdb76bd80085bc543abcb2"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.84.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_darwin_arm64.zip",
+          "shasum": "570350a201a0950229d90b73c06896006e3c8c3182eeefecded1c553eb578660"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.84.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_freebsd_386.zip",
+          "shasum": "3cd4e1af21abf943e5babe4ab0e29526f2cf6ebc5cc69383e063d8a935e8a0e1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.84.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_freebsd_amd64.zip",
+          "shasum": "75043db6ba6b878f3cb0ec1cf6b0d540e86e18f5117d5c34c10a183488d5b94e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.84.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_freebsd_arm.zip",
+          "shasum": "22733327467eb54c14e123a22fd02e7a4ef48d164ba64ca4ec43de581e575771"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.84.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_freebsd_arm64.zip",
+          "shasum": "636cb6a037349b1e51b5f49124bf00b07ecafb392decd9619fbdb016b13c95b6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.84.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_linux_386.zip",
+          "shasum": "9cafa11a23cb064a0e1dbb1ff1f6ba33b9c5b37ddd8cdaad07bc98a045ecf53f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.84.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_linux_amd64.zip",
+          "shasum": "4a2096232077cccca1a73251dc0b388927155d26029d7a5ba4412b2c447a99a3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.84.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_linux_arm.zip",
+          "shasum": "b15fd5b28b343b453c2a4742390658aba38b96623c2a9a6e4d1e3d74a033cec7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.84.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_linux_arm64.zip",
+          "shasum": "4cb45c1ddef6f70309cbe8763049754c4bca99e0d33b1a79774c2f1d4639d3bb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.84.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_windows_386.zip",
+          "shasum": "c96f34a68eb68a1f6b400d40e8ab46442cf3442807a1ce71b0094e3f96f4b2c2"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.84.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_windows_amd64.zip",
+          "shasum": "31907ce4d855930808ca8126f46729809b50f237fdb39b9ead793441247c99cd"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.84.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.84.0/terraform-provider-yandex_0.84.0_windows_arm.zip",
+          "shasum": "1d80e205bf3a45c8671c66e9eaf820fd40f85fb17ea1419a2a68c2615ac17dd0"
+        }
+      ]
+    },
+    {
+      "version": "0.83.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.83.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_darwin_amd64.zip",
+          "shasum": "d79490fee55bac1b533efd3e51bf7ebebb2327e6f964e17d1b190e9738c48ef7"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.83.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_darwin_arm64.zip",
+          "shasum": "2f673ed2f9ef164fb8ae8e40167cae055276571e99ec27d498208022171676b6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.83.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_freebsd_386.zip",
+          "shasum": "e6867c2476aba7d110cbbea3ec4032c9038ff7025c294206096f283e03db4cc4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.83.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_freebsd_amd64.zip",
+          "shasum": "b5d17ee08cf89398e8756277a1d1132e0824382fe71910e10610c4402f0aea1e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.83.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_freebsd_arm.zip",
+          "shasum": "6cfbdda36d91845a5fdd8692e48785cb4543dea4d7de9508485220aeae8d18ed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.83.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_freebsd_arm64.zip",
+          "shasum": "6f91b0a1a2f95668be9dda8c130a5e9b95a9c313f714fb0b4d6e168966420392"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.83.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_linux_386.zip",
+          "shasum": "aa6b1fd9bdce388ed04b203e56a527d4ad2b4fde0392556a3d25f09f3504d861"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.83.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_linux_amd64.zip",
+          "shasum": "a68adbe45738325ff4c95020b6cdd00673a18272ff49009c678eb9243c942f81"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.83.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_linux_arm.zip",
+          "shasum": "8e83b80b6adf45500abadad4e4f6b79bc11eaadef74a163546e159da854d79c3"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.83.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_linux_arm64.zip",
+          "shasum": "07425cca11b043e7427c30eeab562bac5bb291bcd5d72793240f7669fe657c54"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.83.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_windows_386.zip",
+          "shasum": "57977934b5de7b4075515ec4742c888dc70f6284054aa46f45619b180ec18633"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.83.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_windows_amd64.zip",
+          "shasum": "976de5b178c239f63db51140413f18f42b1c832296b2b33338c75906d1125e7d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.83.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.83.0/terraform-provider-yandex_0.83.0_windows_arm.zip",
+          "shasum": "ce28c1738e04b18b566c58fa3c6235f0946fb9f7babbae61fefba5cb8859a335"
+        }
+      ]
+    },
+    {
+      "version": "0.82.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.82.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_darwin_amd64.zip",
+          "shasum": "2be32aedb9b5e67bd2c9ec6c859292ae86eae380dd03df0128d12ca73ac99258"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.82.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_darwin_arm64.zip",
+          "shasum": "b5bdb49089002afbc3db6d44c9147a8eec77e1ff0a09b8436c94fa9a2e8432b2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.82.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_freebsd_386.zip",
+          "shasum": "56fa5bbaee3af051b0291f3c070e86748b3891c33f8c2b181b6e661d57a22a1f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.82.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_freebsd_amd64.zip",
+          "shasum": "c5a4c1741d9fc018c5bef106677c37f6bbe30c55b3d10e8678e0bba5b6f8895a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.82.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_freebsd_arm.zip",
+          "shasum": "9dbc83f25a0512b669b1bfad5e45c016059da4f7ee7178ec8a4170ddb2744286"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.82.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_freebsd_arm64.zip",
+          "shasum": "cf6ac149885d9e57691f384e6f0e5f999320b72a110dfe8ef4cbd0f2cc89e2a6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.82.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_linux_386.zip",
+          "shasum": "184b42e1771a76c352f36ad307e6ad6d9bfc6454fdc8d2dd1d8302e91e8f0941"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.82.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_linux_amd64.zip",
+          "shasum": "db15b2df15ad8a0cc54e910044f11af2c0ca7e3164d6b0ca6faf98b3efb48494"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.82.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_linux_arm.zip",
+          "shasum": "55aaee8f77b03e81abfb62fbe571d92af1448752e6d8117132ac42c2b7ffafba"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.82.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_linux_arm64.zip",
+          "shasum": "d694084351ae02fe81037a3e8fc1ab8042094d41fcfb11cc9abf2c05586e1d61"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.82.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_windows_386.zip",
+          "shasum": "eba5464c91b165a34ffbc92266a2557499659cce3daff4339b5c9048e1727f45"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.82.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_windows_amd64.zip",
+          "shasum": "08f6b4263e58ea5d0f70450e20d1ada5b0763d38f3839667168ba638f7d28f18"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.82.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.82.0/terraform-provider-yandex_0.82.0_windows_arm.zip",
+          "shasum": "eb6ce45d39a56a13221fafc16984211b4fb9b4263bd52eeb8d7a1a50527408e4"
+        }
+      ]
+    },
+    {
+      "version": "0.81.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.81.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_darwin_amd64.zip",
+          "shasum": "aa68798df93fc51a59e9bb1baa20b897bc88d96cad081bffc8faddb18a56054e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.81.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_darwin_arm64.zip",
+          "shasum": "28d61a396173b20197c9c9d21d9f556ad7c12825b9334196f8e03e0ecd18a801"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.81.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_freebsd_386.zip",
+          "shasum": "8aef4e15773323f7c1fcdb8c9d6a9ddf234371267f3a5e4e16241546c4fe23e8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.81.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_freebsd_amd64.zip",
+          "shasum": "4e3ef76f0bdc2df8f37a9127270e7af74c4745d177adec04eee27b4d32e8a011"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.81.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_freebsd_arm.zip",
+          "shasum": "4615a45b4416eb3c1bab362c4dea355eb7af953874c351d6d6a3822f61e07eb8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.81.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_freebsd_arm64.zip",
+          "shasum": "9b85ad56ee46bbd87f8a27bbe862df8621b4ae40896904179698ed07aaf45dbf"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.81.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_linux_386.zip",
+          "shasum": "2b7ef315e8e137d5a47301a0a3954409b7c82887001a32e2234933ddd0bacb2f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.81.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_linux_amd64.zip",
+          "shasum": "c0bb95174b0d1564e762369adb70ced965c9485f4265c178a270848f9ef45e37"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.81.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_linux_arm.zip",
+          "shasum": "3312c154209daff7df3611227b9ff25dcd577e8d71f150cad571662302a95a49"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.81.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_linux_arm64.zip",
+          "shasum": "b673365910e2ef2baec377eedbcb52aecfc866ef0902ce9308d8646fa843273d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.81.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_windows_386.zip",
+          "shasum": "de0116413d08d0d08caf2f32c0a53ef6cb1b469f55dcf4e77350d4e8ab1d1e98"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.81.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_windows_amd64.zip",
+          "shasum": "f2e6cfd3422e97db6e9a7672043873632824fa55a6f3a3f15ec5238e336aafb7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.81.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.81.0/terraform-provider-yandex_0.81.0_windows_arm.zip",
+          "shasum": "3b36c359ad3a3160fc2fef61026e942095e4f9c322c8fc36fcee07e3e8216d3a"
+        }
+      ]
+    },
+    {
+      "version": "0.80.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.80.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_darwin_amd64.zip",
+          "shasum": "1d6f334905292105696649321e3186c609cfc6dfba44cced1a9e046d4086b6fb"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.80.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_darwin_arm64.zip",
+          "shasum": "3bdc48029993edd9f208b9453f397b84e527548f77ba14af04345309869014b2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.80.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_freebsd_386.zip",
+          "shasum": "51c6d62a8560376503f5def93c034ce385f198dbc37b8a7d003822f596fbedda"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.80.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_freebsd_amd64.zip",
+          "shasum": "92cf69d9801eea14804a5cd6361025a9389f2bc681c931956f3304e710b5c4c0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.80.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_freebsd_arm.zip",
+          "shasum": "c605d21eb5f843ef92f8bcbf26e4e27198f1ba7dc65eba26254835a6ef59d030"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.80.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_freebsd_arm64.zip",
+          "shasum": "2b5d23ecffc063c7eb23ea979d33e99064dfb5fb7d0b95fdb334a0912c55a072"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.80.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_linux_386.zip",
+          "shasum": "190aeb8ee0faae2ff748fbf9b7bacf3f2d570f172d17e298339faa54d06b33e3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.80.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_linux_amd64.zip",
+          "shasum": "8a01016fb7a9d5c72450cfee27f8b0742cfaf1a7402e485b61b071ea12cd1853"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.80.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_linux_arm.zip",
+          "shasum": "7a1982bf8a45c362cf4331f921f6e81cc690027cf7c5dda2d3cbfa17bc801887"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.80.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_linux_arm64.zip",
+          "shasum": "a243287382c4f2fee36ed61d4dbc92ec7fbbd8c1455bbbbce755ddef084ee3b8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.80.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_windows_386.zip",
+          "shasum": "fe287ef65928c82e63d2c5fa9223a640ba7ac477e265a4364d5a5055eee518d5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.80.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_windows_amd64.zip",
+          "shasum": "6935a934bc5be5fbd655fcb5be1f93c2a22463c36e3f1bf59c26d4ae66f8627d"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.80.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.80.0/terraform-provider-yandex_0.80.0_windows_arm.zip",
+          "shasum": "eccfd986e8848a6bd23f722bfb826e7b59ac0352a1f54df7e5ad67cc6d23bc89"
+        }
+      ]
+    },
+    {
+      "version": "0.79.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.79.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_darwin_amd64.zip",
+          "shasum": "aaefbc04515dca86f32b70c05b54cc1e4c9a69c28b6c2fc1569ed832b858afc0"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.79.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_darwin_arm64.zip",
+          "shasum": "444f1164b4b013d38e424a50a675bc01260691161110d9a0e0159eeb70665e78"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.79.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_freebsd_386.zip",
+          "shasum": "73dd34dbeef7c02b7e1cd1f20d45b98df3d83f209dca4cd7538ca86ef1673a50"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.79.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_freebsd_amd64.zip",
+          "shasum": "41dfccbfeb2bb37584e6a1ba1b351a6d3b28637186bdb7ab931989225011080d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.79.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_freebsd_arm.zip",
+          "shasum": "71c1541aa70a57ee2267103334a3947ae943481f55309ed106c219b94a27938b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.79.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_freebsd_arm64.zip",
+          "shasum": "1890142496bc627823d37f60ecb9adcadfc1aabb3ce810073d93b2544cf59f31"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.79.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_linux_386.zip",
+          "shasum": "477fb74566d5c7d4fa60318dd5608b3760cbf55ba0c20e5ba053b3f210c1e8c6"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.79.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_linux_amd64.zip",
+          "shasum": "4d16bc406b1423414dfa68614a086c035817662aabdb85d18180311c42eb4d12"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.79.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_linux_arm.zip",
+          "shasum": "78e959c373c6b3723c72a56f21f3ec7244759e1f7fa5580aa5fd76a6758f162d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.79.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_linux_arm64.zip",
+          "shasum": "66010091867a4d18cd95bcf20460f6309371487d48fca50bc441a11c2f0b4859"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.79.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_windows_386.zip",
+          "shasum": "55106064cd8bccbdc92ccb1e2505bc416afadc2793ffff11f2e044c6e2c5971f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.79.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_windows_amd64.zip",
+          "shasum": "63f3e076ccf8a8d39c6ba9058b7e02c685e1a5d88b8e919d6a8d52020809f213"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.79.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.79.0/terraform-provider-yandex_0.79.0_windows_arm.zip",
+          "shasum": "bc5ef88ecef50114bfe716ce49f7835992e3c7abef5b69394786def5d1c501dc"
+        }
+      ]
+    },
+    {
+      "version": "0.78.2",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.2_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_darwin_amd64.zip",
+          "shasum": "757cfb86783b71c1828db7f8dd9428a421e4e112a4cc3aedb29aa5a603290fb6"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.2_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_darwin_arm64.zip",
+          "shasum": "658e1e16832e6cde22d2ace5fe642a28aa5d1abe754077096c3a0ebf8fa92060"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.2_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_freebsd_386.zip",
+          "shasum": "e85e52831426537683265fa4481a56d372d4fb31eaf5b2f36f27638ab387748c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.2_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_freebsd_amd64.zip",
+          "shasum": "0a5d77fcd5c50e5d572cfeec0b621f847828c9f9d222bb39c9801d9b7defd3da"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.2_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_freebsd_arm.zip",
+          "shasum": "79c2edaf99455ba6a13a0b7e11637cfdb256229819d72a26e5c2dd459e0240fd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.2_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_freebsd_arm64.zip",
+          "shasum": "0af8130c7bb8829814200d2bf00a20ab2f1da0bf0b1318ce71744c790bba692e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.2_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_linux_386.zip",
+          "shasum": "096cf39609effeff00d775dce0e40ddbe3f5587cffaebc4c898f1f02ca5a2138"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.2_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_linux_amd64.zip",
+          "shasum": "b55f8f77a02f2e457ec00755cdeb004802cdaf1c344af8bbbe31b11c5e745264"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.2_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_linux_arm.zip",
+          "shasum": "f47be285f75a6d1b4cd7f8959eaa7eec7550b82cbdc59a0f8d77c9d060551971"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.2_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_linux_arm64.zip",
+          "shasum": "e4b25c05e037ff9420f920befb6aad93ea6eb494a04155fbcc780d2f91221631"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.2_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_windows_386.zip",
+          "shasum": "45569f3b2e8f5145efa1759de627d53f55702577c2409cd1a568df09e4fa9a41"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.2_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_windows_amd64.zip",
+          "shasum": "43c5a28dce864de823452f31b971c1db883f9026deb52c3038e4cb46968d4df6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.2_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.2/terraform-provider-yandex_0.78.2_windows_arm.zip",
+          "shasum": "376cf8bf27e631fa8097564386c333605a9c79fc8729bb093b91435375f906aa"
+        }
+      ]
+    },
+    {
+      "version": "0.78.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_darwin_amd64.zip",
+          "shasum": "c2471cfe0a07aa74dfa0df885dd537aae0dc47244c3f2bdc756d2e984c7f3679"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.1_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_darwin_arm64.zip",
+          "shasum": "9067159755defa4a6dd906bf6704635f29444e6847cc84222efd37f428b178c2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_freebsd_386.zip",
+          "shasum": "67be6af68abf8630b545a16f160d0c3fe3f8967b68842057b1b4f4bfa10a9c3e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_freebsd_amd64.zip",
+          "shasum": "1971753942dffa8950eba4f6a75885a2d0d3d29e7f07102ca2ddf7b9ffea9eb0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_freebsd_arm.zip",
+          "shasum": "17bd63253b758e076d6d6fc88b9d960e1b92d3e3b35ae45bc9fcf6a01acb0cef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_freebsd_arm64.zip",
+          "shasum": "524478077b53aa46db17ee4e2209fb82cbe8c8b8b12db3d13e5a3874a03140dc"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_linux_386.zip",
+          "shasum": "4e79f8cbbe2baee1d1b70b983c567d23dc93239bf2d56c1a73abf22aae7faf21"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_linux_amd64.zip",
+          "shasum": "52ee57518d7f3168b7fad2c2ce81c73ff8bc116f8fab476290895273eb943d33"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_linux_arm.zip",
+          "shasum": "dd8db85c601c2864b0e4faff7640bbbfee78c45018fbece31baf5471cc747f3d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_linux_arm64.zip",
+          "shasum": "4395b7b1496808a48d4550edd7eb644417fa3c3db261e9d409c3d56a0adf0234"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_windows_386.zip",
+          "shasum": "1b023c8d3eb47f99d760439446afe23dc42190ef0cc14b65d55a3007f258e1cf"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_windows_amd64.zip",
+          "shasum": "3e84327ed968ad5d58c482959d7665fd1ad367cb41530918f2a823c3a9e096d7"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.1_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.1/terraform-provider-yandex_0.78.1_windows_arm.zip",
+          "shasum": "804f4ab666acc5971da378d8b2dfbf22aa7646bc22e8d5d7e9682dbc795ecc8f"
+        }
+      ]
+    },
+    {
+      "version": "0.78.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_darwin_amd64.zip",
+          "shasum": "abac9637cad0420383ca0d6eed2957fab7311b65ed1d7ca16cbca7c4afcce53f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_darwin_arm64.zip",
+          "shasum": "965c97a2bcd6b631eeafbe8c002185c326194da52001cc993830c5ea20c363f9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_freebsd_386.zip",
+          "shasum": "3c45603c1d6ac942a1ae9d3899611aa62910d8da0a38295e5513f67b52af0ed1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_freebsd_amd64.zip",
+          "shasum": "0e4053235943305179357fc5d9d94b26cc73724d69162cf7853af6c012ae7761"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_freebsd_arm.zip",
+          "shasum": "f42582a15f74bf7708e3589502d3d9547d627a8d45d0ebc5c9b77b5f68955fd5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_freebsd_arm64.zip",
+          "shasum": "364aebfaf0b72a2e90f96d5e61a41eb924d0ed9f793523a8303cb017123a1552"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_linux_386.zip",
+          "shasum": "2b9e4ea2f49677dfa7a248c22d6315520875fe45eebe230c90a2b6edab556472"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_linux_amd64.zip",
+          "shasum": "b69d39b9de809f5f7419c5ba63e7dc09b747c45fbd127f851d4bb7f42cbca213"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_linux_arm.zip",
+          "shasum": "a7c9503d2feb500fa110e61cbd4d86c0b5ca6f6c4360189afaf496ccfdb27c43"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.78.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_linux_arm64.zip",
+          "shasum": "f12da5fe529e80450d9f8263d4957b8024fc5c09f5228a0012fb4ceaa05b8f70"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.78.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_windows_386.zip",
+          "shasum": "e0733ec3b4b523676063d21f6d6723722d4bd15bc27645091e806ead0ad92142"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.78.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_windows_amd64.zip",
+          "shasum": "cbf493011c5bf29045633b901eaabf45f0803730f53019330cdc510b0d470ab6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.78.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.78.0/terraform-provider-yandex_0.78.0_windows_arm.zip",
+          "shasum": "20cda6c1e273e63f31ee797b6e45ffb8f4b07e4d5fbd6c9db3894f849d97a721"
+        }
+      ]
+    },
+    {
+      "version": "0.77.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.77.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_darwin_amd64.zip",
+          "shasum": "ceb96a386e54cf67594c8952e3ce276f7d273dc00fde9584bca23077811e6896"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.77.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_darwin_arm64.zip",
+          "shasum": "b6da892ca8886a0d95fd85cae43ddfd0b84659e5b43aba9918e1f0920c9cd8f2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.77.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_freebsd_386.zip",
+          "shasum": "b3c9e16e4a98a27ea9502d43538aa7270f97e0bd32824e0ad6d55151c268539c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.77.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_freebsd_amd64.zip",
+          "shasum": "656c24bb684e2c97c61035d8810b63d5de787cf7bd0bcd2f5645083adaf3a4da"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.77.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_freebsd_arm.zip",
+          "shasum": "6250fd223d445cec936cddce40ce1162df4efd4df560ca189e9660c6931fb721"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.77.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_freebsd_arm64.zip",
+          "shasum": "5afc3cfc22966b2675dfd9b31c619e93ab86f245f79eb607a0977074084e05bb"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.77.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_linux_386.zip",
+          "shasum": "e9c6dae318ffd3ed6e4f0a53deca090e19f852031ac2d5f49d14696f23a77b37"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.77.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_linux_amd64.zip",
+          "shasum": "4ee2e08a5fd883dff0a7634e8f039b932f4b6e148dfd8783e0342fbb1fe5d57d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.77.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_linux_arm.zip",
+          "shasum": "44746d7f622e55835f3e22045a3255edfe1c228ea850663c31b6127ab95464af"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.77.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_linux_arm64.zip",
+          "shasum": "092bcc8761aa786caf9bf720819ab26a3e35691adcb5db726d6c3f969638aef3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.77.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_windows_386.zip",
+          "shasum": "2b33648cfa7d2c18e80bd6502f4336e0d4ba837cc0991b103bc7cdd10509b925"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.77.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_windows_amd64.zip",
+          "shasum": "d827f845dab1892bb318c54322bbe76edc8f6ccc9125748bd5d4a3629bb44a31"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.77.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.77.0/terraform-provider-yandex_0.77.0_windows_arm.zip",
+          "shasum": "0ba8031b73d9ce18dff5921b93ecef4d6cc738fc4bf5afb331ce71b9dce30aac"
+        }
+      ]
+    },
+    {
+      "version": "0.76.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.76.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_darwin_amd64.zip",
+          "shasum": "24c3bc8a994d4ce5e14a9c3c85db73fbccf473010d1437356e3b6a5ed35b9f21"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.76.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_darwin_arm64.zip",
+          "shasum": "eb4e845adce010c4526b740a830d81466ff592a578b1ec9ce5d7b052df9bfbb5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.76.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_freebsd_386.zip",
+          "shasum": "dd2677d8ddfe2cfcaacca07b5411104e94685dca9f7e18cb7bb6610ec0817d3a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.76.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_freebsd_amd64.zip",
+          "shasum": "bea7cb3afa9d88400bf2dd0d041c881c906407afa7df0adb186d253bea0f1658"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.76.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_freebsd_arm.zip",
+          "shasum": "864e95be9c22e3a83962e2a086b600b564a5ba611e7936a87b91463d445db1a1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.76.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_freebsd_arm64.zip",
+          "shasum": "d628cf7170424b74fc4e5b5ea3afcd027d61615041e442303ac40fe8783e5c0f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.76.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_linux_386.zip",
+          "shasum": "f2c3d9648618e8223b201f26b8d1abd6964d5027f5217016e6f7700f4b726153"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.76.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_linux_amd64.zip",
+          "shasum": "6ed14b4b76025051efb257b8e314db2d63121f7ca445d0cf3048363c22b73c66"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.76.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_linux_arm.zip",
+          "shasum": "2f5dbbdc17ebca9cbba1a85600fdc20f6e99f865f662ae3c6c4e449be789e376"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.76.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_linux_arm64.zip",
+          "shasum": "232da041110d68e4bff2e8f5748b79a57eebf403e23c238fcd734c5e378169a0"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.76.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_windows_386.zip",
+          "shasum": "131a43132ccfe9279bed0eac23767323116921af221055dcd4fe005e0ba9dc97"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.76.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_windows_amd64.zip",
+          "shasum": "0ca994c21bb167dd9f69d4a6670cf85e30c7dd3dcba7e80ad893203b77cffe92"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.76.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.76.0/terraform-provider-yandex_0.76.0_windows_arm.zip",
+          "shasum": "ea80ca47bb8867799bae8c07c41a80daada6bde659e62a47e1d92a60d16c3959"
+        }
+      ]
+    },
+    {
+      "version": "0.75.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.75.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_darwin_amd64.zip",
+          "shasum": "d56a7267594a21d7a2464bed7336415b7c8f5599d25d0c6131cf83776c63c58b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.75.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_darwin_arm64.zip",
+          "shasum": "0c431076eebe47c700f271ab7bfa0a21dcb10737d2a29feb2d62164cb3989fcb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.75.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_freebsd_386.zip",
+          "shasum": "68d3c76ed8f973523fee58e178434c8836759d432cef91b9c09b135f503b56bb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.75.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_freebsd_amd64.zip",
+          "shasum": "18e9d7533f165a1b17904f63d46a9d3170d9da57b04039f0e6dfd3fc66b058b9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.75.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_freebsd_arm.zip",
+          "shasum": "2fb9f29832f5bca80c7ac026b348a7b09d40683aa6aa1911cdf5a5720dc39dbc"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.75.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_freebsd_arm64.zip",
+          "shasum": "441566b6f0a556da4942341161c73841131762287fa42a2a9a78fc1acd5c0fae"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.75.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_linux_386.zip",
+          "shasum": "039181dfb7dc5849723a12e36a1dcac98f6aa9f6a3b64456d5a5b928eabdbac9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.75.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_linux_amd64.zip",
+          "shasum": "52b866a2dbd4ec14a9bb22f6f3db4f73ab9d31a45d4ba84d1c8ba70f50b053b1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.75.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_linux_arm.zip",
+          "shasum": "4095fcc232cadac9f7308415564753ca73eb4ef6eda8b7ac79d12e836ca84d00"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.75.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_linux_arm64.zip",
+          "shasum": "af71fa95c6451c503c91a911689e648afc9b7b1d3a95d467298d67c4b7b81552"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.75.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_windows_386.zip",
+          "shasum": "e0b080b5e191950718d333e1d0ef0f96597b376b72ba60a501aed3f71f7b4234"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.75.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_windows_amd64.zip",
+          "shasum": "4dec3ad41f33d8c78fd4f4e2abba420bfa4a12dcc670dc15091af82647f7e0f6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.75.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.75.0/terraform-provider-yandex_0.75.0_windows_arm.zip",
+          "shasum": "338f73ade74e21cb58743e4d5e6d3e6fa36550a276469b291133b5297b2de6bb"
+        }
+      ]
+    },
+    {
+      "version": "0.74.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.74.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_darwin_amd64.zip",
+          "shasum": "0ae93ec70084677f0026c44513c99252dde3be31435c4d1ef5259c8ab5bde225"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.74.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_darwin_arm64.zip",
+          "shasum": "f53439d40f328b0e4800d8ed00f18bc39b2b03ac3d776b0c7b497722d7f7f0b1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.74.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_freebsd_386.zip",
+          "shasum": "86143792b6395e582b2363ac052675e51741bb9b09dcdabc3f5512f501d49fe5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.74.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_freebsd_amd64.zip",
+          "shasum": "c7114896af26237cd01395c10f81a670752cc103d6ce602e88f81f205987e617"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.74.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_freebsd_arm.zip",
+          "shasum": "aebf8480d0cccbca57a085ccabb5af23d0e35a8d6e54b1bef15ae6432cfdf229"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.74.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_freebsd_arm64.zip",
+          "shasum": "96ca7255602e1f38b42515533bac2e77313163638ef6e68c08a7772ab2515ed6"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.74.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_linux_386.zip",
+          "shasum": "883a06e44b64764459c1d0b37f24b52134a9fb95d7332f95b2b3c2271b76a958"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.74.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_linux_amd64.zip",
+          "shasum": "01914a42590934918a312324fcf8b0b342da113da76c13bc00d40b9d3c0a78d9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.74.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_linux_arm.zip",
+          "shasum": "59acf5f27d378069d7332549c1645e03de2a2ff9208e02e1546491d276031e23"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.74.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_linux_arm64.zip",
+          "shasum": "9bad5d9a023aa238f34db6a05c1ea67f19f2c27fe640be76ec77d850e8cbecf6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.74.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_windows_386.zip",
+          "shasum": "6662ab75109138675de0060957ce259c96c141e87617bc211dd80f1213d69419"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.74.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_windows_amd64.zip",
+          "shasum": "ee82069747c38737e88f01007de0a1180770c14de26c13b79c9cc340204237fc"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.74.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.74.0/terraform-provider-yandex_0.74.0_windows_arm.zip",
+          "shasum": "c84819a708453cc321746eba5fc4bab972e3735607b6533b3d9bab79c3f0d196"
+        }
+      ]
+    },
+    {
+      "version": "0.73.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.73.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_darwin_amd64.zip",
+          "shasum": "737270dc5eab372155f2080fbd5c6c3eb9821148425b7343e52f79ce3cc073f5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.73.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_darwin_arm64.zip",
+          "shasum": "b74d9e60249e74ddf0d4413355863705806b7aea66c645aac511d7dea52bd884"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.73.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_freebsd_386.zip",
+          "shasum": "d01eef1811d37a0df249c32eb7420223f2ef551d79c79ed50eabfd97b92f7ccb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.73.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_freebsd_amd64.zip",
+          "shasum": "ddf687eb2da48d0333efbb782703e701fa843c11501faea5755036705185f7bf"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.73.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_freebsd_arm.zip",
+          "shasum": "7958f3069ef094962af7c05f6ace0414dc8d7677f4ef228654763ed97defc736"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.73.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_freebsd_arm64.zip",
+          "shasum": "ab338887cef821ca8d66714ea9f5614a1ea3a9473b602935daaa7d347927b65e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.73.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_linux_386.zip",
+          "shasum": "2c4b263a4fa25914f95e83482fc8a9a9f71818018bfd2d5b95a66cb40af8783d"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.73.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_linux_amd64.zip",
+          "shasum": "9a2226b572f2df1914c16d8b20fcfb8d5cbea72b74c97a381b4c8b30987c542b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.73.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_linux_arm.zip",
+          "shasum": "e143f33fe8acae7c8ad3927c8a8ede0074a719bde325b24e85f7aaf6f705f71a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.73.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_linux_arm64.zip",
+          "shasum": "911d3fb6d394ce0b1c91f0e52a3b545b06fffb821c947665c8b02e66ef425052"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.73.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_windows_386.zip",
+          "shasum": "9146b05e36af969b992286e63c3628c3ec54d32bb568806caeb245c224cb28da"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.73.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_windows_amd64.zip",
+          "shasum": "2d7c31b20a8968ed149454b1cf6befec7d73bb890c760bc74f33701a2e240f3c"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.73.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.73.0/terraform-provider-yandex_0.73.0_windows_arm.zip",
+          "shasum": "e5e9eba636f385571a2adb2e219d8a54be77a5059003bdf1a611ca175dee68b8"
+        }
+      ]
+    },
+    {
+      "version": "0.72.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.72.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_darwin_amd64.zip",
+          "shasum": "54335ba7e4b6bf32194a53e73fb193af3aa39e45473d72b04505d0455d1a11b9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.72.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_darwin_arm64.zip",
+          "shasum": "7ad007c9e1fa2e34a98ac9259e6c86b6b1713423b0f8f2293b00f360392cdd9c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.72.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_freebsd_386.zip",
+          "shasum": "f3a4bf67ca6d4d5a8dd401c0597261a1fe1514cb88effb410d9d46e588938b2d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.72.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_freebsd_amd64.zip",
+          "shasum": "7b400ca2fd85e04063b2a10f3ef88ebfdf877fe7351ebdc02969a35757a3d915"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.72.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_freebsd_arm.zip",
+          "shasum": "1af6bcb9ddbfe5c3acdbfa9033d6baebcd6e391ff78795cf323f7b9520b330bb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.72.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_freebsd_arm64.zip",
+          "shasum": "30d6f37833bb25cb0723f9d32d4bcd8f27cdd750021daa6afbd36948e527094e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.72.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_linux_386.zip",
+          "shasum": "e20d06595ee96f01b734de9755d6e0a6f7517107153dcde221ba7026321d8241"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.72.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_linux_amd64.zip",
+          "shasum": "52504aa082ca8e83ddc1f0c4dfb08f562b05ae16fb633e12cc7efa66a4c64a27"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.72.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_linux_arm.zip",
+          "shasum": "719f116c71cafa5080f6491655b619b631d96f5f656c875989d678eb85c5df2b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.72.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_linux_arm64.zip",
+          "shasum": "339faaa2b617b2e214cad4dd36981512c954f996cf2aa8bf80cdc1d2968e8e3e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.72.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_windows_386.zip",
+          "shasum": "1eafbd1eeab72cd0f9d91db62e73e43db7ab3472b742bf4cf8726a20d4e12447"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.72.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_windows_amd64.zip",
+          "shasum": "5990c712e02970a6ee4968522c708b29ade9e19b49fcc0c21f1d7bcd448093f1"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.72.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.72.0/terraform-provider-yandex_0.72.0_windows_arm.zip",
+          "shasum": "027310080895b4a2e903390155f0e481517ac59e8f6e3dbbcdf744519f18620c"
+        }
+      ]
+    },
+    {
+      "version": "0.71.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.71.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_darwin_amd64.zip",
+          "shasum": "f12735426f47611b7f6af833ccfc597dc06f3b367465fcc0f274e9258b12f53c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.71.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_darwin_arm64.zip",
+          "shasum": "0bf1c79332d3fd7cc4cdc98e2ab4b3802e5ccc70c112f29d95df02ebfe9d8ce5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.71.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_freebsd_386.zip",
+          "shasum": "1920063af1653d6347cb31dd8188fa9d0cb4e34e8fcdc34fbde8406306ff9b93"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.71.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_freebsd_amd64.zip",
+          "shasum": "82596fa9f7260ae5c0e018ada10d5b00322c94e5e138ce7bb3b75b6b3508fb31"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.71.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_freebsd_arm.zip",
+          "shasum": "cec8eb11b8251ffa2ef0dd7074352dd50802bfffb13d50d107e1b0648ee54b1c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.71.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_freebsd_arm64.zip",
+          "shasum": "168edfa5200fce0434f13274e15ffb8f0473050ec64a64eec5fd12c805da98db"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.71.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_linux_386.zip",
+          "shasum": "1250df0ce05af94283ffa0298f73bb2f4b4b9bf409bdedaf4af870e0bbd64629"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.71.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_linux_amd64.zip",
+          "shasum": "61bda32f11159cc617ed388a1b674898221e96be7de53e89a26d4b8a03af344f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.71.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_linux_arm.zip",
+          "shasum": "9e3153b29906f34d575c9e2945e212f7aabf7e06020cc418bc36371e559c5576"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.71.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_linux_arm64.zip",
+          "shasum": "515d78a40dd35d7045d1a7cfae7575cabebdd59789f3c4653f580cf5dcdef236"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.71.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_windows_386.zip",
+          "shasum": "202028d77aabcf49eff00d67efa2e6a44eb5684adc753f6f174706263c3815a6"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.71.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_windows_amd64.zip",
+          "shasum": "46e2e99b2d9195fc49aa4f0e1712d5e0954336a34267966fdbcb8b948fe7de69"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.71.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.71.0/terraform-provider-yandex_0.71.0_windows_arm.zip",
+          "shasum": "1618f2110d929e3e143ba02275409ad1a72743a976f54afa3df55dcb4ff22590"
+        }
+      ]
+    },
+    {
+      "version": "0.70.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.70.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_darwin_amd64.zip",
+          "shasum": "c5f2d716f5b924429f7ee94402df3e04395755fbcc5fa3e58136beea5461fa7b"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.70.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_darwin_arm64.zip",
+          "shasum": "3e8e399861b0d44f1279fb2a4ee77e93a08379a0ed6f1ddef2327bdbf4557afd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.70.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_freebsd_386.zip",
+          "shasum": "9b5cd6fabd72ae3d5689c55dc5dbcff6d47fe13a03a0b5bf489688f1fccf927c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.70.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_freebsd_amd64.zip",
+          "shasum": "441878ecfa6190abc7407176e1fc35b7db965c8decfa7dc08c396e20a6e3eb98"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.70.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_freebsd_arm.zip",
+          "shasum": "571f6751385ecfb2efce0856c44543c06213bb2a1119cf5e5e2aaea75127a87a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.70.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_freebsd_arm64.zip",
+          "shasum": "973ad38637ff0ce6a647ea9dc0ff71ee4aa1827cc90785653174ec863e79cf01"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.70.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_linux_386.zip",
+          "shasum": "60a3e9df4531d0ee8988e4dff67652f996a08450d4f4950ec2401d24cbad4247"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.70.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_linux_amd64.zip",
+          "shasum": "489c96cd7c76e3cbfccb5c871ca9db8b05b8638c591fcf6cee2dec6f6774bb31"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.70.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_linux_arm.zip",
+          "shasum": "8819043876d846be1cf2c88fac17491c787109c6ee1031dba75084bd7032c846"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.70.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_linux_arm64.zip",
+          "shasum": "efd27a92431c7e086db88c3c3630dcff193d9fa6f6038af40d6ac387b2a84cf9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.70.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_windows_386.zip",
+          "shasum": "b0a7f983bdbd6c56cae69b84a15fcc5b307a60790249891dbd913f3edb0130ef"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.70.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_windows_amd64.zip",
+          "shasum": "d0fe13ae0d86cc8ed04072ebbae31c26ebd714ab3a87ed3457a17c8f576c83e8"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.70.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.70.0/terraform-provider-yandex_0.70.0_windows_arm.zip",
+          "shasum": "115c12664b47c07083a26aad99536a0734cb8e1a8849c3f9dfd0d75011887a44"
+        }
+      ]
+    },
+    {
+      "version": "0.69.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.69.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_darwin_amd64.zip",
+          "shasum": "895c2ec3e18c0e8d0298eabb7bab72f7cfc599fa46093bcd81c322885e9641b3"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.69.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_darwin_arm64.zip",
+          "shasum": "258e697a8caea8b3ac0d3d07e84e3a346e4241a460763ee7de6bc24c892fe89a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.69.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_freebsd_386.zip",
+          "shasum": "5cced842d70d9dcc92615e62fdcfe91c20234181bab89f576754fad4ae0867ad"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.69.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_freebsd_amd64.zip",
+          "shasum": "37813b710033fd60a2a2a92dfd727185a3a4e7aa7be405b746612c554b91ae20"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.69.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_freebsd_arm.zip",
+          "shasum": "cfe8c340e02eab748de31187429d5c637bf011f39552bf14eb804224f3ec02c4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.69.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_freebsd_arm64.zip",
+          "shasum": "a3c134924226e335b346ab907e7243427d3f11d25232fd06ab90a668014e793b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.69.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_linux_386.zip",
+          "shasum": "8da0b764d12f211b76b72e30b4e69417802148b0d891ec9bf3d43b2ef0b4d19c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.69.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_linux_amd64.zip",
+          "shasum": "272bc42b6c61989239f8fa074cf59c01bf3e3d2b2bf1aa382c0641372e5d02e8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.69.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_linux_arm.zip",
+          "shasum": "4ede75defbf576e16b065b643b57b4db25e36df5953e2e34951a7a712183613c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.69.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_linux_arm64.zip",
+          "shasum": "b88b205e1f3d0263519d4764016498e4a723ac732ab89f185454c6c542172124"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.69.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_windows_386.zip",
+          "shasum": "55d6e15d9a45cf81442362056e4b58010eeb76e687309eed2cb3309971409854"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.69.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_windows_amd64.zip",
+          "shasum": "5978c1e099be412fb8d7a5966193c01445a79a32dde8b74ddd354bfc1f04a23a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.69.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.69.0/terraform-provider-yandex_0.69.0_windows_arm.zip",
+          "shasum": "4234d0563e5cdb6e230ba0075e6ccd42d4a4021f19f6809559ac687eed51a59e"
+        }
+      ]
+    },
+    {
+      "version": "0.68.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.68.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_darwin_amd64.zip",
+          "shasum": "220b3c589705c90f9fc286f7b82c8bb47a140588141debdcb83f08b050b0ef25"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.68.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_darwin_arm64.zip",
+          "shasum": "9abfc82de9967925122acaa91e0de6ea513725d79909fecf3f0ef5d3eb5eb91f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.68.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_freebsd_386.zip",
+          "shasum": "7ce9481d53e8aa134f5702849761d3b913483bcf517dc9bcb47f8a03879747d5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.68.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_freebsd_amd64.zip",
+          "shasum": "692b2126e73d442c8309fd24adf2c85bcd24cfcd3c74d0ea3cec349c496c6d0d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.68.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_freebsd_arm.zip",
+          "shasum": "723d0d43509617e55e072603bcf0a4fca7a0c42bc72a7c3c0d9e078011030bf6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.68.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_freebsd_arm64.zip",
+          "shasum": "15c2da894015bc049ccc50758d2fb3efc6ccbfe1854962f7b116c6865e660c29"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.68.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_linux_386.zip",
+          "shasum": "16420d98d4b23ac2c401e5baa62b26d76e3275123ec8bab4ec3a6f6714eb8ef9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.68.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_linux_amd64.zip",
+          "shasum": "23f374c51846989f38573fb5b2be88d1831ecb92cf86ed68e2137e33bf68b963"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.68.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_linux_arm.zip",
+          "shasum": "67a43978facbe8f4f3481673aaae5ebefa47c7e701a7827fc9ae21676d5220a5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.68.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_linux_arm64.zip",
+          "shasum": "50a10a4e8c05b5d800699d33d03322a8b566291071231cf95160070e9fcf421e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.68.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_windows_386.zip",
+          "shasum": "f0a74f1f01bc3c3d0ed6e3bcbcde587a143fb17fa6bae0c6751bdde2201fbf0f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.68.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_windows_amd64.zip",
+          "shasum": "edd6a534ed56e8ab50c802c8dddbd326469b4a093f071ca0b7e6cd435a4ac474"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.68.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.68.0/terraform-provider-yandex_0.68.0_windows_arm.zip",
+          "shasum": "9ad5a083abd7d7d053b3eaff76a8dcc9bd6b1a976be4941c2db7ee454e461d47"
+        }
+      ]
+    },
+    {
+      "version": "0.67.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.67.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_darwin_amd64.zip",
+          "shasum": "1fe05e46a8d0dee13c77f61437ccacea76b6ecb37088c3edadf664d82e2783f5"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.67.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_darwin_arm64.zip",
+          "shasum": "9882aa75ea2b5f9f3aa3db6df209092b99953941d5f9f1ac3e1c7b20c8a743af"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.67.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_freebsd_386.zip",
+          "shasum": "4eb449327f961c54f8ae897cf7b120f5b48c1243669a22f426b8d6659000287f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.67.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_freebsd_amd64.zip",
+          "shasum": "0cfe8f6e6334bbf6dfaa75a6851f3dd129830a01645e5ef9c16720b1f950b924"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.67.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_freebsd_arm.zip",
+          "shasum": "bc3e844eb32f839bd118c788716ec215c27d7fb98eadb2817faffe2269278a0f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.67.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_freebsd_arm64.zip",
+          "shasum": "3e6d12c816599f0854c06fd29fceafd9c725ec9f4604f60ad2889858cdf8d1db"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.67.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_linux_386.zip",
+          "shasum": "6e8ecefcae0d505ef1665f57398416d12bcf588f2a5fb0575a4caca8eb4e2a88"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.67.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_linux_amd64.zip",
+          "shasum": "3050a6ac1d7310f0eee63165c2cd4b7463f6e3e08333e82c550da5cf96bafffc"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.67.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_linux_arm.zip",
+          "shasum": "87e2139795f71a55b250c365b1b7e4c35e6edaf9a81fa573b4e9f734644dc7ea"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.67.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_linux_arm64.zip",
+          "shasum": "6c83a9ffcda072f359073bc1c93b4f018cc59be0f730888a02c7a4266a9ebd51"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.67.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_windows_386.zip",
+          "shasum": "5a1b0cdc0c07095e4dd34fdf7f34e48ac8db66237f999b4a52fa57f643b52857"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.67.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_windows_amd64.zip",
+          "shasum": "a4f915b52514a06471d9b2b2caf912d876a28ed83a5fb1df9717193a2561716a"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.67.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.67.0/terraform-provider-yandex_0.67.0_windows_arm.zip",
+          "shasum": "7aede444c01e82356ca18f606b61e794ffa74ba79792f2b3651a304bc9596168"
+        }
+      ]
+    },
+    {
+      "version": "0.66.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.66.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_darwin_amd64.zip",
+          "shasum": "9c91491d455bc593824c7443abb4f572cec89f323fec7d9d13a27b4d2d40e0fc"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.66.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_darwin_arm64.zip",
+          "shasum": "609f33ad81afc824654e6d22fcb9ddf7e2cebb0eb7bcd5a97a84af489f1592ce"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.66.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_freebsd_386.zip",
+          "shasum": "dc8cd0d2af03079783498d67a006409cd9ea0890e08a9d47df63c649fff4016f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.66.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_freebsd_amd64.zip",
+          "shasum": "2eb19ceb8f054f17e6ce81735ae49898ec16838a5d4bbd691de86a9ebc734a96"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.66.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_freebsd_arm.zip",
+          "shasum": "e298c674aa1bb051a77600455e1bc10f71ffdbd16f84595940510402f5e72b26"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.66.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_freebsd_arm64.zip",
+          "shasum": "77283a62ffb53dba54b9e41dbdb93c63c942346930b6be5a3e6549e060a436da"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.66.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_linux_386.zip",
+          "shasum": "43f1c9f0c37b576a0fb66481a4668f0f0feee02e1b11738ff92af435996adb2c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.66.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_linux_amd64.zip",
+          "shasum": "8a12d8cbcacb07bf433814e3baa36ba4c771d97653ba46d645ecf910a683aa4c"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.66.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_linux_arm.zip",
+          "shasum": "b3b37f8337615a716261d6d43849efdcbe6ba085a2417da7b25be9ec4ca284fd"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.66.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_linux_arm64.zip",
+          "shasum": "44ca4c74744e971b837ed75875c0fba625daef38443483bf8104bd6c928943c9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.66.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_windows_386.zip",
+          "shasum": "6deacbba6fa4e99d2c3307152a9d19836f9dbcf538aa2ca3e5c82f77bc2031a1"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.66.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_windows_amd64.zip",
+          "shasum": "6da9c95ba8209e8d8a5ab49af08ccfaff41f91b1d5e548209bf752751d179d88"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.66.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.66.0/terraform-provider-yandex_0.66.0_windows_arm.zip",
+          "shasum": "3f094b5bb2b304e7b72a11c2c5d3143b5674f29bf536bc34902a7b0d3647a69d"
+        }
+      ]
+    },
+    {
+      "version": "0.65.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.65.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_darwin_amd64.zip",
+          "shasum": "39cf77030ac1a86746420673ea39a96dc12834c3b64794fcaab8825343f1621c"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.65.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_darwin_arm64.zip",
+          "shasum": "bbd8f8f50489078bd7c4c6e82f10e6aaeccc3b21b614f572b4f809f08ca983ce"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.65.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_freebsd_386.zip",
+          "shasum": "d9018d4cdc9a9aae9ba7b82968efc6684123b6497192c877f0bc200306521380"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.65.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_freebsd_amd64.zip",
+          "shasum": "9e3f790cc0b2a39dad2a27fb4bc832a87a27f5692f80e329947b982fdf9c8cc3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.65.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_freebsd_arm.zip",
+          "shasum": "9ef98c943752bc3d9c889f4a714a1e30316eeb3425773b9a4a3e4845694464a0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.65.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_freebsd_arm64.zip",
+          "shasum": "709e1d9c3aa13f32960451dce3f3ba8d94c9023f7e35e13ef049f3a79ae233ed"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.65.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_linux_386.zip",
+          "shasum": "cc7c84176f85f458f2fab4c3285ef5cf5f27789835c6d30f6f7231cbe2cbd914"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.65.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_linux_amd64.zip",
+          "shasum": "feccc719a5d6a6a5de3f2f1a078ae72a0076bba325d97a71bc5184aab956d6a4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.65.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_linux_arm.zip",
+          "shasum": "b9f2f30dfc4fb3990b3445fe4b21ebbd7bb30047d3140bd6f6aeb84d86c8ce62"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.65.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_linux_arm64.zip",
+          "shasum": "fa8ec577944727cf63614a61a918d298721c616e63b1a651f3820ad4e36c96eb"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.65.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_windows_386.zip",
+          "shasum": "e35143765bc22a7c8a0736eae09cc4b3d41d770d63ae6ab602fe31c0452099bb"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.65.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_windows_amd64.zip",
+          "shasum": "2c0d38b2f792e5a200af9266c81ddf45498d0f876f7683e5a9b8d3e6caf7bf94"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.65.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.65.0/terraform-provider-yandex_0.65.0_windows_arm.zip",
+          "shasum": "919f1cf006cbd84b82ffef593a2c8fd4a1aa487ee5434a2588af1d2187f118b4"
+        }
+      ]
+    },
+    {
+      "version": "0.64.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_darwin_amd64.zip",
+          "shasum": "7020b32afae811d2e19345304704ffff4ab2b6ee1f08d200ef8d6e48e86a55d9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.64.1_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_darwin_arm64.zip",
+          "shasum": "c998ece45b009dc7a698a7849b538bf4e43efa3c55a4a13299bede7ef8eeeb3e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.64.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_freebsd_386.zip",
+          "shasum": "34441e0b2088c6e3b459369c9df64e322a9113ccc3b76082794d55253a9372f0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_freebsd_amd64.zip",
+          "shasum": "f4b4c1252bff30261c1c34e3c959abe52ad095f439d953bcb5ede30be347a140"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.64.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_freebsd_arm.zip",
+          "shasum": "dc68babdec19df9729ce680444f977ec7981884509ec75b0d50d3236c1feadc3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.64.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_freebsd_arm64.zip",
+          "shasum": "6696f47fa8020d14dff42aec387e9fd12dcdda2d9b6b270168a4dbb6b1f46bd0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.64.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_linux_386.zip",
+          "shasum": "961ff35c731575fdd86a21af6d807e334efe8472ffdbd7a284cfeb55d7d7bc87"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_linux_amd64.zip",
+          "shasum": "5b4f55617654141a52e1f7b48e06ef6bf641556ccdd86752627977c2cfe38557"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.64.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_linux_arm.zip",
+          "shasum": "c14823da37a85b949822e4725268bdf2b620ce63ff604823c920fd0947905f45"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.64.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_linux_arm64.zip",
+          "shasum": "9670055536a34d0509425b38d161fe1d97c2ce08d220aec3fba4569dc3b3af0d"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.64.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_windows_386.zip",
+          "shasum": "318568da4883ae0d18a976c7130b19dc1a381a134de78c53f0f6b0caf7c04f7a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_windows_amd64.zip",
+          "shasum": "29590ad6bfedbc5de34c2eb52ac5df27727a7d7069c8651fc0e31a4cdd5d2be4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.64.1_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.1/terraform-provider-yandex_0.64.1_windows_arm.zip",
+          "shasum": "c3e75472995a39da76d7e4707f59096133add6586452637d93974059457bdbcf"
+        }
+      ]
+    },
+    {
+      "version": "0.64.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_darwin_amd64.zip",
+          "shasum": "61b427a9f488afa99803e5e08f6f697b5382b76926b5083308434b37ded8cb91"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.64.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_darwin_arm64.zip",
+          "shasum": "9a49d138167f2bcdf4c4662d13b413fa013e0f508b5e3a8dc2a40b352f7932b0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.64.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_freebsd_386.zip",
+          "shasum": "9a87f285c99de2d66dea6ec3e431bc2651afda2e8fd2f99346fd902344c8850b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_freebsd_amd64.zip",
+          "shasum": "605f5273d4c90198d8e78418b2d3d28c3dc0b48ab3dc9aaa363be251d57f0359"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.64.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_freebsd_arm.zip",
+          "shasum": "7db9fab39002e21d34b7392bd8b416d00787479507986170c4d90e6ab1a556b0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.64.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_freebsd_arm64.zip",
+          "shasum": "c6a6c9bb6625f6303be5b275385688ce62c761fbe2024647d3577a01c2717e90"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.64.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_linux_386.zip",
+          "shasum": "b01781e21628af3784f52f0703e3b0382e7478e3822ef3381f7470328b7dbba0"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_linux_amd64.zip",
+          "shasum": "040308ac17378c7df8a9c35853aac0bf7d1d0bda14a40a9527a1a6743651b1f1"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.64.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_linux_arm.zip",
+          "shasum": "6822fe96744e96aa86a225ebf30c1eba8fe29c74aa9f408234b7fef304d22dc8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.64.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_linux_arm64.zip",
+          "shasum": "f6bd02f9443a07f160cc62bfe00ff6a0d2114fd44d42275a6334d710e4267987"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.64.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_windows_386.zip",
+          "shasum": "deb496dc90d0ec11f6b6ab9ef12f997683c604aec087a750af20ff180ce2f7c9"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.64.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_windows_amd64.zip",
+          "shasum": "b8666a14ac4cf3a46117d96d85761923a0dc12f7df60c9fe5999eaccf3bd0cb4"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.64.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.64.0/terraform-provider-yandex_0.64.0_windows_arm.zip",
+          "shasum": "838771159b37b594d36411fa3c39fc83e224ae0e3a49b2795570faef76eef1e7"
+        }
+      ]
+    },
+    {
+      "version": "0.63.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_darwin_amd64.zip",
+          "shasum": "76bbd4bbcf42bdb767dd5335a10d98ec6d9c0ccb2219f8e93cae0ebee9fdecf9"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.63.1_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_darwin_arm64.zip",
+          "shasum": "e16e20c07ae89bea435427510ab4047b78da7b5f1762e42b2192a2cb61c0e6d8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.63.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_freebsd_386.zip",
+          "shasum": "773a476b720206cef13d0ae369050c136c3e4ab2c33a6c6cef1775b3d0281ea5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_freebsd_amd64.zip",
+          "shasum": "72fb616affb4392efc58135743f3b388b2fd13336b58f8a462e33b93ed445d05"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.63.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_freebsd_arm.zip",
+          "shasum": "c0b9ad8cdc153a7a666164a203b5d53caa2f7e5bc0b19afa4680dbc09bd629e7"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.63.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_freebsd_arm64.zip",
+          "shasum": "a347f58f27b40f730d78f326f3ff3c8a4c8dc977612577f079eddcffb2f9dbad"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.63.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_linux_386.zip",
+          "shasum": "27a4c0ec95ccc0e58d01fd358bc280dfb6e6711393a4141aa4501578e0edead7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_linux_amd64.zip",
+          "shasum": "878d6954b6e73669a5b5542254d53d7ac7fd81d1cd1a3fe1014a8d90b4c521a4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.63.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_linux_arm.zip",
+          "shasum": "817699dd287e7b1ef65f483f96e30f0623c89552c84f0369c3edaaacc893c8b0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.63.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_linux_arm64.zip",
+          "shasum": "d4bdd03bfbc4daa19525a61d0eaffb3b5a2b1a1993611fbde57d796ecbdde856"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.63.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_windows_386.zip",
+          "shasum": "849fcf026399f5a8a99a1556680421cd59dd1edb8872c2c3eaae83e1ec25dac0"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_windows_amd64.zip",
+          "shasum": "f71bb64b87c260044e6de0e0fee606be8e356d859498fbbbe5457d217b65ec09"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.63.1_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.1/terraform-provider-yandex_0.63.1_windows_arm.zip",
+          "shasum": "3adca68a987c67b349dc08e45c509f3459be861bb0c10059d0b622efdc372dd9"
+        }
+      ]
+    },
+    {
+      "version": "0.63.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_darwin_amd64.zip",
+          "shasum": "94f85b2ea309b7bab0bb1bed696e92a13618a41fb4205d55b94ee795f4e7102d"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.63.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_darwin_arm64.zip",
+          "shasum": "18475f8b5eca04714b50f3d262b916139136b9e6b28fb6d0ff7bf713df2b5914"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.63.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_freebsd_386.zip",
+          "shasum": "2f7054fe8ee80a9f2534f9f16424c65f2ca35f6ec5c457ea98195f1d1b0cc5cb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_freebsd_amd64.zip",
+          "shasum": "e211eb2bbbf93478414320ec837ddc86beeeee450bc3f5b719583ca7a67a6aed"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.63.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_freebsd_arm.zip",
+          "shasum": "e6ff3cfb8c0d61390ea67777515850b076c3d6a9280eb24579cd53e58b7ff02b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.63.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_freebsd_arm64.zip",
+          "shasum": "88162fac969771472b1599a5ef314544c9a2a336c85d83f73aa9677fdfabe5c2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.63.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_linux_386.zip",
+          "shasum": "6f3bb4f382e54cd9f62eb8e5c8aef86863fa08e7d5300de9c6e2c4b46e166594"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_linux_amd64.zip",
+          "shasum": "a44329c3d52575936bb5ef24478ea5311faea35f5fe1612cb5078497e87ffc58"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.63.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_linux_arm.zip",
+          "shasum": "1751fbe37d68ead9318f78f1f6c235061d2aafd0e2110f68be35434e0633ba98"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.63.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_linux_arm64.zip",
+          "shasum": "9547ff12a0bd93a242466efbf00e33ac3baa85336ca5be0d102f5fd746d064ee"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.63.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_windows_386.zip",
+          "shasum": "880870fa9d259f61886e5b3342f460b74f70c3ba25e6c9c5100369844b855eb4"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.63.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_windows_amd64.zip",
+          "shasum": "b8bb1520ff27067dd1ae1cf4f5c69c2eac9e675e5f2a668b4f4eef084eda81c0"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.63.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.63.0/terraform-provider-yandex_0.63.0_windows_arm.zip",
+          "shasum": "01e5723c1d41c6a9e94e245b64f5ea5a1a14f333701455932dfe529a32164260"
+        }
+      ]
+    },
+    {
+      "version": "0.62.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.62.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_darwin_amd64.zip",
+          "shasum": "599eb758961b66ce57f33c56cddb2c584161529ad14b0c07b7dded215c81e6bd"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.62.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_darwin_arm64.zip",
+          "shasum": "776d2cd9f715dad2218a95f663d079e85fcedcd9a83f08d2e60c76e40477cb3b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.62.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_freebsd_386.zip",
+          "shasum": "501e15ad45df71789372ac234036e75acbc338852ef70114f767aac70d6e29d2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.62.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_freebsd_amd64.zip",
+          "shasum": "b0f993f82988b51206fc5e5bd1b44cd1fb1798a0ff0b0198e75dc38f03d2e797"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.62.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_freebsd_arm.zip",
+          "shasum": "4ae3f381532e95906e6491e8cb3175a308122ce43d7e6b299ca069886f107fd2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.62.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_freebsd_arm64.zip",
+          "shasum": "f45aaf73bec8d9d2649439621b15bc146567111a19a27e70d2516f5177fa407f"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.62.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_linux_386.zip",
+          "shasum": "e752853e2ca4de55353f419f9b51fa80414c90ab03ccaa187a404a79e9f5eaf7"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.62.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_linux_amd64.zip",
+          "shasum": "7d4f3b722245b4899d58f4f9e572dd9c1dbe1522d29e75fe6b958cf6629ae389"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.62.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_linux_arm.zip",
+          "shasum": "2b6ab2dacd09cc121eb951985378e0a17df73577d58494936630d3bae40ccee2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.62.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_linux_arm64.zip",
+          "shasum": "79560b73db5c24b4b108ffaa9319a2df9dc8e713ab70891e64592ad6513643b4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.62.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_windows_386.zip",
+          "shasum": "c6a3421d8f3a0a78fb5f560ef172eba989d0519a2ab235fc0d283ba14fde8c35"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.62.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_windows_amd64.zip",
+          "shasum": "f980fe3acfcb34f6a8b872e4a62dcda8d0ca4d945ad4d2a82a6d2caa3b6eaabe"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.62.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.62.0/terraform-provider-yandex_0.62.0_windows_arm.zip",
+          "shasum": "e96c6696e13c59747e73d927272158d1b5b700835f51df2676d9eb80c979f99e"
+        }
+      ]
+    },
+    {
+      "version": "0.61.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.61.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_darwin_amd64.zip",
+          "shasum": "c3271a09eaddc9b26fb9e4557205c0061d9598ac494aa1ff79aff3a8aad9a6af"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.61.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_darwin_arm64.zip",
+          "shasum": "7db9ed59e2e4812742ef6d395964f53109917e83ca15f2366faeefef507a2c68"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.61.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_freebsd_386.zip",
+          "shasum": "1e2373d2b7f7884c727298f3f316be440edceeed1dee164fc11e999681b7dd7f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.61.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_freebsd_amd64.zip",
+          "shasum": "3863dc8af706cda0d9a56899179b7ecafebaa74c598f8900c8c2c7750aaae80f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.61.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_freebsd_arm.zip",
+          "shasum": "d3900e43c33bae7a40d380cd4884259a454ddcdfd648d3fef799e4e16aa0295f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.61.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_freebsd_arm64.zip",
+          "shasum": "3ec58f287b9675f0316c5c3099614f795108366ba90cff41ca3058d5aa3cbc5d"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.61.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_linux_386.zip",
+          "shasum": "33417856d3d99ff45d3d5a049bc03c10ca442d21de7bd32ba5a6484fb5fb72f9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.61.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_linux_amd64.zip",
+          "shasum": "0b86997686aee3b482fbbcbcd924b93f40211b3b9cf274e64a893c05f79a8379"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.61.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_linux_arm.zip",
+          "shasum": "206178cdc0e81848bdefea25674486e97bacf6a55bc54a8f88e71f58f62781ad"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.61.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_linux_arm64.zip",
+          "shasum": "0de9ca24cf0bebe4bf85c498249a1af7e327478f61e768e3ddf5476da3818c8e"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.61.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_windows_386.zip",
+          "shasum": "a00d8c35a70213bc218f497dcdfd3f24696e0a140755685f9662ce57e49c43c2"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.61.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_windows_amd64.zip",
+          "shasum": "de33d84ef2665318efc11a0390f629ae5bc33c319d9aacb0eacd7a62761c6141"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.61.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.61.0/terraform-provider-yandex_0.61.0_windows_arm.zip",
+          "shasum": "17cd2ab877b11c73c62149b847ae2e3c293260823b62df3739712ac9fd0604e6"
+        }
+      ]
+    },
+    {
+      "version": "0.60.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.60.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_darwin_amd64.zip",
+          "shasum": "dd48e22173b73f683a69f336ac6bd0da57f127346d32b71cd2a16520692c4b3e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.60.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_darwin_arm64.zip",
+          "shasum": "78451633ade94a9e96ab7dcb9269155db9f239e39dbb7115a9e4af2b937e6ff5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.60.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_freebsd_386.zip",
+          "shasum": "d30a065de82981a8e2b026a3cc29ba14ccc25934419e5bb858f3a4bd97aaa985"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.60.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_freebsd_amd64.zip",
+          "shasum": "0f8c80d925941dea661e1623f3baa65921eb5784377648386a58a20fa3128640"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.60.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_freebsd_arm.zip",
+          "shasum": "aebf7ef6b6cbd670319fa008461c1f5b09fcac6b194d4dbac011658dd897cc12"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.60.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_freebsd_arm64.zip",
+          "shasum": "00a8a238e3126a65370ab13b8645b4632f5e5b7549b40405b506043a47261492"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.60.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_linux_386.zip",
+          "shasum": "901d63d88e48738c544614a6b47e338beb04849c9b429f410ac5bc875dde1afe"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.60.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_linux_amd64.zip",
+          "shasum": "41d277d950e07699dfbdb43f7c3a3792dd61ed18e9cc407183e1211013937b9b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.60.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_linux_arm.zip",
+          "shasum": "f0c15a24ee258e3dab8004129204bfd41220285372b92b4db2f1500d4982ec86"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.60.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_linux_arm64.zip",
+          "shasum": "26013f75c2bc01cbabdb30e1706d98c7b3094f734f46bbd6dbba51512a298fe9"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.60.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_windows_386.zip",
+          "shasum": "91e538a15e9aa66f94ec9c64d1d0cbeb176407d81b988991914700f27a002081"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.60.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_windows_amd64.zip",
+          "shasum": "033e762b331edbd2a4e89f8a838e67b35d7ed2dbe486500e4862657b3bda9b74"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.60.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.60.0/terraform-provider-yandex_0.60.0_windows_arm.zip",
+          "shasum": "99cfbc47ce811d9b97d44549ee554f3f52334040481bf2bdd071a07c38be2bf8"
+        }
+      ]
+    },
+    {
+      "version": "0.59.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.59.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_darwin_amd64.zip",
+          "shasum": "72cb3b2bab03820ea923dc8a6736b02b4e25054d445554cb056677417f3d28e8"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.59.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_darwin_arm64.zip",
+          "shasum": "badc47293095b68d3b5437af247dbc29172d8197b316b85af8052920feffb0b0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.59.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_freebsd_386.zip",
+          "shasum": "8b6b2faca40706d3f73aad623821ce45b7292641bf50a68c4d93f2906b51f196"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.59.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_freebsd_amd64.zip",
+          "shasum": "7e5737a03429b96f2a809722ad8d75dd68a99d5dd114c667bc43ec3c369efbe8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.59.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_freebsd_arm.zip",
+          "shasum": "519d393cc8680b316ad76f8efa879e96c6b900d129932246d1ef748e9fd387ec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.59.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_freebsd_arm64.zip",
+          "shasum": "14e0137113d9b490e344b930fd942954e6903e15b4eb13c144507797a154ac8a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.59.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_linux_386.zip",
+          "shasum": "89e12147089dd6355456bc0394cc7eb7400c74a7410c86bc80177fc902d91d5f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.59.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_linux_amd64.zip",
+          "shasum": "dc76a88078744af49e5915de15dd7fd3445287f1ea182a54096107c95e14a900"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.59.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_linux_arm.zip",
+          "shasum": "6101757806b3c49e77c06dfa91149cc8b88145e58f996d47d20e32951fa9597b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.59.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_linux_arm64.zip",
+          "shasum": "4913f5c7726868f29c53a908260bed3145996dd193a910dfce712367938a5cf4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.59.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_windows_386.zip",
+          "shasum": "d80b6cff47dd38523fa62415b83ed5d1bf8587c240819de86b41a942919d92f5"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.59.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_windows_amd64.zip",
+          "shasum": "939d924ead44b61f66630708117ca605e56412ff449f2a3fafb6ac6460f0ac92"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.59.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.59.0/terraform-provider-yandex_0.59.0_windows_arm.zip",
+          "shasum": "05ea1109218d2b1b75f1a8def93b7a5c80c1f47e1bd89cf600776f9b0870241b"
+        }
+      ]
+    },
+    {
+      "version": "0.58.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.58.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_darwin_amd64.zip",
+          "shasum": "f89de271164fa9dc79ae8a030a2e9e669dca3590c8a00f4b9522537c208a70ab"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.58.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_darwin_arm64.zip",
+          "shasum": "f1b923a7057130045b950346a5d99b566ed4685de7b911dbe6cbaf6d5b178371"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.58.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_freebsd_386.zip",
+          "shasum": "1a357317cb2eef258944286cac734c89f6f2184424444e989afc4d9442349fae"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.58.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_freebsd_amd64.zip",
+          "shasum": "6bc81b5285cba2fa271c26de5bbff203ead8e391a09fa0372adf887de293c43a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.58.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_freebsd_arm.zip",
+          "shasum": "cf22239ff31124b3aa6c8642c5cdefe6a30b7695f5975794cac757a09824314c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.58.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_freebsd_arm64.zip",
+          "shasum": "32aae46e90e73d0cae2068f1130a257c5f48ad791e1f7a049476b9be0fb65abe"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.58.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_linux_386.zip",
+          "shasum": "b47c5f2e4714037e979221630b8bd3f0c7e3e94eb89e2937f635b54ef2fb4173"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.58.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_linux_amd64.zip",
+          "shasum": "5584bb8036352d28b4296ff0376efcf5ad8449b4c5c15d436b8e55a3ff1033d5"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.58.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_linux_arm.zip",
+          "shasum": "c8d21c1b99064233c970394226ab30c181df382724064b96adf8cd4f41e62f9e"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.58.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_linux_arm64.zip",
+          "shasum": "f4ada4b6b5595ba70c58cfaaa9fea4d6875e66a21421d96141479238f8c60929"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.58.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_windows_386.zip",
+          "shasum": "b534a83278820931fae901bdd68f859383137a999b5c3ff150e4401b4d2248ec"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.58.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_windows_amd64.zip",
+          "shasum": "751c5f515dbd7b435f767b316523f9c18eb95cf00fdb0450083e9299d94be93b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.58.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.58.0/terraform-provider-yandex_0.58.0_windows_arm.zip",
+          "shasum": "c3b68c81b339bf0312a38c5d84cbbc68a98ddf7f89ce9d05e41e4c84c4063f5a"
+        }
+      ]
+    },
+    {
+      "version": "0.57.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.57.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_darwin_amd64.zip",
+          "shasum": "3daff7cec7ce70ca38f2a12c653d415d61beb7a95018adbbfaf487ca41ad58ab"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.57.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_darwin_arm64.zip",
+          "shasum": "5b040bfe4e9236b1bcbc3823524e205f945da4156477b82118c243ab07de0be5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.57.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_freebsd_386.zip",
+          "shasum": "311ddc7b57e9ed7cd7575fd892b2f638f88cfb7c7bf9fdc3c55c328373a00b2d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.57.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_freebsd_amd64.zip",
+          "shasum": "deccb81975cb0f81632a61ea52d781b6bf39d6f275350155efb3987c35eca797"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.57.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_freebsd_arm.zip",
+          "shasum": "b275fc49f338e8fdb90561cc505939e913ee018afcd4a25a7184706a0e62ce98"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.57.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_freebsd_arm64.zip",
+          "shasum": "bfc4cf91d760f06506e596c4a79973374ecca5277ff609ef757848fe604dfee9"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.57.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_linux_386.zip",
+          "shasum": "323c88aec9c42084373d295c75e27d5e8a94dc8b2749eb665ea58584a35cb4b3"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.57.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_linux_amd64.zip",
+          "shasum": "2ad92ad7e0ab778b430e3442856cc5a237352200a2039c8a5b8152890d0ded0b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.57.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_linux_arm.zip",
+          "shasum": "f71ddc896849a4574a3b51fc40df90a6f75a24d1b4404f4c896fa60e262dfa75"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.57.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_linux_arm64.zip",
+          "shasum": "2d1885c95c465fc1c0886cf3e936b66c1180ee7c911eda7e7415a350e30c6b66"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.57.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_windows_386.zip",
+          "shasum": "bda4701f5496dbe89cd7ce2df70494b87e5e85bc408213d809a276bff92d337e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.57.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_windows_amd64.zip",
+          "shasum": "ade10186058d9cb28f19b608486d85c75c9640eddfde94c5f8f2c0172e280c4b"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.57.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.57.0/terraform-provider-yandex_0.57.0_windows_arm.zip",
+          "shasum": "88fb9b9a8ae8868aa2f3b4bccc227bbae7a153fc94ebffdb7fd90ae9c6b1d65f"
+        }
+      ]
+    },
+    {
+      "version": "0.56.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.56.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_darwin_amd64.zip",
+          "shasum": "6cb3a57c27c43bafb3da3b1193cc68abf3faab4a375c4c11f2f18162b95864ad"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.56.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_darwin_arm64.zip",
+          "shasum": "609eb49f49880a4b1e3109411d01eefe10eb7b74927f671ab2426916bdca86fd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.56.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_freebsd_386.zip",
+          "shasum": "74ce38fb2d806cd789244edb35233695492883139a178d59c3d3658aa1ba2dcd"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.56.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_freebsd_amd64.zip",
+          "shasum": "f4315ccba4e397dc97a675bb2d044a60b8873168103a664b15c378bd8b1fb1bb"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.56.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_freebsd_arm.zip",
+          "shasum": "da81f5df30329651825cf2b0daa65792d49890c1bfdf53631c61a2b377b1cd2f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.56.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_freebsd_arm64.zip",
+          "shasum": "e5d3559fc25d5f7ad1704bdb53abf4a44ee395a2fd0c54c6af7a1d374b82b5bf"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.56.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_linux_386.zip",
+          "shasum": "2d781edd57f56122f32e7f43487c6c880460c3c6d789a01b175e417cbb363220"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.56.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_linux_amd64.zip",
+          "shasum": "c55746e83d5313e29c1e6bd810c927ad9475869f67d7a50137005887569fdaa9"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.56.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_linux_arm.zip",
+          "shasum": "41f926efeee7dcb98f864c53a16d2efb6ab349f48b9df1033add73e0b1d74c48"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.56.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_linux_arm64.zip",
+          "shasum": "c6c1f52f1022dabc49c27b28869b1370b9e09cd2a9ec6522f41eb9f0a6935fe8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.56.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_windows_386.zip",
+          "shasum": "9cdf129f31dccfadac622cf6297e8668fb79c37ae8397658b334af9da71bc55a"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.56.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_windows_amd64.zip",
+          "shasum": "fb129fc30a01d77704d564991104afe38d28f24a701f1b6a1cd39f00bb59d6d6"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.56.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.56.0/terraform-provider-yandex_0.56.0_windows_arm.zip",
+          "shasum": "a34cc9f4ec82f880dbf7a6b9f2eec3ec49f3f1e1dda7d6314712ef870994fc71"
+        }
+      ]
+    },
+    {
+      "version": "0.55.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.55.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_darwin_amd64.zip",
+          "shasum": "3aed8271286c2005d4701fe06432ffafabf887e6791a7adda3b19339b10e149e"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.55.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_darwin_arm64.zip",
+          "shasum": "0bed35470223d95b0365ca6206fab1861b089c5b3ad7546c4508cbfddc88e2b9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.55.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_freebsd_386.zip",
+          "shasum": "2eb102c6b58fc93d01429c2b0043283eb37f0bc56a15d4dfeb11caefb891620b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.55.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_freebsd_amd64.zip",
+          "shasum": "c411c0591c553f8c440525231d57e6b39deb47f871bfe02ab219b19f0a1d9dbe"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.55.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_freebsd_arm.zip",
+          "shasum": "2ffd19ba17598b06975c52be821839d30dc444c37ea8c3639c44b3c8b35bb6b6"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.55.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_freebsd_arm64.zip",
+          "shasum": "393c4eea0a207f93e2a5f7a93772f67375a339b988ecc93f8f516d4f8051994b"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.55.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_linux_386.zip",
+          "shasum": "a8108528d28244969ca990b5346c21eab9af1ab8817994d40ea52f026f656d7e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.55.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_linux_amd64.zip",
+          "shasum": "c747292eeef422e7870f39abc967cf16346e4b7aadd98a75203c7a01eab505f4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.55.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_linux_arm.zip",
+          "shasum": "ead1ab308f53d72863b182233669f7a37270181e2b73272ea3a35eb580fe7f38"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.55.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_linux_arm64.zip",
+          "shasum": "679c162ee1c9e73d0df5f14a9124ba40b5ed320735dd6f73e84c046d691e43c5"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.55.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_windows_386.zip",
+          "shasum": "438efe49aa948292b7c6d046d6d42ec1dd63309b7bda32a7102a4a5a802d5ebd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.55.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_windows_amd64.zip",
+          "shasum": "9e767299afa4836b679b90b3bea238255e91541d785a4ecfe178903d7e260f8f"
+        },
+        {
+          "os": "windows",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.55.0_windows_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.55.0/terraform-provider-yandex_0.55.0_windows_arm.zip",
+          "shasum": "4f708b651840001d7245cc26a3699a7d455b90a740a89f88f8b6a66bb6a3fa37"
+        }
+      ]
+    },
+    {
+      "version": "0.54.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.54.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_darwin_amd64.zip",
+          "shasum": "8cadfc6e516cae38bbe8c2f01568b2087b139db87b365cbab3f1b6c148e9b16f"
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.54.0_darwin_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_darwin_arm64.zip",
+          "shasum": "2a370e75a14487c4761edc8a4b7521c91569b50845cc666d3375be03160f9454"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.54.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_freebsd_386.zip",
+          "shasum": "248a9b4908e885a4fc276d4f265b6960ce863cf572f6caca55d2899cab608bec"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.54.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_freebsd_amd64.zip",
+          "shasum": "4f1c8036e6b31125bd48ee8f40a893cfd9dd6a53cf5cd71b7e1842f403bd326f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.54.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_freebsd_arm.zip",
+          "shasum": "d7ca1e8a403e8369fed01a154efa644443e050238cfc86a99e887ab32a4c2ea3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.54.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_freebsd_arm64.zip",
+          "shasum": "01152190a0c82d349f9d21c581707219dcc84305ebd1bb524e9b47b5a9dadc24"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.54.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_linux_386.zip",
+          "shasum": "d1a506308bdcc7d067224bfc4ea5d8ac958682a42862d80f4aca2b2f14740019"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.54.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_linux_amd64.zip",
+          "shasum": "cadf8b365b44c78a811e93c805f0bb1dfec9e4f6936452243878c4044bf86642"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.54.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_linux_arm.zip",
+          "shasum": "ece7c7a924ae7505de214402fdeabc4144b67d0581cbed1f7c30647aaafa13c2"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.54.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_linux_arm64.zip",
+          "shasum": "fe5b799287041978914e5d18de635169788721df58e6a71e7bd2a94c7e768676"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.54.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_windows_386.zip",
+          "shasum": "a1f1b2f084846e9b783159ae3896f1efeef6bd11c739405d5683505d7b3f885c"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.54.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.54.0/terraform-provider-yandex_0.54.0_windows_amd64.zip",
+          "shasum": "19e729338f3344300a0142e7325dbb28b81f0ce1250e13e706243a7e8d98cc07"
+        }
+      ]
+    },
+    {
+      "version": "0.53.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.53.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_darwin_amd64.zip",
+          "shasum": "a697fa12a793896b0c13f2326c4b424b503d82a6f57ec00c44693ec05d400ea4"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.53.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_freebsd_386.zip",
+          "shasum": "f179873f6566039cedcffc641e8d076c7de70b9aa5866aa95f07db629275bda3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.53.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_freebsd_amd64.zip",
+          "shasum": "71c46268b5d038df22d9cad4bd4ee12b15f4149f9a65475fd5481907f1da211c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.53.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_freebsd_arm.zip",
+          "shasum": "3b49d69e75a337c7acf96dd6c86bac2dec27f0645e79c61e90dc0bf18c4f56b0"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.53.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_freebsd_arm64.zip",
+          "shasum": "e8e767c808e04d7caf28834995123d97514c6292106b52ba75e44bb6e8db146c"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.53.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_linux_386.zip",
+          "shasum": "a03775c0f4a162d6821d2a5fb780928030457392f34f29ece0a97d97b5d35032"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.53.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_linux_amd64.zip",
+          "shasum": "e4c48785f8d023193c91b509a87cbe9a1057dc76d05d199c04b7b18e196759b7"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.53.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_linux_arm.zip",
+          "shasum": "b1e46be1a5ab99f8a4c429a7828a7f0c3613817e654809cdd978ac98d8a65df6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.53.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_linux_arm64.zip",
+          "shasum": "edb78bce97eb6950f7c3fd6825267439b1550d5294c249494542291b6d1b1626"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.53.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_windows_386.zip",
+          "shasum": "1fa68fc7484e258cc3b852528c44071cb205fc923b7cbdd96f768e8b4698cd4d"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.53.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.53.0/terraform-provider-yandex_0.53.0_windows_amd64.zip",
+          "shasum": "d85e2a191c54d94c56c950ccdb76fd2132d99b0cde6aa7e1915034b7e7dcea77"
+        }
+      ]
+    },
+    {
+      "version": "0.52.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.52.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_darwin_amd64.zip",
+          "shasum": "d3c82d3677f29afe9f74916e05543000e8fc600b1c2be3c34891416ecbd8a826"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.52.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_freebsd_386.zip",
+          "shasum": "cc77afec89e75beb21eb2569f32b9db675f305f5a7940cf6b375c4a5abb1f485"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.52.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_freebsd_amd64.zip",
+          "shasum": "85ab7fe74971b6338458c3f832089c347cef11e3009d99d52ef6013ed634bab9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.52.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_freebsd_arm.zip",
+          "shasum": "23db771ac0d1902703282b02d9474879297c73fd178d4a4352b846f69137848c"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.52.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_freebsd_arm64.zip",
+          "shasum": "556b387be8330da12399419c7dcbdbb745c71c96077bc311432d692452f213e4"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.52.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_linux_386.zip",
+          "shasum": "5dc856c27cf087071467034e111649d1441e50aa60d61933137a201975027244"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.52.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_linux_amd64.zip",
+          "shasum": "b221918ed32ece41e1c2beab245f911639728afb40e6ed7c9c0bf3130c26e4be"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.52.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_linux_arm.zip",
+          "shasum": "9d6a53781b89e5bdc953ba231fcbe6faf359743e758a4686008b53c2d128438b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.52.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_linux_arm64.zip",
+          "shasum": "f00b6ce3e011e0f99bada164cddb7cba4d0954925625935b530c9d3ae55f985c"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.52.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_windows_386.zip",
+          "shasum": "e0b5471b7d592ccd6aedfc591a19f7b13720db39117c4ed22f9c36c09ba3177e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.52.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.52.0/terraform-provider-yandex_0.52.0_windows_amd64.zip",
+          "shasum": "50ecb8c8d5f1cac0c21b23c2032f8b5ccea5909e428af4f2d1c203d6942287c3"
+        }
+      ]
+    },
+    {
+      "version": "0.51.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_darwin_amd64.zip",
+          "shasum": "5e89d5059d0c95336e664d638b5251c08035c0a18fc8aa109027d9ba0c813072"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.51.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_freebsd_386.zip",
+          "shasum": "7e08a173948e56a4137d452fdac1b97ebbb3aa176c97f873cea501f50e720801"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_freebsd_amd64.zip",
+          "shasum": "e4b281868af9686ae7bfa0dd579e7373c85fc8d351acf2be477f9fdc6e021be2"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.51.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_freebsd_arm.zip",
+          "shasum": "4349a19973e768c285633402b0a37b7a47edad098eb0e6de6b49b8ba2ba125d3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.51.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_freebsd_arm64.zip",
+          "shasum": "55caa8a92b5aa65ce2d42295f947b22babf7e205cf1eb231d286c8d6b51ff91e"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.51.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_linux_386.zip",
+          "shasum": "99d33929271848fad26e169b89da38b54889ed8ff25c18864b01c3d2bbe5f743"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_linux_amd64.zip",
+          "shasum": "45861a3a20fd67ec57d02828e76a4ac05a515dca345a947fcb062f6e068d2093"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.51.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_linux_arm.zip",
+          "shasum": "c5f6e79a3479a2182838583d58fba5890ed5145be2dc7dcd97f2e825f5ddcd1f"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.51.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_linux_arm64.zip",
+          "shasum": "5ccd011eaa61fca457ff5e8d93dee6341698ff0f2f5a6ac6eae0906b41e65ab8"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.51.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_windows_386.zip",
+          "shasum": "a46b31662a54bd3b11c80021878ec1c091cecbade16bbd608b91c32949712a13"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.1/terraform-provider-yandex_0.51.1_windows_amd64.zip",
+          "shasum": "36a211fd74a5092a3d96d871ba3dbb2af727fe85cabce2441b67813654cc326b"
+        }
+      ]
+    },
+    {
+      "version": "0.51.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_darwin_amd64.zip",
+          "shasum": "45e47c53e2689736a01c5e2ea75255080219e6815e044ff3da96164ee85b3878"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.51.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_freebsd_386.zip",
+          "shasum": "6ccf45f50060b52fe51286430c07b494980695457941c96b73fa3736145cb531"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_freebsd_amd64.zip",
+          "shasum": "6685347b86f87085801cd68fdc7d1a92cf8153d62b44d162a6dd2eedfcf10165"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.51.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_freebsd_arm.zip",
+          "shasum": "59cac1c2d7625270ee7e5bdb10cc6eb5afbfe8ef4c3fa52d910e6e090d66e32e"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.51.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_freebsd_arm64.zip",
+          "shasum": "9289af5aca924b6834e5de2bdadbf55e2add91626a5b4c36ddcfef19541003ed"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.51.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_linux_386.zip",
+          "shasum": "01a261ed738027c4dc85d59104730e82bb09e1aef36015c2b3f4a53703374f57"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_linux_amd64.zip",
+          "shasum": "9cbcd12c040d07d946c230abcb02b9c7734a26f14e6582aaf1f42f0baa371fa0"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.51.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_linux_arm.zip",
+          "shasum": "9b98742a4d7f4fcaed70ecbd42e2a8a06312ec48b7c2d16c0ffa866d956483c8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.51.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_linux_arm64.zip",
+          "shasum": "c844b9bdac61eb08e0c4b464091b87adf436fa065bedaa9a5a926d4674f12e51"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.51.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_windows_386.zip",
+          "shasum": "29257feb2c139e0be6761bd58a3ba2da59c952e63a19aefa4a9686fec913752f"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.51.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.51.0/terraform-provider-yandex_0.51.0_windows_amd64.zip",
+          "shasum": "776ab221eebf4b499d8e44e68e17ef5268dbf4a16895daa3c66e875d03d60d3d"
+        }
+      ]
+    },
+    {
+      "version": "0.50.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.50.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_darwin_amd64.zip",
+          "shasum": "b260019d1851747374f24a861557f8caa1301bf132173bbe293a88ef185f7e29"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.50.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_freebsd_386.zip",
+          "shasum": "744267103a3480396dfe735950299a64b184710895ed3ec97122fc8a4185e4ae"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.50.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_freebsd_amd64.zip",
+          "shasum": "491f4a876f2a5c0fe7542026ffe3d3ea09455a8c6c18e3b646056495d3799bba"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.50.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_freebsd_arm.zip",
+          "shasum": "b471dc6292b4274b2a4bc8fb6d1b2e390df7c6a8eea26e7191e4ef25cfc17702"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.50.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_freebsd_arm64.zip",
+          "shasum": "4ef2cb4cd6d67d268f568c07ce05f27d6683a1a6ef7dfdecb2ab636df85a9429"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.50.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_linux_386.zip",
+          "shasum": "da0073f5954694b565d11431146b22c6aa633a9035773fc066af332a7832df62"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.50.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_linux_amd64.zip",
+          "shasum": "c94de71caf5436ee30990a9667c8336f86dc17ef37166edd2447c0ba03d07f9d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.50.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_linux_arm.zip",
+          "shasum": "a33a3ef3761e2ef35dc643834b5791d3e480802c1715176f982544709670d830"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.50.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_linux_arm64.zip",
+          "shasum": "82250bcda0727490a89814647a56ed37f5416930093c8aca73867076bdf252b6"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.50.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_windows_386.zip",
+          "shasum": "3441766287cc72e892d77d591fc4dcf91569936084eeef60d4f971d15ea038d7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.50.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.50.0/terraform-provider-yandex_0.50.0_windows_amd64.zip",
+          "shasum": "df8eacca1172cb454fec64cc46963727fb655fca98d7b1f1b8985e3b1c4d18c6"
+        }
+      ]
+    },
+    {
+      "version": "0.49.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.49.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_darwin_amd64.zip",
+          "shasum": "7e582a0ee30edcd60f507223d689dc72d951ff4c12c608d3ca5a57495327e7ef"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.49.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_freebsd_386.zip",
+          "shasum": "ef2659bfcbafff4854cb151869d42dff1832c71eaa35df0e3f5805afe2682751"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.49.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_freebsd_amd64.zip",
+          "shasum": "439f876975efb4986cb9b7335d932f2e23e6070fd35784fc6bea6bbd5100d8a3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.49.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_freebsd_arm.zip",
+          "shasum": "22c140f06a7cc8fb33f5bc817c571b6115203fe1b1bd1f90af6bb69274bdfce9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.49.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_freebsd_arm64.zip",
+          "shasum": "3a0680e65eaab1989ca4bd6c0bef04dbba1c0dfd2d81d1b78b03d2da9fa02da2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.49.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_linux_386.zip",
+          "shasum": "0d6b74cb3efb896c46316a6922c4e68d42856b49472276f851b56592aabdff4e"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.49.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_linux_amd64.zip",
+          "shasum": "6764f8a65998a657df1d842a0f30f523fbd336a11fb3f69aec21fb886c50b746"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.49.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_linux_arm.zip",
+          "shasum": "6eeed9f3de37e5a1c49c62b0d3d5fb164aadd326769113a76ab69f3e43bbb7f8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.49.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_linux_arm64.zip",
+          "shasum": "ca9bb1f874726e5c8de4bb2badc6fe5072c63965cc821ab727afd9e2363d53b3"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.49.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_windows_386.zip",
+          "shasum": "77719cc9700dc6a93dd4b4f24ef962f6f16ba3c3a7e574034d7395b209399931"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.49.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.49.0/terraform-provider-yandex_0.49.0_windows_amd64.zip",
+          "shasum": "5c164ad34095b5b3b2e2d6e303b5fd674e52332b73b98ec72286457e013bfff6"
+        }
+      ]
+    },
+    {
+      "version": "0.48.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.48.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_darwin_amd64.zip",
+          "shasum": "eefd8364ada75bbf0d21d0309a60f4ac8f5b482e9790c4a54d3083e1092d6d64"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.48.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_freebsd_386.zip",
+          "shasum": "043f65f9a0958ccf52b5e3028e4defd25aeca4a31a54376799ccbe250fce093f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.48.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_freebsd_amd64.zip",
+          "shasum": "68485a06b4cdd37f0e4403958850d8b36904a36431ba93d7a0dc846d2b30f2f1"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.48.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_freebsd_arm.zip",
+          "shasum": "a3cdaec8ca25f34339811e57d9f5a6acb89efde538419cfa307d09e5802dd6c3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.48.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_freebsd_arm64.zip",
+          "shasum": "7243431bb30f036da6712a1a9ee3573a5ceb37f08e98bca572879e9544b254b1"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.48.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_linux_386.zip",
+          "shasum": "88cae059cab8dffa3fff66b9d103de698222e0856c726e81bbab0a36b06ea55f"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.48.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_linux_amd64.zip",
+          "shasum": "e95ac49f2f4ce116ab976d603469c779063c87e13b38e083c539299b4269eb2a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.48.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_linux_arm.zip",
+          "shasum": "028bd20be25c903a4ecf2be1eba5ca61c3419b417e26a1c69c2a66cb1f7c7170"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.48.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_linux_arm64.zip",
+          "shasum": "f5f0615b1fb74803318b5d2344077eb9cbdeb0adce327300992c65f694f0b0b1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.48.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_windows_386.zip",
+          "shasum": "da6991b1f3213965348307996a789e98a5b7447c1ea77b5d8c3b36ff6977817e"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.48.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.48.0/terraform-provider-yandex_0.48.0_windows_amd64.zip",
+          "shasum": "5febbdc33865b0f2050eb2fc69b65a458b0851f7534ad87bee2dcce70b790090"
+        }
+      ]
+    },
+    {
+      "version": "0.47.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.47.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_darwin_amd64.zip",
+          "shasum": "4e5d851f091541af4274ee37005355d75cc17d362cbb7587ac3842647e9d3cf3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.47.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_freebsd_386.zip",
+          "shasum": "373e038337639f4368a785b7f54cdb23d2293138484e2608a1a2f70a18e1c07d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.47.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_freebsd_amd64.zip",
+          "shasum": "2399eb285f09da52055d12e074d6716f2333df645da6e430f01edd5c2fd63516"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.47.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_freebsd_arm.zip",
+          "shasum": "8239ac505d21209004459079124643334fd73c226dfc8a216266678f6cd3b035"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.47.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_freebsd_arm64.zip",
+          "shasum": "3e961a3c3b26d80e912215507f9e0d4076382651ee8c53b0826d946bd8979ed2"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.47.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_linux_386.zip",
+          "shasum": "fa517bf0355c83852b2bda3fe3b7a1c659e1813b08a99c77e937605fa07bce92"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.47.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_linux_amd64.zip",
+          "shasum": "1d0973876a3ceb591ce3a248f98a058621687e8e098761e06b98c09102d53189"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.47.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_linux_arm.zip",
+          "shasum": "abb7c93c321aba4a0a60cac55573c1615bb23770adc3ee84aeeca2144bc18c46"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.47.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_linux_arm64.zip",
+          "shasum": "0d642a129041f358552559eef45e7e049392231033ad41fd015b7da00f13ac7f"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.47.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_windows_386.zip",
+          "shasum": "32b59dda88adecae15e837cdd40805ea1ff533f74d54707f53602b0f93fe7125"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.47.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.47.0/terraform-provider-yandex_0.47.0_windows_amd64.zip",
+          "shasum": "ea08e8fe66688ee50413a6faeff9da9abe04595b1113a873451a2c7b4c174274"
+        }
+      ]
+    },
+    {
+      "version": "0.46.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.46.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_darwin_amd64.zip",
+          "shasum": "8df71cde6b00279c1beee1e088aa962ae9350ad809d75da3df7ecc47c54fba9f"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.46.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_freebsd_386.zip",
+          "shasum": "621f797ba23d709ba03436bddf383d57219e32d09849eccab72da22e1687c9c8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.46.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_freebsd_amd64.zip",
+          "shasum": "6b6fcd5374f8fdde130dfab29988fc6d0d5825c12097bc4595f37f258355f489"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.46.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_freebsd_arm.zip",
+          "shasum": "c992df5040b24f84d2332fc470bc9b8d767d90813758b6db1c55ae6c9c2136a5"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.46.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_freebsd_arm64.zip",
+          "shasum": "38ee461850a7802123012077fe3a785d95cbf58ce84766c3aea95c44ec4cee60"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.46.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_linux_386.zip",
+          "shasum": "d4382eb080d5e8ebd0c9c35e91116bdc2c0865ad2ad8f0a1224b3b317512be58"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.46.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_linux_amd64.zip",
+          "shasum": "1110580c4d4e74630806b0a9d138a7b3672d851a6384134e2427e9e33e9fe5b8"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.46.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_linux_arm.zip",
+          "shasum": "6acb8a5cad92fc1cfbaaa08bd9fb4a86fec5123bcd2bf14e78869cbd662f658a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.46.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_linux_arm64.zip",
+          "shasum": "a1ee6935f67fc3ecbdd24e6dd979003a172ba27dd306cf5a3064320ee92fd5e1"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.46.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_windows_386.zip",
+          "shasum": "42577780a318b61d7390ab09148cd38d4dab33ab96419d4717f3278e357dade7"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.46.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.46.0/terraform-provider-yandex_0.46.0_windows_amd64.zip",
+          "shasum": "085b543de638168be95ef310eb7575e81affbade6132518a5c3b6bf3d30a24e3"
+        }
+      ]
+    },
+    {
+      "version": "0.45.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_darwin_amd64.zip",
+          "shasum": "021f156514841241f9e210f888fad7e042d1b7f7f03d84179714e522ef29b427"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.45.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_freebsd_386.zip",
+          "shasum": "702fb07829855de16d11bff7794fcaf0547e2978ebe7486aab7d4af6920372d8"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_freebsd_amd64.zip",
+          "shasum": "a02680e5fe1c0b2cd628f536a3d2fcf613445549a01f48388d8333abea21f9c9"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.45.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_freebsd_arm.zip",
+          "shasum": "ccec660034da796ec87b01ff336eab41b68f95a9b8845c694d7526014e2f2293"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.45.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_freebsd_arm64.zip",
+          "shasum": "63c7ae27a15e6441dc0cfe6e3f14c9809646fee55de36552549cb221da974731"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.45.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_linux_386.zip",
+          "shasum": "88144ad8c2dd4d860e8b96acb114978ea91ea70c4ac5f83971d4d190e3ae5cf9"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_linux_amd64.zip",
+          "shasum": "8bc6aa9a337ce004fc8bf1963c774f4db6fe3c26d5aca883cc3e8cc168dbde29"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.45.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_linux_arm.zip",
+          "shasum": "274da23e986ca9c5b7c83cdf7dc7b7220ac04ae2f24a0d5b858e1b8835432430"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.45.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_linux_arm64.zip",
+          "shasum": "ea22b854f3b95fadaa6077d5fab37759a1039c5a39372ead5a980bd604513982"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.45.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_windows_386.zip",
+          "shasum": "e73f0ce2ac2e2b4cfbece8d0a736b64fa5fde055faf49eba4e413a3670fa08ee"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.1/terraform-provider-yandex_0.45.1_windows_amd64.zip",
+          "shasum": "ac7c9f4fb0cf4f0c7e8ce7b3f934dc3fd6f575be70716fbc49f829c945a74a25"
+        }
+      ]
+    },
+    {
+      "version": "0.45.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_darwin_amd64.zip",
+          "shasum": "ce8c36e62b5a0cbaaac6b7b033d4d4b588f0c01bd55d4e53b1d6d95a3dfdd133"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.45.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_freebsd_386.zip",
+          "shasum": "57d33c84dbdeb04990308a2af79fc467063efe72c823fbc5128928051ffaf29d"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_freebsd_amd64.zip",
+          "shasum": "5c7fa764cdc9644b289ad05dc37be3ea15fda782d807fbff15e1fdc8a669587b"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.45.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_freebsd_arm.zip",
+          "shasum": "76717d7ced08aa2bfb4575079b44bae54700805055e002b56af6fdcd864aa7b3"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.45.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_freebsd_arm64.zip",
+          "shasum": "3a2d6653522bfcba8cc0771a2a5243b2368cda1388a7140210ea941d2feebef0"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.45.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_linux_386.zip",
+          "shasum": "75b9058c1a18906b19ffce538bf387f73d737232d3cea9f5f1a9508c74fc0d5c"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_linux_amd64.zip",
+          "shasum": "48b1345333237699b9a6cbf24306fafc96539682bd6520e570ac78b94ac5a6f4"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.45.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_linux_arm.zip",
+          "shasum": "1ce49845eabf243a96686d42a4283a95e40ccc5560a27f577ab9562a17c5108b"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.45.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_linux_arm64.zip",
+          "shasum": "bee304934cc3cb12ee9385b908aebaafaf034e2623e39dee87e0f1b23913d789"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.45.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_windows_386.zip",
+          "shasum": "5def8bb7e5efcccac41c754e0330950dee17114b9cbc1f36e9d1752d762fd5cd"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.45.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.45.0/terraform-provider-yandex_0.45.0_windows_amd64.zip",
+          "shasum": "44978932cb032949ee17485a15a60d68f3fb3e5dcc8e906d2100af686effb9e1"
+        }
+      ]
+    },
+    {
+      "version": "0.44.1",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.1_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_darwin_amd64.zip",
+          "shasum": "5c32f2b0613441f37f9913fa74546dda4a417be4098fdbcf68c3d5dcfdfe7576"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.44.1_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_freebsd_386.zip",
+          "shasum": "6131528baa8020d04898cbe45ad49b7d4b41e2dbe4eef0beb6b67ed477945621"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.1_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_freebsd_amd64.zip",
+          "shasum": "d34c83af80d067ba69c28b1401fb84370bbf82b2db83b476d4ef43e4cf39dc18"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.44.1_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_freebsd_arm.zip",
+          "shasum": "38475d71fc0a354b833deaf6577122f3ee09ecb0848ec65294dc7b5dc8feb37a"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.44.1_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_freebsd_arm64.zip",
+          "shasum": "9830ad3dd4abd7168885a2d2b56028f11967d2ab58909af37378d67f2c999c8a"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.44.1_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_linux_386.zip",
+          "shasum": "64bdcbeedcbe7decad6e2e6f47c26f1d2daae74034d3d5e42e4002ddc5127c9b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.1_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_linux_amd64.zip",
+          "shasum": "20a04e8e8190b5517aab5fc4683259177ebe4aa834c2958423ca27fd7770449a"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.44.1_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_linux_arm.zip",
+          "shasum": "e6dd3cf6b84b18ea899d12f60a02b3af98fb5024266f232c405de8f0f705649d"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.44.1_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_linux_arm64.zip",
+          "shasum": "52920f7d1af533e00bcf4ed38c7bbefc3706263aef09f850cab666ea64b4c0a4"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.44.1_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_windows_386.zip",
+          "shasum": "fa5b7f5c13972f8103d41796827b0df0e6a46595636d7ede6a356ee9d01578a8"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.1_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.1/terraform-provider-yandex_0.44.1_windows_amd64.zip",
+          "shasum": "1fcf1589a5c138039e060b03b32b4143f8a397183cea069cb7ace87f2923e850"
+        }
+      ]
+    },
+    {
+      "version": "0.44.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.0_darwin_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_darwin_amd64.zip",
+          "shasum": "e71c378188a44abcd887a2c640d01b62c4f22855bd8c736409f83a3aae5f5f43"
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.44.0_freebsd_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_freebsd_386.zip",
+          "shasum": "60f1b757f5859236f4940a55781431ff9ad8a9636759fbc21952ec79a41cc2aa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_freebsd_amd64.zip",
+          "shasum": "9e337f296c3dc4da97641dbc6ea02f9f09697aa28b79455cb516a7fb8ebcecfa"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.44.0_freebsd_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_freebsd_arm.zip",
+          "shasum": "0d205c3a47513016447bdcbea16436edb716bfb3c85c5709bb3a9b9b99630176"
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.44.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_freebsd_arm64.zip",
+          "shasum": "9546c545e3e4c98f1e0f28a311e7efb295deb9c8b77e99817a98c91953f50611"
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.44.0_linux_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_linux_386.zip",
+          "shasum": "5d1deb6e61e03d1754e81823ba2c4f90d70430443c8762158ac18f87e3f5522b"
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.0_linux_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_linux_amd64.zip",
+          "shasum": "1210d8fd682f603a17af2a84e805470a38a97b71917243dac36d4cdf4000e536"
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-yandex_0.44.0_linux_arm.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_linux_arm.zip",
+          "shasum": "ab3216fc9c53b0d8e980f371abe51e39a5273c3e80c794d9a6a6055667ccf7f6"
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-yandex_0.44.0_linux_arm64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_linux_arm64.zip",
+          "shasum": "a9d78001aa11fb76fccdbc657c42d162d148d89e04b9f6da960f112d5afd3236"
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-yandex_0.44.0_windows_386.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_windows_386.zip",
+          "shasum": "50a1fc64f51ef86c7f58e676d4607ca285ba9401e8f3f525fc4fb0bab312ee86"
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-yandex_0.44.0_windows_amd64.zip",
+          "download_url": "https://github.com/yandex-cloud/terraform-provider-yandex/releases/download/v0.44.0/terraform-provider-yandex_0.44.0_windows_amd64.zip",
+          "shasum": "9294f4c658272966151f030a6b9ac10893a67e1704aae84a363be44e14501acc"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Explanation

Yesterday, pull request #817 was successfully approved and merged into the main branch. As part of this pull request, all providers affiliated with or based in Russia were removed from the project's repository.


To explain this change, @cam72cam [provided](https://github.com/opentofu/registry/pull/817#issuecomment-2314944090) two links: [README.md](https://github.com/opentofu/opentofu/blob/main/README.md#registry-access) and [TSC_SUMMARY.md](https://github.com/opentofu/opentofu/blob/main/TSC_SUMMARY.md#sanctions-russia-vs-registry-access).

Additionally, as part of the discussion in issue #823, @DicsyDel [provided](https://github.com/opentofu/registry/issues/823#issuecomment-2314320206) information that "it was deemed appropriate to block access from certain territories to avoid any legal issues", citing sanctions on a [Russian legal entity](https://sanctionssearch.ofac.treas.gov/Details.aspx?id=18715).

# Why this decision is absolutely wrong and the arguments in its favor do not confirm its correctness

1. README.md, as well as TSC_SUMMARY.md, mention only the restriction on access from Russian IPs to the registry, but not the removal of Russian-related providers from the registry.
2. [Here](https://ofac.treasury.gov/faqs/1186), the U.S. Treasury Office of Foreign Assets Control explains how the restriction on the provision of information technology to Russia should be interpreted. The presence of files from Russian providers in the registry clearly does not fall under these interpretation.
3. [Here](https://ofac.treasury.gov/faqs/1188), the U.S. Treasury Office of Foreign Assets Control explains the nuances of providing information technology to companies affiliated with Russian companies. In particular, Yandex LLC, whose provider was removed from the register, has a subsidiary in Kazakhstan that uses the same provider, which makes it absolutely wrong to exclude the Yandex LLC provider from the register due to US sanctions.

# What should be done

The restriction on access to the registry from Russian IP addresses is absolutely justified by the need to comply with US sanctions. However, the removal of Russian-linked providers has nothing to do with compliance with sanctions, which I explained above.


Therefore, these providers should be returned to the registry. I kindly ask you not to close this PR without a full explanation of the reason for such deletion, as well as an answer to my counterarguments. After all, this is an open source, and the community would like to get a good explanation of what happened.
