### PR TITLE
Fix recent key change detection for namespace/provider_name

### DIFF
--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Copy Changed Providers"
           git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^providers | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp foo ./pruned/foo; echo foo" | bash
           echo "Copy Changed Providers by Keys"
-          git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^keys | xargs dirname | sort | uniq | sed -e 's/^keys/providers/' | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp -r foo ./pruned/foo; echo foo" | bash
+          git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^keys | sed -e 's,^keys/\([^/]*\)/\([^/]*\).*,providers/\1/\2,' | sort | uniq | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp -r foo ./pruned/foo; echo foo" | bash
           echo "Copy Changed Modules"
           git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^modules | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp foo ./pruned/foo; echo foo" | bash
 


### PR DESCRIPTION
```
git diff --name-only "$(git rev-list -1 --before="$(date -d '-1000 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^keys | sed -e 's,^keys/\([^/]*\)/\([^/]*\).*,providers/\1/\2,' | sort | uniq
providers/1/1password
providers/a/ably
providers/a/azure
providers/b/bpg
providers/c/ciscodevnet
providers/c/claranet
providers/f/fknittel
providers/k/komminarlabs
providers/l/loafoe
providers/m/marshallford
providers/n/netlify
providers/n/nint8835
providers/s/snowplow-devops
providers/t/terraformindepth
providers/t/terraform-provider-gpg
```