### PR TITLE
ci: add concurrency groups to generate-and-deploy workflows

### DIFF
--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -13,6 +13,10 @@ on:
           - Development
           - Production
 
+concurrency:
+  group: r2-sync-recent
+  cancel-in-progress: true
+
 jobs:
   generate-and-sync:
     timeout-minutes: 10

--- a/.github/workflows/generate-and-deploy-with-delete.yml
+++ b/.github/workflows/generate-and-deploy-with-delete.yml
@@ -11,6 +11,10 @@ on:
           - Development
           - Production-with-delete
 
+concurrency:
+  group: r2-sync
+  cancel-in-progress: false
+
 jobs:
   generate-and-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-and-deploy.yml
+++ b/.github/workflows/generate-and-deploy.yml
@@ -13,6 +13,10 @@ on:
           - Development
           - Production
 
+concurrency:
+  group: r2-sync
+  cancel-in-progress: false
+
 jobs:
   generate-and-sync:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes #1499

Multiple simultaneous runs of the generate-and-deploy workflows can cause concurrent writes to the same R2 bucket, which may produce inconsistent state.

## Changes

Add concurrency groups to prevent overlapping runs:

- **`generate-and-deploy.yml`** and **`generate-and-deploy-with-delete.yml`**: share the `r2-sync` group with `cancel-in-progress: false` so a full sync is never cancelled mid-run, but a queued duplicate is dropped.
- **`generate-and-deploy-recent.yml`**: uses its own `r2-sync-recent` group with `cancel-in-progress: true` since it runs every 15 minutes and a stale queued run can safely be replaced by the next trigger.

## Testing

Workflow syntax validated locally. The concurrency keys ensure:
- Full syncs are never interrupted
- Duplicate queued runs are dropped
- Recent-only syncs can cancel stale runs