### PR TITLE
GPG Key validation fixes

### DIFF
--- a/.github/scripts/submit-provider-key-check.sh
+++ b/.github/scripts/submit-provider-key-check.sh
@@ -81,7 +81,7 @@ apt update && apt install -y gpg
 gpg --import "${keyfile}" 2>/dev/null
 # trust the newly imported key
 # shellcheck disable=SC2312
-for fpr in $(gpg --list-keys --with-colons | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "5\ny\n" | gpg -q --command-fd 0 --expert --edit-key "${fpr}" trust; done
+for fpr in $(gpg --list-keys --with-colons | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "5\ny\n" | gpg -q --command-fd 0 --no-tty --expert --edit-key "${fpr}" trust; done
 
 if [[ -n "${provider_name}" ]]; then
   # if the submission contains also the provider name, we will check the signatures only of that particular provider
@@ -103,5 +103,5 @@ gh issue comment "${NUMBER}" -b "Key validation against provider's signatures su
 
 # cleanup keys
 # shellcheck disable=SC2312
-for fpr in $(gpg --list-keys --with-colons -q | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "y\n" | gpg --command-fd 0 --expert --delete-keys "${fpr}"; done
+for fpr in $(gpg --list-keys --with-colons -q | grep "pub:" | awk -F: '{print $5}' | sort -u); do  echo -e "y\n" | gpg --command-fd 0 --no-tty --expert --delete-keys "${fpr}"; done
 

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -94,7 +94,9 @@ git push -u origin "${branch}"
 # Create pull request and update issue
 pr=$(gh pr create --title "${TITLE}" --body "${msg} ${keyfile/.././} for provider ${namespace}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
 gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
-gh issue lock "${NUMBER}" -r resolved
 
 curr_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
 "${curr_dir}/submit-provider-key-check.sh" "${keyfile}" "${namespace}" "${providername}"
+
+# lock the issue after checking the key against provider's signatures to allow additional comments to be added
+gh issue lock "${NUMBER}" -r resolved


### PR DESCRIPTION
add no-tty to the gpg commands; lock the issue only after checking the signature