### PR TITLE
Backfill provider meta

### DIFF
--- a/src/cmd/bump-versions/main.go
+++ b/src/cmd/bump-versions/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/opentofu/registry-stable/internal/blacklist"
 	"github.com/opentofu/registry-stable/internal/github"
@@ -13,6 +14,8 @@ import (
 )
 
 func main() {
+	started := time.Now()
+
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	logger.Info("Starting version bump process for modules and providers")
 
@@ -20,6 +23,7 @@ func main() {
 	moduleNamespace := flag.String("module-namespace", "", "Which module namespace to limit the command to")
 	providerDataDir := flag.String("provider-data", "../providers", "Directory containing the provider data")
 	providerNamespace := flag.String("provider-namespace", "", "Which provider namespace to limit the command to")
+	targetDuration := flag.Duration("target-duration", time.Minute*5, "Used to limit how much of a backfill this command can perform")
 
 	flag.Parse()
 
@@ -67,4 +71,26 @@ func main() {
 	}
 
 	logger.Info("Completed version bump process for modules and providers")
+
+	deadline := started.Add(*targetDuration)
+	remainingTime := deadline.Sub(time.Now())
+
+	ctx, _ = context.WithTimeout(ctx, remainingTime)
+
+	if ctx.Err() != nil {
+		logger.Info("Skipping backfill process, deadline exceeded")
+		return
+	}
+
+	logger.Info("Beginning backfill process for providers", slog.Any("time_allocated", remainingTime))
+
+	err = providers.Parallel(20, func(p provider.Provider) error {
+		if ctx.Err() != nil {
+			// Outta-time
+			return nil
+		}
+		return p.BackfillVersionData(ctx)
+	})
+
+	logger.Info("Completed backfill process for providers")
 }

--- a/src/cmd/bump-versions/main.go
+++ b/src/cmd/bump-versions/main.go
@@ -74,7 +74,7 @@ func main() {
 	logger.Info("Completed version bump process for modules and providers")
 
 	deadline := started.Add(*targetDuration)
-	remainingTime := deadline.Sub(time.Now())
+	remainingTime := time.Until(deadline)
 
 	ctx, cancel := context.WithTimeout(ctx, remainingTime)
 	defer cancel()
@@ -111,6 +111,11 @@ func main() {
 		}
 		return err
 	})
+
+	if err != nil {
+		logger.Error("Failed to backfill providers", slog.Any("err", err))
+		os.Exit(1)
+	}
 
 	logger.Info("Completed backfill process for providers")
 }

--- a/src/cmd/bump-versions/main.go
+++ b/src/cmd/bump-versions/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"log/slog"
 	"os"
