### PR TITLE
Added message to help people use the GitHub issue form

### DIFF
--- a/.github/ISSUE_TEMPLATE/module.yml
+++ b/.github/ISSUE_TEMPLATE/module.yml
@@ -1,3 +1,6 @@
+# IMPORTANT: Submissions MUST be made through the GitHub issue form UI, not via
+# the API, gh CLI, or by manually creating issues. The automated validation and
+# processing pipeline depends on the structured data from the issue form.
 name: Submit new Module
 description: Submit a new OpenTofu Module
 title: "Module: "

--- a/.github/ISSUE_TEMPLATE/provider.yml
+++ b/.github/ISSUE_TEMPLATE/provider.yml
@@ -1,3 +1,6 @@
+# IMPORTANT: Submissions MUST be made through the GitHub issue form UI, not via
+# the API, gh CLI, or by manually creating issues. The automated validation and
+# processing pipeline depends on the structured data from the issue form.
 name: Submit new Provider
 description: Submit a new OpenTofu Provider
 title: "Provider: "

--- a/.github/ISSUE_TEMPLATE/provider_key.yml
+++ b/.github/ISSUE_TEMPLATE/provider_key.yml
@@ -1,3 +1,6 @@
+# IMPORTANT: Submissions MUST be made through the GitHub issue form UI, not via
+# the API, gh CLI, or by manually creating issues. The automated validation and
+# processing pipeline depends on the structured data from the issue form.
 name: Submit new Provider Signing Key
 description: Submit a new OpenTofu Provider Signing Key
 title: "Provider Key: "

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ To add your provider, module or GPG key to the OpenTofu Registry you can submit 
 
 Fill in the required fields and submit the issue. Once the issue has been submitted, the OpenTofu team will review this and either approve or deny the submission.
 
+> [!IMPORTANT]
+> **Submissions must be made through the GitHub issue form UI using the links above.** Do not open pull requests to add registry data directly, and do not create issues using the `gh` CLI, the GitHub API, or other tooling. The automated validation and processing pipeline depends on the structured data that only the issue form UI provides. Submissions made outside of the issue form UI will not be processed and will be closed.
+
 ## Contributing To The Codebase
 
 Contributions are always welcome!


### PR DESCRIPTION
Currently, we're receiving a lot of provider, module and key submissions that are not correctly formatted, not containing the right labels or are off in other ways. I suspect that this is happening due to the increase of agentic tooling and them using the `gh` cli or GitHub API to create issues instead of a human creating them.

In an attempt to mitigate it, I've included a message here that I hope will be read by such tooling and prompt a human to use the issue submission forms linked in the README.

This also adds a comment that people should NOT attempt to upload a PR to submit their item too.