### PR TITLE
Calculate and store provider meta (H1 hash and size)

### DIFF
--- a/src/internal/github/assets.go
+++ b/src/internal/github/assets.go
@@ -7,8 +7,14 @@ import (
 	"net/http"
 )
 
-// DownloadAssetContents downloads the contents of the asset at the given URL and returns it directly
+// DownloadAssetContents downloads the contents of the asset at the given URL and returns it directly (32kb limit)
 func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
+	return c.DownloadAssetContentsLimited(downloadURL, 32*1024) // 32kb is a reasonable limit for most metadata files
+}
+
+// DownloadAssetContentsLimited downloads the contents of the asset at the given URL and returns it directly, as long as it
+// is within the given limit.
+func (c Client) DownloadAssetContentsLimited(downloadURL string, limit int64) ([]byte, error) {
 	done := c.assetThrottle()
 	defer done()
 
@@ -30,9 +36,21 @@ func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status code when downloading asset %s: %d", downloadURL, resp.StatusCode)
 	}
 
-	contents, err := io.ReadAll(resp.Body)
+	if resp.ContentLength > limit {
+		return nil, fmt.Errorf("exceeded download file content length of %vb for %s with a reported content length of %vb", limit, downloadURL, resp.ContentLength)
+	}
+
+	limiter := &io.LimitedReader{
+		R: resp.Body,
+		N: limit,
+	}
+	contents, err := io.ReadAll(limiter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read asset contents of %s: %w", downloadURL, err)
+	}
+
+	if limiter.N <= 0 {
+		return nil, fmt.Errorf("exceeded download file size of %vb for %s with a reported content length of %vb", limit, downloadURL, resp.ContentLength)
 	}
 
 	logger.Info("asset successfully downloaded", slog.Int("size", len(contents)))

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"golang.org/x/mod/sumdb/dirhash"
+)
+
+func (p Provider) CalculateHash1(releaseDownloadUrl string, shaExpected string) (string, error) {
+	contents, assetErr := p.Github.DownloadAssetContents(releaseDownloadUrl)
+	if assetErr != nil {
+		return "", fmt.Errorf("failed to download release for calcualting hashes: %w", assetErr)
+	}
+
+	shaHasher := sha256.New()
+	_, err := io.Copy(shaHasher, bytes.NewBuffer(contents))
+	if err != nil {
+		panic(err)
+	}
+
+	shaCalculated := fmt.Sprintf("%x", shaHasher.Sum(nil))
+	if shaCalculated != shaExpected {
+		return "", fmt.Errorf("expected SHA256 %q, got %q", shaExpected, shaCalculated)
+	}
+
+	h1, err := HashZip(contents, dirhash.Hash1)
+	if err != nil {
+		return "", fmt.Errorf("unable to hash provider release: %w", err)
+	}
+	return h1, nil
+}
+
+// Inspired heavily from golang.org/x/mod/sumdb/dirhash, but re-written to use a in-memory zip stream
+// Ideally this would be contributed upstream
+func HashZip(zipdata []byte, hash dirhash.Hash) (string, error) {
+	z, err := zip.NewReader(bytes.NewReader(zipdata), int64(len(zipdata)))
+	if err != nil {
+		return "", err
+	}
+	var files []string
+	zfiles := make(map[string]*zip.File)
+	for _, file := range z.File {
+		files = append(files, file.Name)
+		zfiles[file.Name] = file
+	}
+	zipOpen := func(name string) (io.ReadCloser, error) {
+		f := zfiles[name]
+		if f == nil {
+			return nil, fmt.Errorf("file %q not found in zip", name) // should never happen
+		}
+		return f.Open()
+	}
+	return hash(files, zipOpen)
+}

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -10,32 +10,34 @@ import (
 	"golang.org/x/mod/sumdb/dirhash"
 )
 
