### PR TITLE
Add support for provider specific keys

### DIFF
--- a/.github/ISSUE_TEMPLATE/provider_key.yml
+++ b/.github/ISSUE_TEMPLATE/provider_key.yml
@@ -10,6 +10,13 @@ body:
       description: GitHub Username or Organization that contains Providers
     validations:
       required: true
+  - type: input
+    id: providername
+    attributes:
+      label: Provider Name
+      description: Name of the provider this key is used for (without the terraform-provider- prefix). If omitted, this key will be added at the namespace/organization level.
+    validations:
+      required: false
   - type: checkboxes
     id: public_membership
     attributes:

--- a/.github/ISSUE_TEMPLATE/provider_key.yml
+++ b/.github/ISSUE_TEMPLATE/provider_key.yml
@@ -13,7 +13,7 @@ body:
   - type: input
     id: providername
     attributes:
-      label: Provider Name
+      label: Provider Name (Optional)
       description: Name of the provider this key is used for (without the terraform-provider- prefix). If omitted, this key will be added at the namespace/organization level.
     validations:
       required: false

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -173,6 +173,7 @@ jobs:
         working-directory: ./src
         run: |
           namespace=$(echo "$BODY" | grep "### Provider Namespace" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
+          providername=$(echo "$BODY" | grep "### Provider Name" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
           keydata=$(echo "$BODY" | grep -A 1000 "BEGIN PGP PUBLIC KEY BLOCK"  | grep -B 1000 "END PGP PUBLIC KEY BLOCK")
           echo "$keydata" > tmp.key
 
@@ -186,7 +187,11 @@ jobs:
             exit 1
           fi
 
-          keyfile="../keys/${namespace:0:1}/$namespace/provider-$(date +%s).asc"
+          if [[ -z "$providername" ]]; then
+            keyfile="../keys/${namespace:0:1}/$namespace/provider-$(date +%s).asc"
+          else
+            keyfile="../keys/${namespace:0:1}/$namespace/$providername/provider-$(date +%s).asc"
+          fi
           if [ -d $(dirname $keyfile) ]; then
             msg=Updated
             #git rm $(dirname $keyfile)/*

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -84,8 +84,9 @@ func (p ProviderGenerator) VersionDetails() (map[string]ProviderVersionDetails, 
 	versionDetails := make(map[string]ProviderVersionDetails)
 
 	keyCollection := gpg.KeyCollection{
-		Namespace: p.Provider.EffectiveNamespace(),
-		Directory: p.KeyLocation,
+		Namespace:    p.Provider.EffectiveNamespace(),
+		ProviderName: p.Provider.ProviderName,
+		Directory:    p.KeyLocation,
 	}
 
 	keys, err := keyCollection.ListKeys()


### PR DESCRIPTION
We now scan both ./keys/n/namespace/ and ./keys/n/namespace/provider/. This allows users to provide both organization level keys and provider specific keys.