### PR TITLE
Add PR provenance links and JSON verification check

### DIFF
--- a/.github/scripts/submit-module.sh
+++ b/.github/scripts/submit-module.sh
@@ -62,6 +62,8 @@ git commit -s -m "Create module ${namespace}/${name}/${target}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
+# GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID are default GitHub Actions env vars
+# shellcheck disable=SC2154
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 pr_body="Created ${jsonfile/../src/} for module ${namespace}/${name}/${target}.
 

--- a/.github/scripts/submit-module.sh
+++ b/.github/scripts/submit-module.sh
@@ -62,6 +62,13 @@ git commit -s -m "Create module ${namespace}/${name}/${target}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/} for module ${namespace}/${name}/${target}.  Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+pr_body="Created ${jsonfile/../src/} for module ${namespace}/${name}/${target}.
+
+- **Source Issue:** #${NUMBER}
+- **Created by:** [GitHub Actions Run](${run_url})
+
+Closes #${NUMBER}."
+pr=$(gh pr create --title "${TITLE}" --body "${pr_body}")
 gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
 gh issue lock "${NUMBER}" -r resolved

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -92,6 +92,13 @@ fi
 git push -u origin "${branch}"
 
 # Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "${msg} ${keyfile/.././} for provider ${namespace}. Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+pr_body="${msg} ${keyfile/.././} for provider ${namespace}.
+
+- **Source Issue:** #${NUMBER}
+- **Created by:** [GitHub Actions Run](${run_url})
+
+Closes #${NUMBER}."
+pr=$(gh pr create --title "${TITLE}" --body "${pr_body}")
 gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
 gh issue lock "${NUMBER}" -r resolved

--- a/.github/scripts/submit-provider-key.sh
+++ b/.github/scripts/submit-provider-key.sh
@@ -92,6 +92,8 @@ fi
 git push -u origin "${branch}"
 
 # Create pull request and update issue
+# GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID are default GitHub Actions env vars
+# shellcheck disable=SC2154
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 pr_body="${msg} ${keyfile/.././} for provider ${namespace}.
 

--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -61,6 +61,8 @@ git commit -s -m "Create provider ${namespace}/${name}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
+# GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID are default GitHub Actions env vars
+# shellcheck disable=SC2154
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 pr_body="Created ${jsonfile/../src/} for provider ${namespace}/${name}.
 

--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -61,6 +61,13 @@ git commit -s -m "Create provider ${namespace}/${name}"
 git push -u origin "${branch}"
 
 # Create pull request and update issue
-pr=$(gh pr create --title "${TITLE}" --body "Created ${jsonfile/../src/} for provider ${namespace}/${name}.  Closes #${NUMBER}.") #--assignee opentofu/core-engineers)
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+pr_body="Created ${jsonfile/../src/} for provider ${namespace}/${name}.
+
+- **Source Issue:** #${NUMBER}
+- **Created by:** [GitHub Actions Run](${run_url})
+
+Closes #${NUMBER}."
+pr=$(gh pr create --title "${TITLE}" --body "${pr_body}")
 gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}).  This issue has been locked."
 gh issue lock "${NUMBER}" -r resolved