-func (p Provider) CalculateHash1(releaseDownloadUrl string, shaExpected string) (string, error) {
+func (p Provider) CalculateHash1AndSize(releaseDownloadUrl string, shaExpected string) (string, int, error) {
 	contents, assetErr := p.Github.DownloadAssetContents(releaseDownloadUrl)
 	if assetErr != nil {
-		return "", fmt.Errorf("failed to download release for calcualting hashes: %w", assetErr)
+		return "", 0, fmt.Errorf("failed to download release for calculating hashes: %w", assetErr)
 	}
+
+	size := len(contents)
 
 	shaHasher := sha256.New()
 	_, err := io.Copy(shaHasher, bytes.NewBuffer(contents))
 	if err != nil {
-		panic(err)
+		return "", 0, fmt.Errorf("failed to calculate sha256 from contents: %w", err)
 	}
 
 	shaCalculated := fmt.Sprintf("%x", shaHasher.Sum(nil))
 	if shaCalculated != shaExpected {
-		return "", fmt.Errorf("expected SHA256 %q, got %q", shaExpected, shaCalculated)
+		return "", 0, fmt.Errorf("expected sha256 %q, got %q", shaExpected, shaCalculated)
 	}
 
 	h1, err := HashZip(contents, dirhash.Hash1)
 	if err != nil {
-		return "", fmt.Errorf("unable to hash provider release: %w", err)
+		return "", 0, fmt.Errorf("unable to hash provider release: %w", err)
 	}
-	return h1, nil
+	return h1, size, nil
 }
 
 // Inspired heavily from golang.org/x/mod/sumdb/dirhash, but re-written to use a in-memory zip stream
-// Ideally this would be contributed upstream
+// Ideally this would be contributed upstream. https://github.com/golang/go/issues/76021
 func HashZip(zipdata []byte, hash dirhash.Hash) (string, error) {
 	z, err := zip.NewReader(bytes.NewReader(zipdata), int64(len(zipdata)))
 	if err != nil {

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p Provider) CalculateHash1AndSize(releaseDownloadUrl string, shaExpected string) (string, int, error) {
-	contents, assetErr := p.Github.DownloadAssetContents(releaseDownloadUrl)
+	contents, assetErr := p.Github.DownloadAssetContentsLimited(releaseDownloadUrl, 256*1024*1024) // 256MB max
 	if assetErr != nil {
 		return "", 0, fmt.Errorf("failed to download release for calculating hashes: %w", assetErr)
 	}

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -34,9 +34,10 @@ type Version struct {
 type Target struct {
 	OS          string `json:"os"`           // The operating system for which the provider is built.
 	Arch        string `json:"arch"`         // The architecture for which the provider is built.
-	Filename    string `json:"filename"`     // The filename of the provider binary.
-	DownloadURL string `json:"download_url"` // The direct URL to download the provider binary.
-	SHASum      string `json:"shasum"`       // The SHA checksum of the provider binary.
+	Filename    string `json:"filename"`     // The filename of the provider release.
+	DownloadURL string `json:"download_url"` // The direct URL to download the provider release.
+	SHASum      string `json:"shasum"`       // The SHA checksum of the provider release.
+	Hash1       string `json:"h1"`           // The Hash Type 1 of the provider release *contents*
 }
 
 // Provider contains information about a provider.

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -41,6 +41,16 @@ type Target struct {
 	Size        int    `json:"size"`         // The size of the zipped provider release in bytes
 }
 
+func (t *Target) Hashes() []string {
+	hashes := []string{
+		"zh:" + t.SHASum,
+	}
+	if t.Hash1 != "" {
+		hashes = append(hashes, t.Hash1)
+	}
+	return hashes
+}
+
 // Provider contains information about a provider.
 type Provider struct {
 	ProviderName string // The provider name

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -38,6 +38,7 @@ type Target struct {
 	DownloadURL string `json:"download_url"` // The direct URL to download the provider release.
 	SHASum      string `json:"shasum"`       // The SHA checksum of the provider release.
 	Hash1       string `json:"h1"`           // The Hash Type 1 of the provider release *contents*
+	Size        int    `json:"size"`         // The size of the zipped provider release in bytes
 }
 
 // Provider contains information about a provider.

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -91,9 +91,10 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 				}
 			}
 
-			target.Hash1, err = p.CalculateHash1(target.DownloadURL, target.SHASum)
+			target.Hash1, target.Size, err = p.CalculateHash1AndSize(target.DownloadURL, target.SHASum)
 			if err != nil {
-				// Release is inaccessable, misconfigured, or corrupt
+				// Release is inaccessible, misconfigured, or corrupt
+				// TODO consider of this constitutes a failure, or if we should fall back to pre-h1 logic
 				return nil, err
 			}
 

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -94,7 +94,7 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 			target.Hash1, target.Size, err = p.CalculateHash1AndSize(target.DownloadURL, target.SHASum)
 			if err != nil {
 				// Release is inaccessible, misconfigured, or corrupt
-				// TODO consider of this constitutes a failure, or if we should fall back to pre-h1 logic
+				// TODO consider if this constitutes a failure, or if we should fall back to pre-h1 logic
 				return nil, err
 			}
 

--- a/src/internal/v1api/platform.go
+++ b/src/internal/v1api/platform.go
@@ -1,7 +1,1 @@
 package v1api
-
-// Platform represents a platform that a provider supports.
-type Platform struct {
-	OS   string `json:"os"`
-	Arch string `json:"arch"`
-}

--- a/src/internal/v1api/platform.go
+++ b/src/internal/v1api/platform.go
@@ -1,1 +1,0 @@
-package v1api

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -65,13 +65,15 @@ func (p ProviderGenerator) VersionListing() ProviderVersionListingResponse {
 		verResp := ProviderVersionResponseItem{
 			Version:   ver.Version,
 			Protocols: ver.Protocols,
-			Platforms: make([]Platform, len(ver.Targets)),
+			Platforms: make([]ProviderPlatform, len(ver.Targets)),
 		}
 
 		for targetIdx, target := range ver.Targets {
-			verResp.Platforms[targetIdx] = Platform{
-				OS:   target.OS,
-				Arch: target.Arch,
+			verResp.Platforms[targetIdx] = ProviderPlatform{
+				OS:          target.OS,
+				Arch:        target.Arch,
+				PackageSize: target.Size,
+				Hashes:      target.Hashes(),
 			}
 		}
 		versions[versionIdx] = verResp
@@ -100,6 +102,15 @@ func (p ProviderGenerator) VersionDetails() (map[string]ProviderVersionDetails, 
 	}
 
 	for _, ver := range p.Metadata.Versions {
+		packages := map[string]ProviderPackage{}
+		for _, target := range ver.Targets {
+			pkg := ProviderPackage{
+				PackageSize: target.Size,
+				Hashes:      target.Hashes(),
+			}
+			packages[fmt.Sprintf("%s_%s", target.OS, target.Arch)] = pkg
+		}
+
 		for _, target := range ver.Targets {
 			details := ProviderVersionDetails{
 				Protocols:           ver.Protocols,
@@ -113,6 +124,7 @@ func (p ProviderGenerator) VersionDetails() (map[string]ProviderVersionDetails, 
 				SigningKeys: SigningKeys{
 					GPGPublicKeys: keys,
 				},
+				Packages: packages,
 			}
 			versionDetails[p.VersionDownloadPath(ver, details)] = details
 		}

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -70,10 +70,8 @@ func (p ProviderGenerator) VersionListing() ProviderVersionListingResponse {
 
 		for targetIdx, target := range ver.Targets {
 			verResp.Platforms[targetIdx] = ProviderPlatform{
-				OS:          target.OS,
-				Arch:        target.Arch,
-				PackageSize: target.Size,
-				Hashes:      target.Hashes(),
+				OS:   target.OS,
+				Arch: target.Arch,
 			}
 		}
 		versions[versionIdx] = verResp

--- a/src/internal/v1api/responses.go
+++ b/src/internal/v1api/responses.go
@@ -55,9 +55,18 @@ type ProviderVersionListingResponse struct {
 }
 
 type ProviderVersionResponseItem struct {
-	Version   string     `json:"version"`   // The version number of the provider.
-	Protocols []string   `json:"protocols"` // The protocol versions the provider supports.
-	Platforms []Platform `json:"platforms"` // A list of platforms for which this provider version is available.
+	Version   string             `json:"version"`   // The version number of the provider.
+	Protocols []string           `json:"protocols"` // The protocol versions the provider supports.
+	Platforms []ProviderPlatform `json:"platforms"` // A list of platforms for which this provider version is available.
+}
+
+// ProviderPlatform represents a platform that a provider supports.
+type ProviderPlatform struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+	// Extensions
+	Hashes      []string `json:"hashes"`
+	PackageSize int      `json:"package_size,omitempty"`
 }
 
 // ProviderVersionDetails provides comprehensive details about a specific provider version.
@@ -73,9 +82,17 @@ type ProviderVersionDetails struct {
 	SHASumsSignatureURL string      `json:"shasums_signature_url"` // The URL to the GPG signature of the SHA checksums file.
 	SHASum              string      `json:"shasum"`                // The SHA checksum of the provider binary.
 	SigningKeys         SigningKeys `json:"signing_keys"`          // The signing keys used for this provider version.
+	// Extensions
+	Packages map[string]ProviderPackage `json:"packages"` // The package data for all platforms available for this provider version.
 }
 
 // SigningKeys represents the GPG public keys used to sign a provider version.
 type SigningKeys struct {
 	GPGPublicKeys []gpg.Key `json:"gpg_public_keys"` // A list of GPG public keys.
+}
+
+// ProviderPackage represents data we have scraped and computed about a given provider package on a platform.
+type ProviderPackage struct {
+	Hashes      []string `json:"hashes"`
+	PackageSize int      `json:"package_size,omitempty"`
 }

--- a/src/internal/v1api/responses.go
+++ b/src/internal/v1api/responses.go
@@ -64,9 +64,6 @@ type ProviderVersionResponseItem struct {
 type ProviderPlatform struct {
 	OS   string `json:"os"`
 	Arch string `json:"arch"`
-	// Extensions
-	Hashes      []string `json:"hashes"`
-	PackageSize int      `json:"package_size,omitempty"`
 }
 
 // ProviderVersionDetails provides comprehensive details about a specific provider version.


### PR DESCRIPTION
This is for https://github.com/opentofu/opentofu/pull/3434

Once merged, this will add the additional metadata for new provider releases the registry discovers. I am intentionally not adding the backfill process in this PR to keep the concerns separate.

This code has been running on https://github.com/cam72cam/opentofu-registry/ for a few months now and does not show any significant performance impediment.

Sample Generation:
v1/providers/hashicorp/local/0.1.0/download/linux/amd64
```json
{
  "protocols": [
    "5.0"
  ],
  "os": "linux",
  "arch": "amd64",
  "filename": "terraform-provider-local_0.1.0_linux_amd64.zip",
  "download_url": "https://github.com/opentofu/terraform-provider-local/releases/download/v0.1.0/terraform-provider-local_0.1.0_linux_amd64.zip",
  "shasums_url": "https://github.com/opentofu/terraform-provider-local/releases/download/v0.1.0/terraform-provider-local_0.1.0_SHA256SUMS",
  "shasums_signature_url": "https://github.com/opentofu/terraform-provider-local/releases/download/v0.1.0/terraform-provider-local_0.1.0_SHA256SUMS.sig",
  "shasum": "34d89a61574f2387e77c7d641823fce9e2a0339a1527d6a25404b2c3c7d10da7",
  "signing_keys": {
    "gpg_public_keys": [
      {
        "ascii_armor": "...",
        "key_id": "0C0AF313E5FD9F80"
      }
    ]
  },
  "packages": {
    "darwin_amd64": {
      "hashes": [
        "zh:5b30e49702c1e18200fda9628fcd36fe782c502125e25972153b3660ac1122f2",
        "h1:cPER98d6LWpUZ4QPNx1nH8a6vTyI6gQtojPhzBf1Rtw="
      ],
      "package_size": 3694015
    },
    "linux_386": {
      "hashes": [
        "zh:4b2cd9c6b21ce4142124a194ef96480aad4efdbcae4449d9678fc939c29d3754",
        "h1:/WX6cY2ijQM/le95WUqDeAq6JO5BRljkMEClcf1vGQY="
      ],
      "package_size": 3278244
    },
    "linux_amd64": {
      "hashes": [
        "zh:34d89a61574f2387e77c7d641823fce9e2a0339a1527d6a25404b2c3c7d10da7",
        "h1:MDZJm4NtP8OCv5e4SI3avLV8xZbQXVJOyLGNNmO7nS4="
      ],
      "package_size": 3516023
    },
    "windows_386": {
      "hashes": [
        "zh:a51ed8a7992aed9047547c4b6811c74b7dc7f2452ace313a790eeb929b01ade0",
        "h1:1ctrk5nQ+U0swj7as9vYeyKkMth6uDh7u5/wT1dkm1s="
      ],
      "package_size": 3266737
    },
    "windows_amd64": {
      "hashes": [
        "zh:80bc8857c4f069e392155214b6cdbe4c0e02924fe7cc621f30936cdd46ddc8b6",
        "h1:eiyrESXZ5jx0xnOt2/2aMqBfSZFa9QJNKO+75SnqaeA="
      ],
      "package_size": 3514114
    }
  }
}
```

<details>
<summary>Potential Alternative</summary>

v1/providers/hashicorp/local/versions
```json
{
  "versions": [
    {
      "version": "0.1.0",
      "protocols": [
        "5.0"
      ],
      "platforms": [
        {
          "os": "darwin",
          "arch": "amd64",
          "hashes": [
            "zh:5b30e49702c1e18200fda9628fcd36fe782c502125e25972153b3660ac1122f2",
            "h1:cPER98d6LWpUZ4QPNx1nH8a6vTyI6gQtojPhzBf1Rtw="
          ],
          "package_size": 3694015
        },
        {
          "os": "linux",
          "arch": "386",
          "hashes": [
            "zh:4b2cd9c6b21ce4142124a194ef96480aad4efdbcae4449d9678fc939c29d3754",
            "h1:/WX6cY2ijQM/le95WUqDeAq6JO5BRljkMEClcf1vGQY="
          ],
          "package_size": 3278244
        },
        {
          "os": "linux",
          "arch": "amd64",
          "hashes": [
            "zh:34d89a61574f2387e77c7d641823fce9e2a0339a1527d6a25404b2c3c7d10da7",
            "h1:MDZJm4NtP8OCv5e4SI3avLV8xZbQXVJOyLGNNmO7nS4="
          ],
          "package_size": 3516023
        },
        {
          "os": "windows",
          "arch": "386",
          "hashes": [
            "zh:a51ed8a7992aed9047547c4b6811c74b7dc7f2452ace313a790eeb929b01ade0",
            "h1:1ctrk5nQ+U0swj7as9vYeyKkMth6uDh7u5/wT1dkm1s="
          ],
          "package_size": 3266737
        },
        {
          "os": "windows",
          "arch": "amd64",
          "hashes": [
            "zh:80bc8857c4f069e392155214b6cdbe4c0e02924fe7cc621f30936cdd46ddc8b6",
            "h1:eiyrESXZ5jx0xnOt2/2aMqBfSZFa9QJNKO+75SnqaeA="
          ],
          "package_size": 3514114
        }
      ]
    }
  ]
}
```

</details>