### PR TITLE
Better logging when missing checksum files

### DIFF
--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -61,6 +61,6 @@ git commit -s -m "Create provider ${namespace}/${name}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/} for provider ${namespace}/${name}.  Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
-gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
+pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/} for provider ${namespace}/${name}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}). This issue has been locked."
 gh issue lock "${NUMBER}" -r resolved

--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -61,6 +61,6 @@ git commit -s -m "Create provider ${namespace}/${name}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/} for provider ${namespace}/${name}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
-gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}). This issue has been locked."
+pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/} for provider ${namespace}/${name}.  Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
 gh issue lock "${NUMBER}" -r resolved

--- a/src/cmd/add-provider/main.go
+++ b/src/cmd/add-provider/main.go
@@ -101,7 +101,7 @@ func main() {
 			return fmt.Errorf("An unexpected error occured: %w", err)
 		}
 		if len(meta.Versions) == 0 {
-			return fmt.Errorf("No versions detected for repository %s", submitted.RepositoryURL())
+			return fmt.Errorf("No valid versions are detected for repository %s. Please check the releases and their checksum files.", submitted.RepositoryURL())
 		}
 
 		output.Namespace = submitted.Namespace

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -46,6 +46,7 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	if checksums == nil {
 		logger.Warn("checksums not found in release, skipping...")
 		return nil, nil


### PR DESCRIPTION
Resolves #280 

Right now, our code is showing errors on the Github issue by using a json file: 

- This is what is writing the file: https://github.com/opentofu/registry/blob/main/src/cmd/add-provider/main.go#L119
- The validation error is here: https://github.com/opentofu/registry/blob/main/src/cmd/add-provider/main.go#L115
- After that, we read from the `output.json` file, and comment on Github https://github.com/opentofu/registry/blob/main/.github/scripts/submit-provider.sh#L34

This makes difficult to return multiple errors to the Github interface since only one error is allowed. This would need to be refactored in order to support multiple error messages, because sometimes we allow missing Checksum files, depending if there's one valid release, so this would have no errors.

Since this is a small issue, I propose we don't spend too much time on it and just return a message that point to people that a checksum file can be missing in addition to the "No valid versions" message. At the same time, I'm logging specifically which releases are missing.