--- a/.github/scripts/verify-pr-json.sh
+++ b/.github/scripts/verify-pr-json.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ -z "${PR_NUMBER:-}" ]]; then
+  echo "PR_NUMBER is required."
+  exit 1
+fi
+
+failed=0
+error_file="/tmp/verify-errors.md"
+
+write_error_header() {
+  if [[ ! -f "${error_file}" ]]; then
+    cat > "${error_file}" <<'HEADER'
+## JSON Verification Failed
+
+The JSON files in this PR do not match what is generated from the source repositories. This may indicate tampered data or a race condition with new upstream releases.
+
+HEADER
+  fi
+}
+
+# Compare two JSON files semantically (normalized key order and formatting)
+# Returns 0 if equal, 1 if different. Stores diff output in $json_diff_output.
+json_diff() {
+  json_diff_output=$(diff -u <(jq --sort-keys '.' "$1") <(jq --sort-keys '.' "$2") || true)
+  [[ -z "${json_diff_output}" ]]
+}
+
+# Get changed provider and module JSON files via GitHub API
+changed_providers=$(gh pr diff "${PR_NUMBER}" --name-only | grep '^providers/.*\.json$' || true)
+changed_modules=$(gh pr diff "${PR_NUMBER}" --name-only | grep '^modules/.*\.json$' || true)
+
+if [[ -z "${changed_providers}" && -z "${changed_modules}" ]]; then
+  echo "No provider or module JSON changes detected."
+  exit 0
+fi
+
+# Verify each changed provider JSON
+for file in ${changed_providers}; do
+  # Path format: providers/{first_char}/{namespace}/{name}.json
+  namespace=$(echo "${file}" | cut -d'/' -f3)
+  name=$(basename "${file}" .json)
+  repo="${namespace}/terraform-provider-${name}"
+
+  tmpdir=$(mktemp -d)
+
+  echo "::group::Verifying provider ${repo}"
+  echo "Regenerating JSON for ${repo}..."
+
+  if ! go run ./cmd/add-provider -repository="${repo}" -provider-data="${tmpdir}" -output="${tmpdir}/output.json" 2>&1; then
+    echo "::error::Failed to regenerate provider ${repo}"
+    write_error_header
+    printf '### Provider `%s`\nFailed to regenerate JSON from source repository.\n\n' "${repo}" >> "${error_file}"
+    failed=1
+    rm -rf "${tmpdir}"
+    echo "::endgroup::"
+    continue
+  fi
+
+  first_char=$(echo "${namespace}" | cut -c1 | tr '[:upper:]' '[:lower:]')
+  generated_file="${tmpdir}/${first_char}/${namespace}/${name}.json"
+
+  if [[ ! -f "${generated_file}" ]]; then
+    echo "::error::Regeneration produced no output file for provider ${repo}"
+    write_error_header
+    printf '### Provider `%s`\nRegeneration produced no output file.\n\n' "${repo}" >> "${error_file}"
+    failed=1
+    rm -rf "${tmpdir}"
+    echo "::endgroup::"
+    continue
+  fi
+
+  if ! json_diff "../${file}" "${generated_file}"; then
+    echo "${json_diff_output}"
+    echo "::error::Provider ${repo} JSON does not match regenerated output. PR may contain tampered data."
+    write_error_header
+    printf '### Provider `%s`\nJSON does not match regenerated output:\n```diff\n' "${repo}" >> "${error_file}"
+    echo "${json_diff_output}" >> "${error_file}"
+    printf '```\n\n' >> "${error_file}"
+    failed=1
+  else
+    echo "PASS: Provider ${repo} JSON matches regenerated output."
+  fi
+
+  rm -rf "${tmpdir}"
+  echo "::endgroup::"
+done
+
+# Verify each changed module JSON
+for file in ${changed_modules}; do
+  # Path format: modules/{first_char}/{namespace}/{name}/{target}.json
+  namespace=$(echo "${file}" | cut -d'/' -f3)
+  name=$(echo "${file}" | cut -d'/' -f4)
+  target=$(basename "${file}" .json)
+  repo="${namespace}/terraform-${target}-${name}"
+
+  tmpdir=$(mktemp -d)
+
+  echo "::group::Verifying module ${repo}"
+  echo "Regenerating JSON for ${repo}..."
+
+  if ! go run ./cmd/add-module -repository="${repo}" -module-data="${tmpdir}" -output="${tmpdir}/output.json" 2>&1; then
+    echo "::error::Failed to regenerate module ${repo}"
+    write_error_header
+    printf '### Module `%s`\nFailed to regenerate JSON from source repository.\n\n' "${repo}" >> "${error_file}"
+    failed=1
+    rm -rf "${tmpdir}"
+    echo "::endgroup::"
+    continue
+  fi
+
+  first_char=$(echo "${namespace}" | cut -c1 | tr '[:upper:]' '[:lower:]')
+  generated_file="${tmpdir}/${first_char}/${namespace}/${name}/${target}.json"
+
+  if [[ ! -f "${generated_file}" ]]; then
+    echo "::error::Regeneration produced no output file for module ${repo}"
+    write_error_header
+    printf '### Module `%s`\nRegeneration produced no output file.\n\n' "${repo}" >> "${error_file}"
+    failed=1
+    rm -rf "${tmpdir}"
+    echo "::endgroup::"
+    continue
+  fi
+
+  if ! json_diff "../${file}" "${generated_file}"; then
+    echo "${json_diff_output}"
+    echo "::error::Module ${repo} JSON does not match regenerated output. PR may contain tampered data."
+    write_error_header
+    printf '### Module `%s`\nJSON does not match regenerated output:\n```diff\n' "${repo}" >> "${error_file}"
+    echo "${json_diff_output}" >> "${error_file}"
+    printf '```\n\n' >> "${error_file}"
+    failed=1
+  else
+    echo "PASS: Module ${repo} JSON matches regenerated output."
+  fi
+
+  rm -rf "${tmpdir}"
+  echo "::endgroup::"
+done
+
+if [[ "${failed}" -ne 0 ]]; then
+  echo ""
+  echo "::error::Verification failed. One or more JSON files do not match regenerated output."
+  exit 1
+fi
+
+echo ""
+echo "All provider and module JSON files verified successfully."

