### PR TITLE
add `.github/CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone opens a
+# pull request.
+
+* @opentofu/maintainers


### PR DESCRIPTION
Missing CODEOWNERS file for this repo.