### PR TITLE
Update the submission scripts with a hint on how to retrigger the workflow

### DIFF
--- a/.github/scripts/submit-module.sh
+++ b/.github/scripts/submit-module.sh
@@ -39,7 +39,9 @@ if ! go run ./cmd/add-module -repository="${repository}" -output=./output.json ;
     gh issue close "${NUMBER}" -c "$(jq -r '.validation' < ./output.json || true)"
     exit 0
   else
-    gh issue comment "${NUMBER}" -b "$(jq -r '.validation' < ./output.json || true)"
+    error_msg="$(jq -r '.validation' < ./output.json || true)"
+    error_msg="${error_msg}<br\>After the issue is fixed, update the title or the description of the issue to retrigger the submission workflow."
+    gh issue comment "${NUMBER}" -b "${error_msg}"
     exit 1
   fi
 fi

--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -31,7 +31,9 @@ if ! go run ./cmd/add-provider -repository="${repository}" -output=./output.json
     gh issue close "${NUMBER}" -c "$(jq -r '.validation' < ./output.json || true)"
     exit 0
   else
-    gh issue comment "${NUMBER}" -b "$(jq -r '.validation' < ./output.json || true)"
+    error_msg="$(jq -r '.validation' < ./output.json || true)"
+    error_msg="${error_msg}<br\>After the issue is fixed, update the title or the description of the issue to retrigger the submission workflow."
+    gh issue comment "${NUMBER}" -b "${error_msg}"
     exit 1
   fi
 fi

--- a/src/pkg/verification/render.go
+++ b/src/pkg/verification/render.go
@@ -49,5 +49,9 @@ func (r *Result) RenderMarkdown() string {
 		}
 		output += "\n"
 	}
+	if r.DidFail() {
+		output += "\nAfter the issue is fixed, update the title or the description of the issue to retrigger the submission workflow."
+		output += "\n"
+	}
 	return output
 }


### PR DESCRIPTION
It's not clear for the users how to retrigger a submission workflow when there is an error that asks for their action.
This PR adds a hint on what retriggers the workflow.