--- a/.github/scripts/verify-pr-json.sh
+++ b/.github/scripts/verify-pr-json.sh
@@ -3,29 +3,29 @@
 set -euo pipefail
 
 if [[ -z "${PR_NUMBER:-}" ]]; then
-  echo "PR_NUMBER is required."
-  exit 1
+	echo "PR_NUMBER is required."
+	exit 1
 fi
 
 failed=0
 error_file="/tmp/verify-errors.md"
 
 write_error_header() {
-  if [[ ! -f "${error_file}" ]]; then
-    cat > "${error_file}" <<'HEADER'
+	if [[ ! -f "${error_file}" ]]; then
+		cat >"${error_file}" <<'HEADER'
 ## JSON Verification Failed
 
 The JSON files in this PR do not match what is generated from the source repositories. This may indicate tampered data or a race condition with new upstream releases.
 
 HEADER
-  fi
+	fi
 }
 
 # Compare two JSON files semantically (normalized key order and formatting)
 # Stores diff output in $json_diff_output. Sets return code 0 if equal, 1 if different.
 json_diff() {
-  json_diff_output=$(diff -u <(jq --sort-keys '.' "$1") <(jq --sort-keys '.' "$2") || true)
-  [[ -z "${json_diff_output}" ]]
+	json_diff_output=$(diff -u <(jq --sort-keys '.' "$1") <(jq --sort-keys '.' "$2") || true)
+	[[ -z "${json_diff_output}" ]]
 }
 
 # Get changed provider and module JSON files via GitHub API
