### PR TITLE
add one additional validation for the provider keys

### DIFF
--- a/.github/scripts/submit-provider-key-check.sh
+++ b/.github/scripts/submit-provider-key-check.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+set -x
+
+keyfile="$1"
+owner="$2"
+provider_name="$3"
+if [[ -z "${NUMBER}" ]]; then
+  echo "Please run this script from a GitHub Action. The issue NUMBER is missing"
+  exit 1
+fi
+if [[ -z "${keyfile}" ]]; then
+  echo "no keyfile provided"
+  exit 1
+fi
+if [[ -z "${owner}" ]]; then
+  echo  "no owner provided"
+  exit 2
+fi
+if [[ "${owner}" == "hashicorp" || "${owner}" == "opentofu" ]]; then
+  echo "No checks required for 'hashicorp' or 'opentofu' namespaced providers"
+  exit 0
+fi
+
+function check_repo_release() {
+  local owner="${1}"
+  local repo="${2}"
+  local release="${3}"
+  # download the GPG signature from the given provider release
+  gh release download --repo "${owner}/${repo}" "${release}" -p "*SHA256*"
+  # verify the signatures
+  sigfile=$(find . -name "*SHA256SUMS.sig" -print | head -1)
+  shafile=$(find . -name "*SHA256SUMS" -print | head -1)
+  if gpg --verify "${sigfile}" "${shafile}" > /dev/null 2>&1
+  then
+    echo "Key is matching signatures from ${owner}/${repo}@${release}"
+    rm "${shafile}" "${sigfile}"
+    return 0
+  fi
+  echo "Key does not match signatures from ${owner}/${repo}@${release}"
+  rm "${shafile}" "${sigfile}"
+  return 1
+}
+
+function check_repo_versions() {
+  local owner="${1}"
+  local repo="${2}"
+  # check recent releases of the owner's repo (3 releases checked)
+  while IFS= read -r release; do
+    if check_repo_release "${owner}" "${repo}" "${release}"
+    then
+      # once one release is matching the signature, we are good to go, so return success
+      return 0
+    fi
+  # list the latest 100 releases of the repository and get only the release names
+  done <<< "$(gh release list --exclude-drafts --exclude-pre-releases --repo "${owner}/${repo}" -L 3 -O desc --json name -q '.[].name')"
+  # if no release is matching the signature, return error
+  return 1
+}
+
+function check_owner_repos() {
+  local owner="${1}"
+  # list first 100 repos of the owner and get all the terraform-provider-* repos to check their releases
+  repos="$(gh repo list "${owner}" --no-archived --source -L 100 --json name -q '.[].name | select(. | contains("terraform-provider-"))')"
+  while IFS= read -r repo; do
+    if check_repo_versions "${owner}" "${repo}" "${release}"
+    then
+      return 0
+    fi
+  done <<< "${repos}"
+  return 1
+}
+
+# prepare gpg
+apt update && apt install -y gpg
+# import the submitted key
+gpg --import "${keyfile}" 2>/dev/null
+# trust the newly imported key
+for fpr in $(gpg --list-keys --with-colons | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "5\ny\n" | gpg -q --command-fd 0 --expert --edit-key "${fpr}" trust; done
+
+if [[ -n "${provider_name}" ]]; then
+  # if the submission contains also the provider name, we will check the signatures only of that particular provider
+  repo="terraform-provider-${provider_name}"
+  if ! check_repo_versions "${owner}" "${repo}"
+  then
+    gh issue comment "${NUMBER}" -b "Key is matching no recent release of ${owner}/${repo}"
+    echo "Key is matching no recent release of ${owner}/${repo}"
+    exit 0
+  fi
+else
+  # if no provider name is given, will check the key against any terraform-provider-* repo of the owner
+  if ! check_owner_repos "${owner}"
+  then
+    gh issue comment "${NUMBER}" -b "Key is matching no recent release from any 'terraform-provider-*' of ${owner}"
+    echo "Key is matching no recent release from any 'terraform-provider-*' of ${owner}"
+    exit 0
+  fi
+fi
+gh issue comment "${NUMBER}" -b "Key provider signatures validation succeeded!"
+
+# cleanup keys
+for fpr in $(gpg --list-keys --with-colons -q | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "y\n" | gpg --command-fd 0 --expert --delete-keys "${fpr}"; done
+

--- a/.github/scripts/submit-provider-key-check.sh
+++ b/.github/scripts/submit-provider-key-check.sh
@@ -99,7 +99,7 @@ else
     exit 0
   fi
 fi
-gh issue comment "${NUMBER}" -b "Key provider signatures validation succeeded!"
+gh issue comment "${NUMBER}" -b "Key validation against provider's signatures succeeded!"
 
 # cleanup keys
 # shellcheck disable=SC2312

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -60,12 +60,6 @@ if [[ -z "${providername}" ]]; then
 else
   keyfile="../keys/${namespace:0:1}/${namespace}/${providername}/provider-$(date +%s).asc"
 fi
-if [[ -d "$(dirname "${keyfile}")" ]]; then
-  msg="Updated"
-  #git rm $(dirname $keyfile)/*
-else
-  msg="Created"
-fi
 mkdir -p "$(dirname "${keyfile}")"
 mv tmp.key "${keyfile}"
 

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -55,12 +55,10 @@ if [[ "${verification}" != 0 ]]; then
   exit 1
 fi
 
-repo=""
 if [[ -z "${providername}" ]]; then
   keyfile="../keys/${namespace:0:1}/${namespace}/provider-$(date +%s).asc"
 else
   keyfile="../keys/${namespace:0:1}/${namespace}/${providername}/provider-$(date +%s).asc"
-  repo="${namespace}/terraform-provider-${providername}"
 fi
 if [[ -d "$(dirname "${keyfile}")" ]]; then
   msg="Updated"
@@ -93,29 +91,5 @@ else
 fi
 git push -u origin "${branch}"
 
-# Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "${msg} ${keyfile/.././} for provider ${namespace}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
-gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
-gh issue lock "${NUMBER}" -r resolved
-
-if [[ -n "${repo}" ]]; then
-  apt update && apt install -y gpg
-  # get the latest release of the provider
-  latest_release=$(gh release list --exclude-drafts --exclude-pre-releases --repo "${repo}" -L 1 -O desc --json name -q '.[].name')
-  # download the GPG signature from the last provider release
-  gh release download --repo "${repo}" "${latest_release}" -p "*SHA256*"
-  # import the submitted key
-  gpg --import "${keyfile}"
-  # trust the newly imported key
-  for fpr in $(gpg --list-keys --with-colons | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "5\ny\n" | gpg --command-fd 0 --expert --edit-key "${fpr}" trust; done
-  # verify the signatures
-  sigfile=$(find . -name "*SHA256SUMS.sig" -print | head -1)
-  shafile=$(find . -name "*SHA256SUMS" -print | head -1)
-  if ! gpg --verify "${sigfile}" "${shafile}"
-  then
-    gh issue comment "${NUMBER}" -b "Failed to validate the submitted key against ${repo}@${latest_release}. Could this key be for an older version of the provider?"
-  fi
-  # cleanup
-  rm "${shafile}" "${sigfile}"
-  for fpr in $(gpg --list-keys --with-colons | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "y\n" |  gpg --command-fd 0 --expert --delete-keys "${fpr}"; done
-fi
+curr_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+"${curr_dir}/submit-provider-key-check.sh" "${keyfile}" "${namespace}" "${providername}"

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -113,7 +113,7 @@ if [[ -n "${repo}" ]]; then
   shafile=$(find . -name "*SHA256SUMS" -print | head -1)
   if ! gpg --verify "${sigfile}" "${shafile}"
   then
-    gh issue comment "${NUMBER}" -b "Failed to validate the submitted key against ${repo}@${latest_release}"
+    gh issue comment "${NUMBER}" -b "Failed to validate the submitted key against ${repo}@${latest_release}. Could this key be for an older version of the provider?"
   fi
   # cleanup
   rm "${shafile}" "${sigfile}"

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -60,6 +60,12 @@ if [[ -z "${providername}" ]]; then
 else
   keyfile="../keys/${namespace:0:1}/${namespace}/${providername}/provider-$(date +%s).asc"
 fi
+if [[ -d "$(dirname "${keyfile}")" ]]; then
+  msg="Updated"
+  #git rm $(dirname $keyfile)/*
+else
+  msg="Created"
+fi
 mkdir -p "$(dirname "${keyfile}")"
 mv tmp.key "${keyfile}"
 
@@ -84,6 +90,11 @@ else
   git commit -s -m "Create provider key ${namespace}"
 fi
 git push -u origin "${branch}"
+
+# Create pull request and update issue
+pr=$(gh pr create --title "${TITLE}" --body "${msg} ${keyfile/.././} for provider ${namespace}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
+gh issue lock "${NUMBER}" -r resolved
 
 curr_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 "${curr_dir}/submit-provider-key-check.sh" "${keyfile}" "${namespace}" "${providername}"


### PR DESCRIPTION
Resolved #356

These are the validations that I personally run every time a new provider key is submitted.
I suggest adding these in the script that validates the submitted keys. This way, we also tackle [this part of the PROCEDURES.md](https://github.com/opentofu/registry/blob/main/PROCEDURES.md#user-complaint-the-provider-is-not-signed-with-a-valid-signing-key).

As also discussed in #356, we could also use `tofu init` for doing so but for the moment that is overkill. In case the current approach does not suffice, we could reiterate later.