### PR TITLE
provider: deprecate sapcc/ccloud provider

### DIFF
--- a/providers/s/sapcc/ccloud.json
+++ b/providers/s/sapcc/ccloud.json
@@ -1919,5 +1919,8 @@
         }
       ]
     }
+  ],
+  "warnings": [
+    "This provider has moved to SAP-cloud-infrastructure/sci. Please update your source in required_providers."
   ]
 }


### PR DESCRIPTION
Added a warning message to inform users that the `sapcc/ccloud` provider is deprecated and they should use a replacement instead. This helps guide users to the maintained version of the provider.

Similar to:

```
$ curl -s https://registry.terraform.io/v1/providers/sapcc/ccloud/versions | jq -r '.warnings'
[
  "For users on Terraform 0.13 or greater, this provider has moved to SAP-cloud-infrastructure/sci. Please update your source in required_providers."
]
```