### PR TITLE
ci: update `actions/setup-go` to v5

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
           cache-dependency-path: './src/go.sum'

--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
           cache-dependency-path: './src/go.sum'

--- a/.github/workflows/generate-and-deploy-with-delete.yml
+++ b/.github/workflows/generate-and-deploy-with-delete.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
           cache-dependency-path: './src/go.sum'

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
           cache-dependency-path: './src/go.sum'

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
 
@@ -45,18 +45,18 @@ jobs:
           set +e
           go run ./cmd/add-provider -repository="$repository" -output=./output.json
           if [[ "$?" != 0 ]]; then
-            if [ "$(cat ./output.json | jq -r '.exists')" == "true" ]; then
-              gh issue close $NUMBER -c "$(cat ./output.json | jq -r '.validation')"
+            if [ "$(jq -r '.exists' < ./output.json)" == "true" ]; then
+              gh issue close $NUMBER -c "$(jq -r '.validation' < ./output.json)"
               exit 0
             else
-              gh issue comment $NUMBER -b "$(cat ./output.json | jq -r '.validation')"
+              gh issue comment $NUMBER -b "$(jq -r '.validation' < ./output.json)"
               exit 1
             fi
           fi
           set -e
-          namespace=$(cat ./output.json | jq -r '.namespace')
-          name=$(cat ./output.json | jq -r '.name')
-          jsonfile=$(cat ./output.json | jq -r '.file')
+          namespace=$(jq -r '.namespace' < ./output.json)
+          name=$(jq -r '.name' < ./output.json) 
+          jsonfile=$(jq -r '.file' < ./output.json)
 
 
           # Create Branch
@@ -94,7 +94,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
 
@@ -122,19 +122,19 @@ jobs:
           set +e
           go run ./cmd/add-module -repository="$repository" -output=./output.json
           if [[ "$?" != 0 ]]; then
-            if [ "$(cat ./output.json | jq -r '.exists')" == "true" ]; then
-              gh issue close $NUMBER -c "$(cat ./output.json | jq -r '.validation')"
+            if [ "$(jq -r '.exists' < ./output.json)" == "true" ]; then
+              gh issue close $NUMBER -c "$(jq -r '.validation' < ./output.json)"
               exit 0
             else
-              gh issue comment $NUMBER -b "$(cat ./output.json | jq -r '.validation')"
+              gh issue comment $NUMBER -b "$(jq -r '.validation' < ./output.json)"
               exit 1
             fi
           fi
           set -e
-          namespace=$(cat ./output.json | jq -r '.namespace')
-          name=$(cat ./output.json | jq -r '.name')
-          target=$(cat ./output.json | jq -r '.target')
-          jsonfile=$(cat ./output.json | jq -r '.file')
+          namespace=$(jq -r '.namespace' < ./output.json)
+          name=$(jq -r '.name' < ./output.json)
+          target=$(jq -r '.target' < ./output.json)
+          jsonfile=$(jq -r '.file' < ./output.json)
 
 
           # Create Branch
@@ -172,7 +172,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
 
@@ -205,7 +205,7 @@ jobs:
           verification=$?
           set -e
 
-          gh issue comment $NUMBER -b "$(cat ./output.json | jq -r '.')"
+          gh issue comment $NUMBER -b "$(jq -r '.' < ./output.json)"
           if [[ "$verification" != 0 ]]; then
             exit 1
           fi

--- a/.github/workflows/validate-json-module.yml
+++ b/.github/workflows/validate-json-module.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
 

--- a/.github/workflows/validate-json-provider.yml
+++ b/.github/workflows/validate-json-provider.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: './src/go.mod'
 


### PR DESCRIPTION
- Update `actions/setup-go` to v5 (removes deprecation warnings about node 16 runtime)
- Remove `cat file | jq` in favor of `jq < file` in workflow


While it falls forward to 20 anyway, it generates a warning like this:
<img width="1095" alt="image" src="https://github.com/user-attachments/assets/05335031-a4e6-4ba2-8f8d-f05f1cf69edf">