### PR TITLE
Remove the DCO check for providers, and modules entry submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/module.yml
+++ b/.github/ISSUE_TEMPLATE/module.yml
@@ -10,10 +10,3 @@ body:
       description: Path to a public GitHub repository following the pattern {owner}/terraform-{target}-{name}, ex. GoogleCloudPlatform/terraform-google-secured-data-warehouse
     validations:
       required: true
-  - type: checkboxes
-    id: dco
-    attributes:
-      label: DCO
-      options:
-        - label: I sign this project's [DCO](https://developercertificate.org/)
-          required: true

--- a/.github/ISSUE_TEMPLATE/provider.yml
+++ b/.github/ISSUE_TEMPLATE/provider.yml
@@ -10,10 +10,3 @@ body:
       description: Path to a public GitHub repository following the pattern {owner}/terraform-provider-{name}, ex. opentofu/terraform-provider-aws
     validations:
       required: true
-  - type: checkboxes
-    id: dco
-    attributes:
-      label: DCO
-      options:
-        - label: I sign this project's [DCO](https://developercertificate.org/)
-          required: true

--- a/.github/ISSUE_TEMPLATE/provider_key.yml
+++ b/.github/ISSUE_TEMPLATE/provider_key.yml
@@ -23,10 +23,3 @@ body:
     attributes:
       label: Provider GPG Key
       description: Armoured public PGP key
-  - type: checkboxes
-    id: dco
-    attributes:
-      label: DCO
-      options:
-        - label: I sign this project's [DCO](https://developercertificate.org/)
-          required: true

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -32,14 +32,6 @@ jobs:
           BODY: ${{ github.event.issue.body }}
         working-directory: ./src
         run: |
-          set +e
-          echo "$BODY" | grep "\- \[[xX]\] I sign this project's \[DCO\](https://developercertificate.org/)"
-          if [[ "$?" != 0 ]]; then
-            gh issue comment $NUMBER -b "DCO must be signed to submit this repository"
-            exit 1
-          fi
-          set -e
-
           repository=$(echo "$BODY" | grep "### Provider Repository" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
 
           set +e
@@ -109,14 +101,6 @@ jobs:
           BODY: ${{ github.event.issue.body }}
         working-directory: ./src
         run: |
-          set +e
-          echo "$BODY" | grep "\- \[[xX]\] I sign this project's \[DCO\](https://developercertificate.org/)"
-          if [[ "$?" != 0 ]]; then
-            gh issue comment $NUMBER -b "DCO must be signed to submit this repository"
-            exit 1
-          fi
-          set -e
-
           repository=$(echo "$BODY" | grep "### Module Repository" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
 
           set +e
@@ -188,14 +172,6 @@ jobs:
           BODY: ${{ github.event.issue.body }}
         working-directory: ./src
         run: |
-          set +e
-          echo "$BODY" | grep "\- \[[xX]\] I sign this project's \[DCO\](https://developercertificate.org/)"
-          if [[ "$?" != 0 ]]; then
-            gh issue comment $NUMBER -b "DCO must be signed to submit this repository"
-            exit 1
-          fi
-          set -e
-
           namespace=$(echo "$BODY" | grep "### Provider Namespace" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
           keydata=$(echo "$BODY" | grep -A 1000 "BEGIN PGP PUBLIC KEY BLOCK"  | grep -B 1000 "END PGP PUBLIC KEY BLOCK")
           echo "$keydata" > tmp.key


### PR DESCRIPTION
The DCO signoff of providers/modules was added as a precaution in the early days of the OpenTofu registry.  Upon further analysis we have determined that, given the contents of the submission, it is not applicable and are removing it.