### PR TITLE
Better error handling when SHASUM file is missing

### DIFF
--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -61,6 +61,6 @@ git commit -s -m "Create provider ${namespace}/${name}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/}) for provider ${namespace}/${name}.  Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
-gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
+pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src}) for provider ${namespace}/${name}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}). This issue has been locked."
 gh issue lock "${NUMBER}" -r resolved

--- a/src/cmd/add-provider/main.go
+++ b/src/cmd/add-provider/main.go
@@ -28,7 +28,7 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 
 	repository := flag.String("repository", "", "The provider repository to add")
-	outputFile := flag.String("output", "", "Path to write JSON result to")
+	outputFile := flag.String("output", "output.json", "Path to write JSON result to")
 	providerDataDir := flag.String("provider-data", "../providers", "Directory containing the provider data")
 
 	flag.Parse()
@@ -70,8 +70,8 @@ func main() {
 		}
 		for _, p := range providers {
 			if strings.ToLower(p.RepositoryURL()) == strings.ToLower(submitted.RepositoryURL()) {
-				output.Exists = true
-				return fmt.Errorf("Repository already exists in the registry, %s", p.RepositoryURL())
+				// 	output.Exists = true
+				// 	return fmt.Errorf("Repository already exists in the registry, %s", p.RepositoryURL())
 			}
 		}
 

--- a/src/cmd/add-provider/main.go
+++ b/src/cmd/add-provider/main.go
@@ -70,8 +70,8 @@ func main() {
 		}
 		for _, p := range providers {
 			if strings.ToLower(p.RepositoryURL()) == strings.ToLower(submitted.RepositoryURL()) {
-				// 	output.Exists = true
-				// 	return fmt.Errorf("Repository already exists in the registry, %s", p.RepositoryURL())
+				output.Exists = true
+				return fmt.Errorf("Repository already exists in the registry, %s", p.RepositoryURL())
 			}
 		}
 

--- a/src/internal/provider/shasum.go
+++ b/src/internal/provider/shasum.go
@@ -13,7 +13,7 @@ func (p Provider) GetSHASums(shaFileDownloadUrl string) (map[string]string, erro
 		return nil, fmt.Errorf("failed to download asset contents: %w", assetErr)
 	}
 	if contents == nil {
-		return nil, nil
+		return nil, fmt.Errorf("SHASUM file is empty or missing: %s", shaFileDownloadUrl)
 	}
 
 	return shaFileToMap(contents), nil


### PR DESCRIPTION
Closes #280 

# Description

- Removed a few extra spaces on the texts
- Add output.json as default on this script 
- Removed an extra slash on the github-action bot comment (https://github.com/opentofu/registry/pull/1438) after the src.
- Provided a better error message when shaSum file is missing.

Tested with https://github.com/diofeher/terraform-provider-nix-signature/releases/tag/v0.1.1

<img width="896" alt="Screenshot 2025-01-13 at 19 04 00" src="https://github.com/user-attachments/assets/91f0df92-a5d9-4cc9-8f8b-35ed1948b142" />

