### PR TITLE
fix: warning error for slog

### DIFF
--- a/src/cmd/run-server/main.go
+++ b/src/cmd/run-server/main.go
@@ -18,7 +18,7 @@ func main() {
 
 	_, err := os.Stat(*destinationDir)
 	if err != nil {
-		logger.Error("Could not open folder", err)
+		logger.Error("Could not open folder", slog.Any("error", err))
 		os.Exit(1)
 	}
 
@@ -29,7 +29,7 @@ func main() {
 
 	err = http.ListenAndServeTLS(":8443", *certFile, *keyFile, nil)
 	if err != nil {
-		logger.Error("Failed to start server", err)
+		logger.Error("Failed to start server", slog.Any("error", err))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
When running tests:

```
cmd/run-server/main.go:21:41: slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)
cmd/run-server/main.go:32:42: slog.Logger.Error arg "err" should be a string or a slog.Attr (possible missing key or value)
```

Fixed this.