@@ -33,145 +33,141 @@ changed_providers=$(gh pr diff "${PR_NUMBER}" --name-only | grep '^providers/.*\
 changed_modules=$(gh pr diff "${PR_NUMBER}" --name-only | grep '^modules/.*\.json$' || true)
 
 if [[ -z "${changed_providers}" && -z "${changed_modules}" ]]; then
-  echo "No provider or module JSON changes detected."
-  exit 0
+	echo "No provider or module JSON changes detected."
+	exit 0
 fi
 
 # Verify each changed provider JSON
 for file in ${changed_providers}; do
-  # Path format: providers/{first_char}/{namespace}/{name}.json
-  namespace=$(echo "${file}" | cut -d'/' -f3)
-  name=$(basename "${file}" .json)
-  repo="${namespace}/terraform-provider-${name}"
+	# Path format: providers/{first_char}/{namespace}/{name}.json
+	namespace=$(echo "${file}" | cut -d'/' -f3)
+	name=$(basename "${file}" .json)
+	repo="${namespace}/terraform-provider-${name}"
 
-  tmpdir=$(mktemp -d)
+	tmpdir=$(mktemp -d)
 
-  echo "::group::Verifying provider ${repo}"
-  echo "Regenerating JSON for ${repo}..."
+	echo "::group::Verifying provider ${repo}"
+	echo "Regenerating JSON for ${repo}..."
 
-  if ! go run ./cmd/add-provider -repository="${repo}" -provider-data="${tmpdir}" -output="${tmpdir}/output.json" 2>&1; then
-    echo "::error::Failed to regenerate provider ${repo}"
-    write_error_header
-    cat >> "${error_file}" <<EOF
+	if ! go run ./cmd/add-provider -repository="${repo}" -provider-data="${tmpdir}" -output="${tmpdir}/output.json" 2>&1; then
+		echo "::error::Failed to regenerate provider ${repo}"
+		write_error_header
+		cat >>"${error_file}" <<EOF
 ### Provider \`${repo}\`
 Failed to regenerate JSON from source repository.
 
 EOF
-    failed=1
-    rm -rf "${tmpdir}"
-    echo "::endgroup::"
-    continue
-  fi
+		failed=1
+		rm -rf "${tmpdir}"
+		echo "::endgroup::"
+		continue
+	fi
 
-  first_char=$(echo "${namespace}" | cut -c1 | tr '[:upper:]' '[:lower:]')
-  generated_file="${tmpdir}/${first_char}/${namespace}/${name}.json"
+	first_char=$(echo "${namespace}" | cut -c1 | tr '[:upper:]' '[:lower:]')
+	generated_file="${tmpdir}/${first_char}/${namespace}/${name}.json"
 
-  if [[ ! -f "${generated_file}" ]]; then
-    echo "::error::Regeneration produced no output file for provider ${repo}"
-    write_error_header
-    cat >> "${error_file}" <<EOF
+	if [[ ! -f "${generated_file}" ]]; then
+		echo "::error::Regeneration produced no output file for provider ${repo}"
+		write_error_header
+		cat >>"${error_file}" <<EOF
 ### Provider \`${repo}\`
 Regeneration produced no output file.
 
 EOF
-    failed=1
-    rm -rf "${tmpdir}"
-    echo "::endgroup::"
-    continue
-  fi
+		failed=1
+		rm -rf "${tmpdir}"
+		echo "::endgroup::"
+		continue
+	fi
 
-  json_diff "../${file}" "${generated_file}" || true
-  if [[ -n "${json_diff_output}" ]]; then
-    echo "${json_diff_output}"
-    echo "::error::Provider ${repo} JSON does not match regenerated output. PR may contain tampered data."
-    write_error_header
-    cat >> "${error_file}" <<EOF
+	if ! json_diff "../${file}" "${generated_file}"; then
+		echo "${json_diff_output}"
+		echo "::error::Provider ${repo} JSON does not match regenerated output. PR may contain tampered data."
+		write_error_header
+		cat >>"${error_file}" <<EOF
 ### Provider \`${repo}\`
 JSON does not match regenerated output:
 \`\`\`diff
 ${json_diff_output}
 \`\`\`
-
 EOF
-    failed=1
-  else
-    echo "PASS: Provider ${repo} JSON matches regenerated output."
-  fi
+		failed=1
+	else
+		echo "PASS: Provider ${repo} JSON matches regenerated output."
+	fi
 
-  rm -rf "${tmpdir}"
-  echo "::endgroup::"
+	rm -rf "${tmpdir}"
+	echo "::endgroup::"
 done
 
 # Verify each changed module JSON
 for file in ${changed_modules}; do
-  # Path format: modules/{first_char}/{namespace}/{name}/{target}.json
-  namespace=$(echo "${file}" | cut -d'/' -f3)
-  name=$(echo "${file}" | cut -d'/' -f4)
-  target=$(basename "${file}" .json)
-  repo="${namespace}/terraform-${target}-${name}"
+	# Path format: modules/{first_char}/{namespace}/{name}/{target}.json
+	namespace=$(echo "${file}" | cut -d'/' -f3)
+	name=$(echo "${file}" | cut -d'/' -f4)
+	target=$(basename "${file}" .json)
+	repo="${namespace}/terraform-${target}-${name}"
 
-  tmpdir=$(mktemp -d)
+	tmpdir=$(mktemp -d)
 
-  echo "::group::Verifying module ${repo}"
-  echo "Regenerating JSON for ${repo}..."
+	echo "::group::Verifying module ${repo}"
+	echo "Regenerating JSON for ${repo}..."
 
-  if ! go run ./cmd/add-module -repository="${repo}" -module-data="${tmpdir}" -output="${tmpdir}/output.json" 2>&1; then
-    echo "::error::Failed to regenerate module ${repo}"
-    write_error_header
-    cat >> "${error_file}" <<EOF
+	if ! go run ./cmd/add-module -repository="${repo}" -module-data="${tmpdir}" -output="${tmpdir}/output.json" 2>&1; then
+		echo "::error::Failed to regenerate module ${repo}"
+		write_error_header
+		cat >>"${error_file}" <<EOF
 ### Module \`${repo}\`
 Failed to regenerate JSON from source repository.
 
 EOF
-    failed=1
-    rm -rf "${tmpdir}"
-    echo "::endgroup::"
-    continue
-  fi
+		failed=1
+		rm -rf "${tmpdir}"
+		echo "::endgroup::"
+		continue
+	fi
 
-  first_char=$(echo "${namespace}" | cut -c1 | tr '[:upper:]' '[:lower:]')
-  generated_file="${tmpdir}/${first_char}/${namespace}/${name}/${target}.json"
+	first_char=$(echo "${namespace}" | cut -c1 | tr '[:upper:]' '[:lower:]')
+	generated_file="${tmpdir}/${first_char}/${namespace}/${name}/${target}.json"
 
-  if [[ ! -f "${generated_file}" ]]; then
-    echo "::error::Regeneration produced no output file for module ${repo}"
-    write_error_header
-    cat >> "${error_file}" <<EOF
+	if [[ ! -f "${generated_file}" ]]; then
+		echo "::error::Regeneration produced no output file for module ${repo}"
+		write_error_header
+		cat >>"${error_file}" <<EOF
 ### Module \`${repo}\`
 Regeneration produced no output file.
 
 EOF
-    failed=1
-    rm -rf "${tmpdir}"
-    echo "::endgroup::"
-    continue
-  fi
+		failed=1
+		rm -rf "${tmpdir}"
+		echo "::endgroup::"
+		continue
+	fi
 
-  json_diff "../${file}" "${generated_file}" || true
-  if [[ -n "${json_diff_output}" ]]; then
-    echo "${json_diff_output}"
-    echo "::error::Module ${repo} JSON does not match regenerated output. PR may contain tampered data."
-    write_error_header
-    cat >> "${error_file}" <<EOF
+	if ! json_diff "../${file}" "${generated_file}"; then
+		echo "${json_diff_output}"
+		echo "::error::Module ${repo} JSON does not match regenerated output. PR may contain tampered data."
+		write_error_header
+		cat >>"${error_file}" <<EOF
 ### Module \`${repo}\`
 JSON does not match regenerated output:
 \`\`\`diff
 ${json_diff_output}
 \`\`\`
-
 EOF
-    failed=1
-  else
-    echo "PASS: Module ${repo} JSON matches regenerated output."
-  fi
+		failed=1
+	else
+		echo "PASS: Module ${repo} JSON matches regenerated output."
+	fi
 
-  rm -rf "${tmpdir}"
-  echo "::endgroup::"
+	rm -rf "${tmpdir}"
+	echo "::endgroup::"
 done
 
 if [[ "${failed}" -ne 0 ]]; then
-  echo ""
-  echo "::error::Verification failed. One or more JSON files do not match regenerated output."
-  exit 1
+	echo ""
+	echo "::error::Verification failed. One or more JSON files do not match regenerated output."
+	exit 1
 fi
 
 echo ""

--- a/.github/scripts/verify-pr-json.sh
+++ b/.github/scripts/verify-pr-json.sh
@@ -80,6 +80,7 @@ EOF
 		continue
 	fi
 
+	# shellcheck disable=SC2310
 	if ! json_diff "../${file}" "${generated_file}"; then
 		echo "${json_diff_output}"
 		echo "::error::Provider ${repo} JSON does not match regenerated output. PR may contain tampered data."
@@ -144,6 +145,7 @@ EOF
 		continue
 	fi
 
+	# shellcheck disable=SC2310
 	if ! json_diff "../${file}" "${generated_file}"; then
 		echo "${json_diff_output}"
 		echo "::error::Module ${repo} JSON does not match regenerated output. PR may contain tampered data."

--- a/.github/workflows/verify-pr-json.yaml
+++ b/.github/workflows/verify-pr-json.yaml
@@ -1,0 +1,42 @@
+name: Verify PR JSON
+
+on:
+  pull_request:
+    paths:
+      - 'providers/**/*.json'
+      - 'modules/**/*.json'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: './src/go.mod'
+
+      - name: Verify PR JSON
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        working-directory: ./src
+        run: ../.github/scripts/verify-pr-json.sh
+
+      - name: Comment on PR with errors
+        if: failure()
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if [[ -f /tmp/verify-errors.md ]]; then
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/verify-errors.md
+          fi

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,1 @@
+enable=all


### PR DESCRIPTION
Resolves #113 

## Summary

- Automated PRs now include links to the source issue and the GitHub Actions run that created them
- **New PR verification check:** A **required** check that regenerates provider/module JSON from source and compares it against the PR contents, preventing tampered or manually-crafted PRs from being merged.
- Adds .shellcheckrc file to the root of the repo so that local dev environments get the same warnings as ci/cd. This is because our github action for shellcheck checks `-o all`. 

We want to improve the review process of accepting automated provider and module submissions to this repository and part of that is improving our automated security stance and reducing human processes where they can be automated.