### PR TITLE
Add retries on 403 errors when fetching assets from github releases

### DIFF
--- a/src/internal/github/assets.go
+++ b/src/internal/github/assets.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"time"
 )
 
 // DownloadAssetContents downloads the contents of the asset at the given URL and returns it directly
@@ -15,9 +16,29 @@ func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
 	logger := c.log.With(slog.String("url", downloadURL))
 	logger.Info("Downloading asset")
 
-	resp, err := c.httpClient.Get(downloadURL)
-	if err != nil {
-		return nil, fmt.Errorf("error downloading asset %s: %w", downloadURL, err)
+	var resp *http.Response
+	var err error
+	maxRetries := 4
+
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		resp, err = c.httpClient.Get(downloadURL)
+		if err != nil {
+			return nil, fmt.Errorf("error downloading asset %s: %w", downloadURL, err)
+		}
+
+		// Only retry on 403 Forbidden - suspected GitHub caching issue
+		if resp.StatusCode == http.StatusForbidden && attempt < maxRetries-1 {
+			resp.Body.Close()
+			backoffDuration := time.Duration(1<<attempt) * time.Second
+
+			logger.Warn("got 403 Forbidden, retrying after backoff due to suspected github caching issue 🤞",
+				slog.Int("attempt", attempt+1),
+				slog.Duration("backoff", backoffDuration))
+			time.Sleep(backoffDuration)
+			continue
+		}
+
+		break
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
Lately, we've been seeing strange 403 errors when fetching assets from GitHub releases.

This PR adds a retry mechanism to handle these errors gracefully. 
We suspect that there is something going on with GitHub's rate limiting or access control that is causing these intermittent failures, and this is a bit of a last-ditch attempt until we can reproduce this locally 100% of the time.

The retry mechanism will attempt to fetch the asset up to three times before giving up, which should help mitigate the impact of these errors on our users.