### PR TITLE
fix: detect provider repo accidentally submitted as module

### DIFF
--- a/.github/scripts/submit-module.sh
+++ b/.github/scripts/submit-module.sh
@@ -24,6 +24,14 @@ if [[ ! "${repository}" =~ ^[a-zA-Z0-9-]+/terraform-[a-zA-Z0-9-]+$ ]]; then
   exit 1
 fi
 
+# Detect if the user accidentally submitted a provider repo as a module.
+# Provider repos follow the pattern terraform-provider-NAME, which also matches
+# the module regex above. Catch this early with a helpful redirect message.
+if [[ "${repository}" =~ ^[a-zA-Z0-9-]+/terraform-provider-[a-zA-Z0-9-]+$ ]]; then
+  gh issue comment "${NUMBER}" -b "Failed validation: It looks like \`${repository}\` is a **provider** repository, not a module. Provider repos follow the \`terraform-provider-NAME\` naming convention. If you meant to submit a provider, please open a new issue using the [provider submission form](https://github.com/opentofu/registry/issues/new?template=provider.yml). Module repositories should follow the pattern \`ORGANIZATION/terraform-NAME-TARGETSYSTEM\`."
+  exit 1
+fi
+
 set +e
 if ! go run ./cmd/add-module -repository="${repository}" -output=./output.json ; then
   set -euo pipefail


### PR DESCRIPTION
## Summary

Fixes #2034

When a user submits a module issue but accidentally enters a provider repository (e.g. `opentofu/terraform-provider-aws`), the existing format validation check passes because `terraform-provider-aws` matches the broad `terraform-[a-zA-Z0-9-]+` pattern. The error only surfaces later in the Go tooling with a less helpful message.

## Changes

Added an explicit check in `.github/scripts/submit-module.sh` that detects if the submitted repository name follows the `terraform-provider-NAME` pattern **after** the general format check. If matched, the issue receives a clear error comment pointing the user to the correct [provider submission form](https://github.com/opentofu/registry/issues/new?template=provider.yml).

## Example error message

> Failed validation: It looks like `opentofu/terraform-provider-aws` is a **provider** repository, not a module. Provider repos follow the `terraform-provider-NAME` naming convention. If you meant to submit a provider, please open a new issue using the [provider submission form](https://github.com/opentofu/registry/issues/new?template=provider.yml). Module repositories should follow the pattern `ORGANIZATION/terraform-NAME-TARGETSYSTEM`.

## Testing

The logic is a simple bash regex check — no new dependencies. The fix is consistent with the existing pattern used in `submit-provider.sh`.