### PR TITLE
Remove outscale provider v1.4.0 to resolve #3668

### DIFF
--- a/providers/o/outscale/outscale.json
+++ b/providers/o/outscale/outscale.json
@@ -1,30 +1,6 @@
 {
   "versions": [
     {
-      "version": "1.4.0",
-      "protocols": [
-        "5.0"
-      ],
-      "shasums_url": "https://github.com/outscale/terraform-provider-outscale/releases/download/v1.4.0/terraform-provider-outscale_1.4.0_SHA256SUMS",
-      "shasums_signature_url": "https://github.com/outscale/terraform-provider-outscale/releases/download/v1.4.0/terraform-provider-outscale_1.4.0_SHA256SUMS.sig",
-      "targets": [
-        {
-          "os": "windows",
-          "arch": "386",
-          "filename": "terraform-provider-outscale_1.4.0_windows_386.zip",
-          "download_url": "https://github.com/outscale/terraform-provider-outscale/releases/download/v1.4.0/terraform-provider-outscale_1.4.0_windows_386.zip",
-          "shasum": "17ded897caf8497e351cf22613002679d807046767c27e3467b00b2fda32f9a6"
-        },
-        {
-          "os": "windows",
-          "arch": "amd64",
-          "filename": "terraform-provider-outscale_1.4.0_windows_amd64.zip",
-          "download_url": "https://github.com/outscale/terraform-provider-outscale/releases/download/v1.4.0/terraform-provider-outscale_1.4.0_windows_amd64.zip",
-          "shasum": "f8b9f5377a173e8aced10ca1ed15e414487fadcd39ff5f70b6b9e794984012d7"
-        }
-      ]
-    },
-    {
       "version": "1.3.2",
       "protocols": [
         "5.0"


### PR DESCRIPTION
Resolves #3668

As mentioned in #3668: The v1.4.0 release was published with an incorrect goreleaser configuration that produced only Windows ZIP artifacts instead of the expected Linux/Darwin packages. The provider maintainers have since corrected and republished the release.

By removing this version, the next automated version bump of the registry should re-index the corrected version.