@@ -75,9 +76,10 @@ func main() {
 	deadline := started.Add(*targetDuration)
 	remainingTime := deadline.Sub(time.Now())
 
-	ctx, _ = context.WithTimeout(ctx, remainingTime)
+	ctx, cancel := context.WithTimeout(ctx, remainingTime)
+	defer cancel()
 
-	if ctx.Err() != nil {
+	if ctx.Err() == context.DeadlineExceeded {
 		logger.Info("Skipping backfill process, deadline exceeded")
 		return
 	}
@@ -85,9 +87,12 @@ func main() {
 	logger.Info("Beginning backfill process for providers", slog.Any("time_allocated", remainingTime))
 
 	err = providers.Parallel(20, func(p provider.Provider) error {
-		if ctx.Err() != nil {
-			// Outta-time
-			return nil
+		if err := ctx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Outta-time
+				return nil
+			}
+			return err
 		}
 		return p.BackfillVersionData(ctx)
 	})

--- a/src/cmd/bump-versions/main.go
+++ b/src/cmd/bump-versions/main.go
@@ -86,6 +86,15 @@ func main() {
 
 	logger.Info("Beginning backfill process for providers", slog.Any("time_allocated", remainingTime))
 
+	// Setup a new github client with the limited context
+	ghClient = github.NewClient(ctx, logger, token)
+
+	// Re-list providers with new github client (not ideal)
+	providers, err = provider.ListProviders(*providerDataDir, *providerNamespace, logger, ghClient, bl)
+	if err != nil {
+		logger.Error("Failed to list providers", slog.Any("err", err))
+		os.Exit(1)
+	}
 	err = providers.Parallel(20, func(p provider.Provider) error {
 		if err := ctx.Err(); err != nil {
 			if errors.Is(err, context.DeadlineExceeded) {
@@ -94,7 +103,13 @@ func main() {
 			}
 			return err
 		}
-		return p.BackfillVersionData(ctx)
+		err := p.BackfillVersionData(ctx)
+		if errors.Is(err, context.DeadlineExceeded) {
+			p.Logger.Info("Partial completion of backfill due to time limitation")
+			// Outta-time
+			return nil
+		}
+		return err
 	})
 
 	logger.Info("Completed backfill process for providers")

--- a/src/internal/github/assets.go
+++ b/src/internal/github/assets.go
@@ -7,8 +7,14 @@ import (
 	"net/http"
 )
 
-// DownloadAssetContents downloads the contents of the asset at the given URL and returns it directly
+// DownloadAssetContents downloads the contents of the asset at the given URL and returns it directly (32kb limit)
 func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
+	return c.DownloadAssetContentsLimited(downloadURL, 32*1024) // 32kb is a reasonable limit for most metadata files
+}
+
+// DownloadAssetContentsLimited downloads the contents of the asset at the given URL and returns it directly, as long as it
+// is within the given limit.
+func (c Client) DownloadAssetContentsLimited(downloadURL string, limit int64) ([]byte, error) {
 	done := c.assetThrottle()
 	defer done()
 
@@ -30,9 +36,21 @@ func (c Client) DownloadAssetContents(downloadURL string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status code when downloading asset %s: %d", downloadURL, resp.StatusCode)
 	}
 
-	contents, err := io.ReadAll(resp.Body)
+	if resp.ContentLength > limit {
+		return nil, fmt.Errorf("exceeded download file content length of %vb for %s with a reported content length of %vb", limit, downloadURL, resp.ContentLength)
+	}
+
+	limiter := &io.LimitedReader{
+		R: resp.Body,
+		N: limit,
+	}
+	contents, err := io.ReadAll(limiter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read asset contents of %s: %w", downloadURL, err)
+	}
+
+	if limiter.N <= 0 {
+		return nil, fmt.Errorf("exceeded download file size of %vb for %s with a reported content length of %vb", limit, downloadURL, resp.ContentLength)
 	}
 
 	logger.Info("asset successfully downloaded", slog.Int("size", len(contents)))

--- a/src/internal/provider/backfill.go
+++ b/src/internal/provider/backfill.go
@@ -1,0 +1,51 @@
+package provider
+
+import "context"
+
+func (p *Provider) BackfillVersionData(ctx context.Context) error {
+	p.Logger.Info("Beginning version backfill process")
+
+	meta, err := p.ReadMetadata()
+	if err != nil {
+		return err
+	}
+
+	madeChanges := false
+	for key, version := range meta.Versions {
+		if ctx.Err() != nil {
+			// Outta-time
+			break
+		}
+
+		// Check to see if this version has already
+		// been populated
+		hasMeta := false
+		for _, target := range version.Targets {
+			if target.Size != 0 {
+				hasMeta = true
+				break
+			}
+		}
+		if hasMeta {
+			continue
+		}
+
+		newVersion, err := p.VersionFromTag("v" + version.Version)
+		if err != nil {
+			// TODO log
+			continue
+		}
+		if newVersion != nil {
+			meta.Versions[key] = *newVersion
+			madeChanges = true
+		}
+	}
+
+	p.Logger.Info("Completed version backfill process")
+
+	if madeChanges {
+		return p.WriteMetadata(meta)
+	}
+
+	return nil
+}

--- a/src/internal/provider/backfill.go
+++ b/src/internal/provider/backfill.go
@@ -13,14 +13,12 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 		return err
 	}
 
+	var errs []error
 	madeChanges := false
 	for key, version := range meta.Versions {
 		if err := ctx.Err(); err != nil {
-			if errors.Is(err, context.DeadlineExceeded) {
-				// Outta-time
-				break
-			}
-			return err
+			errs = append(errs, err)
+			break
 		}
 
 		// Check to see if this version has already
@@ -38,7 +36,7 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 
 		newVersion, err := p.VersionFromTag("v" + version.Version)
 		if err != nil {
-			// TODO log
+			errs = append(errs, err)
 			continue
 		}
 		if newVersion != nil {
@@ -50,8 +48,8 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 	p.Logger.Info("Completed version backfill process")
 
 	if madeChanges {
-		return p.WriteMetadata(meta)
+		errs = append(errs, p.WriteMetadata(meta))
 	}
 
-	return nil
+	return errors.Join(errs...)
 }

--- a/src/internal/provider/backfill.go
+++ b/src/internal/provider/backfill.go
@@ -1,6 +1,9 @@
 package provider
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 func (p *Provider) BackfillVersionData(ctx context.Context) error {
 	p.Logger.Info("Beginning version backfill process")
@@ -12,9 +15,12 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 
 	madeChanges := false
 	for key, version := range meta.Versions {
-		if ctx.Err() != nil {
-			// Outta-time
-			break
+		if err := ctx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Outta-time
+				break
+			}
+			return err
 		}
 
 		// Check to see if this version has already

--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -108,6 +108,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 		}()
 	}
 
+	addedReleases := false
 	for range newReleases {
 		result := <-verChan
 		if result.err != nil {
@@ -119,6 +120,12 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 		}
 		// append the new release to the metadata
 		meta.Versions = append(meta.Versions, *result.v)
+
+		addedReleases = true
+	}
+	if !addedReleases {
+		// Prevent file modification if not changed
+		return nil, nil
 	}
 
 	semverSortFunc := func(a, b Version) int {

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -1,0 +1,58 @@
+package provider
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io"
+
+	"golang.org/x/mod/sumdb/dirhash"
+)
+
+func (p Provider) CalculateHash1(releaseDownloadUrl string, shaExpected string) (string, error) {
+	contents, assetErr := p.Github.DownloadAssetContents(releaseDownloadUrl)
+	if assetErr != nil {
+		return "", fmt.Errorf("failed to download release for calcualting hashes: %w", assetErr)
+	}
+
+	shaHasher := sha256.New()
+	_, err := io.Copy(shaHasher, bytes.NewBuffer(contents))
+	if err != nil {
+		panic(err)
+	}
+
+	shaCalculated := fmt.Sprintf("%x", shaHasher.Sum(nil))
+	if shaCalculated != shaExpected {
+		return "", fmt.Errorf("expected SHA256 %q, got %q", shaExpected, shaCalculated)
+	}
+
+	h1, err := HashZip(contents, dirhash.Hash1)
+	if err != nil {
+		return "", fmt.Errorf("unable to hash provider release: %w", err)
+	}
+	return h1, nil
+}
+
+// Inspired heavily from golang.org/x/mod/sumdb/dirhash, but re-written to use a in-memory zip stream
+// Ideally this would be contributed upstream
+func HashZip(zipdata []byte, hash dirhash.Hash) (string, error) {
+	z, err := zip.NewReader(bytes.NewReader(zipdata), int64(len(zipdata)))
+	if err != nil {
+		return "", err
+	}
+	var files []string
+	zfiles := make(map[string]*zip.File)
+	for _, file := range z.File {
+		files = append(files, file.Name)
+		zfiles[file.Name] = file
+	}
+	zipOpen := func(name string) (io.ReadCloser, error) {
+		f := zfiles[name]
+		if f == nil {
+			return nil, fmt.Errorf("file %q not found in zip", name) // should never happen
+		}
+		return f.Open()
+	}
+	return hash(files, zipOpen)
+}

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -10,32 +10,34 @@ import (
 	"golang.org/x/mod/sumdb/dirhash"
 )
 
-func (p Provider) CalculateHash1(releaseDownloadUrl string, shaExpected string) (string, error) {
+func (p Provider) CalculateHash1AndSize(releaseDownloadUrl string, shaExpected string) (string, int, error) {
 	contents, assetErr := p.Github.DownloadAssetContents(releaseDownloadUrl)
 	if assetErr != nil {
-		return "", fmt.Errorf("failed to download release for calcualting hashes: %w", assetErr)
+		return "", 0, fmt.Errorf("failed to download release for calculating hashes: %w", assetErr)
 	}
+
+	size := len(contents)
 
 	shaHasher := sha256.New()
 	_, err := io.Copy(shaHasher, bytes.NewBuffer(contents))
 	if err != nil {
-		panic(err)
+		return "", 0, fmt.Errorf("failed to calculate sha256 from contents: %w", err)
 	}
 
 	shaCalculated := fmt.Sprintf("%x", shaHasher.Sum(nil))
 	if shaCalculated != shaExpected {
-		return "", fmt.Errorf("expected SHA256 %q, got %q", shaExpected, shaCalculated)
+		return "", 0, fmt.Errorf("expected sha256 %q, got %q", shaExpected, shaCalculated)
 	}
 
 	h1, err := HashZip(contents, dirhash.Hash1)
 	if err != nil {
-		return "", fmt.Errorf("unable to hash provider release: %w", err)
+		return "", 0, fmt.Errorf("unable to hash provider release: %w", err)
 	}
-	return h1, nil
+	return h1, size, nil
 }
 
 // Inspired heavily from golang.org/x/mod/sumdb/dirhash, but re-written to use a in-memory zip stream
-// Ideally this would be contributed upstream
+// Ideally this would be contributed upstream. https://github.com/golang/go/issues/76021
 func HashZip(zipdata []byte, hash dirhash.Hash) (string, error) {
 	z, err := zip.NewReader(bytes.NewReader(zipdata), int64(len(zipdata)))
 	if err != nil {

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p Provider) CalculateHash1AndSize(releaseDownloadUrl string, shaExpected string) (string, int, error) {
-	contents, assetErr := p.Github.DownloadAssetContents(releaseDownloadUrl)
+	contents, assetErr := p.Github.DownloadAssetContentsLimited(releaseDownloadUrl, 256*1024*1024) // 256MB max
 	if assetErr != nil {
 		return "", 0, fmt.Errorf("failed to download release for calculating hashes: %w", assetErr)
 	}

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -34,9 +34,10 @@ type Version struct {
 type Target struct {
 	OS          string `json:"os"`           // The operating system for which the provider is built.
 	Arch        string `json:"arch"`         // The architecture for which the provider is built.
-	Filename    string `json:"filename"`     // The filename of the provider binary.
-	DownloadURL string `json:"download_url"` // The direct URL to download the provider binary.
-	SHASum      string `json:"shasum"`       // The SHA checksum of the provider binary.
+	Filename    string `json:"filename"`     // The filename of the provider release.
+	DownloadURL string `json:"download_url"` // The direct URL to download the provider release.
+	SHASum      string `json:"shasum"`       // The SHA checksum of the provider release.
+	Hash1       string `json:"h1"`           // The Hash Type 1 of the provider release *contents*
 }
 
 // Provider contains information about a provider.

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -41,6 +41,16 @@ type Target struct {
 	Size        int    `json:"size"`         // The size of the zipped provider release in bytes
 }
 
+func (t *Target) Hashes() []string {
+	hashes := []string{
+		"zh:" + t.SHASum,
+	}
+	if t.Hash1 != "" {
+		hashes = append(hashes, t.Hash1)
+	}
+	return hashes
+}
+
 // Provider contains information about a provider.
 type Provider struct {
 	ProviderName string // The provider name

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -38,6 +38,7 @@ type Target struct {
 	DownloadURL string `json:"download_url"` // The direct URL to download the provider release.
 	SHASum      string `json:"shasum"`       // The SHA checksum of the provider release.
 	Hash1       string `json:"h1"`           // The Hash Type 1 of the provider release *contents*
+	Size        int    `json:"size"`         // The size of the zipped provider release in bytes
 }
 
 // Provider contains information about a provider.

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -91,9 +91,10 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 				}
 			}
 
-			target.Hash1, err = p.CalculateHash1(target.DownloadURL, target.SHASum)
+			target.Hash1, target.Size, err = p.CalculateHash1AndSize(target.DownloadURL, target.SHASum)
 			if err != nil {
-				// Release is inaccessable, misconfigured, or corrupt
+				// Release is inaccessible, misconfigured, or corrupt
+				// TODO consider of this constitutes a failure, or if we should fall back to pre-h1 logic
 				return nil, err
 			}
 

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -94,7 +94,7 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 			target.Hash1, target.Size, err = p.CalculateHash1AndSize(target.DownloadURL, target.SHASum)
 			if err != nil {
 				// Release is inaccessible, misconfigured, or corrupt
-				// TODO consider of this constitutes a failure, or if we should fall back to pre-h1 logic
+				// TODO consider if this constitutes a failure, or if we should fall back to pre-h1 logic
 				return nil, err
 			}
 

--- a/src/internal/v1api/platform.go
+++ b/src/internal/v1api/platform.go
@@ -1,7 +1,1 @@
 package v1api
-
-// Platform represents a platform that a provider supports.
-type Platform struct {
-	OS   string `json:"os"`
-	Arch string `json:"arch"`
-}

--- a/src/internal/v1api/platform.go
+++ b/src/internal/v1api/platform.go
@@ -1,1 +1,0 @@
-package v1api

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -65,13 +65,15 @@ func (p ProviderGenerator) VersionListing() ProviderVersionListingResponse {
 		verResp := ProviderVersionResponseItem{
 			Version:   ver.Version,
 			Protocols: ver.Protocols,
-			Platforms: make([]Platform, len(ver.Targets)),
+			Platforms: make([]ProviderPlatform, len(ver.Targets)),
 		}
 
 		for targetIdx, target := range ver.Targets {
-			verResp.Platforms[targetIdx] = Platform{
-				OS:   target.OS,
-				Arch: target.Arch,
+			verResp.Platforms[targetIdx] = ProviderPlatform{
+				OS:          target.OS,
+				Arch:        target.Arch,
+				PackageSize: target.Size,
+				Hashes:      target.Hashes(),
 			}
 		}
 		versions[versionIdx] = verResp
@@ -100,6 +102,15 @@ func (p ProviderGenerator) VersionDetails() (map[string]ProviderVersionDetails, 
 	}
 
 	for _, ver := range p.Metadata.Versions {
+		packages := map[string]ProviderPackage{}
+		for _, target := range ver.Targets {
+			pkg := ProviderPackage{
+				PackageSize: target.Size,
+				Hashes:      target.Hashes(),
+			}
+			packages[fmt.Sprintf("%s_%s", target.OS, target.Arch)] = pkg
+		}
+
 		for _, target := range ver.Targets {
 			details := ProviderVersionDetails{
 				Protocols:           ver.Protocols,
@@ -113,6 +124,7 @@ func (p ProviderGenerator) VersionDetails() (map[string]ProviderVersionDetails, 
 				SigningKeys: SigningKeys{
 					GPGPublicKeys: keys,
 				},
+				Packages: packages,
 			}
 			versionDetails[p.VersionDownloadPath(ver, details)] = details
 		}

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -70,10 +70,8 @@ func (p ProviderGenerator) VersionListing() ProviderVersionListingResponse {
 
 		for targetIdx, target := range ver.Targets {
 			verResp.Platforms[targetIdx] = ProviderPlatform{
-				OS:          target.OS,
-				Arch:        target.Arch,
-				PackageSize: target.Size,
-				Hashes:      target.Hashes(),
+				OS:   target.OS,
+				Arch: target.Arch,
 			}
 		}
 		versions[versionIdx] = verResp

--- a/src/internal/v1api/responses.go
+++ b/src/internal/v1api/responses.go
@@ -55,9 +55,18 @@ type ProviderVersionListingResponse struct {
 }
 
 type ProviderVersionResponseItem struct {
-	Version   string     `json:"version"`   // The version number of the provider.
-	Protocols []string   `json:"protocols"` // The protocol versions the provider supports.
-	Platforms []Platform `json:"platforms"` // A list of platforms for which this provider version is available.
+	Version   string             `json:"version"`   // The version number of the provider.
+	Protocols []string           `json:"protocols"` // The protocol versions the provider supports.
+	Platforms []ProviderPlatform `json:"platforms"` // A list of platforms for which this provider version is available.
+}
+
+// ProviderPlatform represents a platform that a provider supports.
+type ProviderPlatform struct {
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
+	// Extensions
+	Hashes      []string `json:"hashes"`
+	PackageSize int      `json:"package_size,omitempty"`
 }
 
 // ProviderVersionDetails provides comprehensive details about a specific provider version.
@@ -73,9 +82,17 @@ type ProviderVersionDetails struct {
 	SHASumsSignatureURL string      `json:"shasums_signature_url"` // The URL to the GPG signature of the SHA checksums file.
 	SHASum              string      `json:"shasum"`                // The SHA checksum of the provider binary.
 	SigningKeys         SigningKeys `json:"signing_keys"`          // The signing keys used for this provider version.
+	// Extensions
+	Packages map[string]ProviderPackage `json:"packages"` // The package data for all platforms available for this provider version.
 }
 
 // SigningKeys represents the GPG public keys used to sign a provider version.
 type SigningKeys struct {
 	GPGPublicKeys []gpg.Key `json:"gpg_public_keys"` // A list of GPG public keys.
+}
+
+// ProviderPackage represents data we have scraped and computed about a given provider package on a platform.
+type ProviderPackage struct {
+	Hashes      []string `json:"hashes"`
+	PackageSize int      `json:"package_size,omitempty"`
 }

--- a/src/internal/v1api/responses.go
+++ b/src/internal/v1api/responses.go
@@ -64,9 +64,6 @@ type ProviderVersionResponseItem struct {
 type ProviderPlatform struct {
 	OS   string `json:"os"`
 	Arch string `json:"arch"`
-	// Extensions
-	Hashes      []string `json:"hashes"`
-	PackageSize int      `json:"package_size,omitempty"`
 }
 
 // ProviderVersionDetails provides comprehensive details about a specific provider version.


### PR DESCRIPTION
Depends on https://github.com/opentofu/registry/pull/3744

Introduces a soft-timeout in the backfill process, it won't start any new version backfills once the deadline is exceeded.  At most a version backfill takes 30s (usually 1-2s) and won't exceed our expected action runtime.