### PR TITLE
Fix delay when bumping versions encounters a conflict

### DIFF
--- a/.github/workflows/bump-versions.sh
+++ b/.github/workflows/bump-versions.sh
@@ -47,7 +47,7 @@ for i in {0..30}; do
 		exit 0
 	fi
 	sleep 1
-	git fetch origin
+	git fetch origin $BRANCH
 	git rebase origin/$BRANCH
 done
 


### PR DESCRIPTION
Given that we have a bunch of old branches (some with rebases), doing a full `git pull origin` can cause significant performance issues when a bump is executed

https://github.com/opentofu/registry/actions/runs/22851721132/job/66281665017

```shell
$ git commit
2026-03-09T11:42:20.6637843Z [main c38b7304] Automated bump of versions for providers and modules (a)
2026-03-09T11:42:20.6638782Z  1 file changed, 3 insertions(+)
$ git push origin $BRANCH
2026-03-09T11:42:20.8818578Z To https://github.com/opentofu/registry
2026-03-09T11:42:20.8819335Z  ! [rejected]          main -> main (non-fast-forward)
2026-03-09T11:42:20.8819911Z error: failed to push some refs to 'https://github.com/opentofu/registry'
2026-03-09T11:42:20.8843341Z hint: Updates were rejected because the tip of your current branch is behind
2026-03-09T11:42:20.8844228Z hint: its remote counterpart. If you want to integrate the remote changes,
2026-03-09T11:42:20.8844667Z hint: use 'git pull' before pushing again.
2026-03-09T11:42:20.8845094Z hint: See the 'Note about fast-forwards' in 'git push --help' for details.
$ sleep 1
$ git fetch origin # No branch specified -> massive delay fetching all the old branches
2026-03-09T11:47:19.7615707Z From https://github.com/opentofu/registry
2026-03-09T11:47:19.7616732Z  * [new branch]            backfill_provider_meta  -> origin/backfill_provider_meta
2026-03-09T11:47:19.7618046Z  * [new branch]            calculate_and_store_provider_meta -> origin/calculate_and_store_provider_meta
2026-03-09T11:47:19.7619472Z  * [new branch]            cisco_key_checker       -> origin/cisco_key_checker
2026-03-09T11:47:19.7620422Z  * [new branch]            download-artifacts      -> origin/download-artifacts
2026-03-09T11:47:19.7621417Z  * [new branch]            find_provider_for_key_validation -> origin/find_provider_for_key_validation
2026-03-09T11:47:19.7622316Z  * [new branch]            go_git                  -> origin/go_git
2026-03-09T11:47:19.7623130Z  * [new branch]            golangci-action-upgrade -> origin/golangci-action-upgrade
2026-03-09T11:47:19.7624039Z  * [new branch]            idempotent_module_tags  -> origin/idempotent_module_tags
2026-03-09T11:47:19.7625430Z  * [new branch]            module-submission_blindops42_project-count-instanses_yc -> origin/module-submission_blindops42_project-count-instanses_yc
2026-03-09T11:47:19.7627208Z  * [new branch]            provider-key-submission_anexia-it-1758608461 -> origin/provider-key-submission_anexia-it-1758608461
2026-03-09T11:47:19.7629044Z  * [new branch]            provider-key-submission_batonogov-1771563075 -> origin/provider-key-submission_batonogov-1771563075
2026-03-09T11:47:19.7630495Z  * [new branch]            provider-key-submission_matthewbaggett -> origin/provider-key-submission_matthewbaggett
2026-03-09T11:47:19.7631869Z  * [new branch]            provider-key-submission_sylr-1769890023 -> origin/provider-key-submission_sylr-1769890023
2026-03-09T11:47:19.7633161Z  * [new branch]            provider-key-submission_v0nnemizez -> origin/provider-key-submission_v0nnemizez
2026-03-09T11:47:19.7634461Z  * [new branch]            provider-submission_batonogov_threexui -> origin/provider-submission_batonogov_threexui
2026-03-09T11:47:19.7635702Z  * [new branch]            provider-submission_essent_slack -> origin/provider-submission_essent_slack
2026-03-09T11:47:19.7636983Z  * [new branch]            provider-submission_rustamkulenov_ruvds -> origin/provider-submission_rustamkulenov_ruvds
2026-03-09T11:47:19.7638080Z  * [new branch]            provider_key_checker    -> origin/provider_key_checker
2026-03-09T11:47:19.7639229Z  * [new branch]            share_code_providers_modules -> origin/share_code_providers_modules
2026-03-09T11:47:19.7640135Z  * [new branch]            simple_listing          -> origin/simple_listing
2026-03-09T11:47:19.7641090Z  * [new branch]            turn-off-rss-throttling-limit -> origin/turn-off-rss-throttling-limit
2026-03-09T11:47:19.7642054Z  * [new branch]
update-module-file      -> origin/update-module-file
```