### PR TITLE
Improve backfill error reporting

### DIFF
--- a/src/internal/provider/backfill.go
+++ b/src/internal/provider/backfill.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"log/slog"
 )
 
 func (p *Provider) BackfillVersionData(ctx context.Context) error {
@@ -15,6 +16,7 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 
 	var errs []error
 	madeChanges := false
+	var backfilled, skipped, errored int
 	for key, version := range meta.Versions {
 		if err := ctx.Err(); err != nil {
 			errs = append(errs, err)
@@ -31,21 +33,30 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 			}
 		}
 		if hasMeta {
+			skipped++
 			continue
 		}
 
 		newVersion, err := p.VersionFromTag("v" + version.Version)
 		if err != nil {
+			p.Logger.Error("Failed to backfill version", slog.String("version", version.Version), slog.Any("err", err))
 			errs = append(errs, err)
+			errored++
 			continue
 		}
 		if newVersion != nil {
 			meta.Versions[key] = *newVersion
 			madeChanges = true
+			backfilled++
 		}
 	}
 
-	p.Logger.Info("Completed version backfill process")
+	p.Logger.Info("Completed version backfill process",
+		slog.Int("backfilled", backfilled),
+		slog.Int("skipped", skipped),
+		slog.Int("errored", errored),
+		slog.Int("total", len(meta.Versions)),
+	)
 
 	if madeChanges {
 		errs = append(errs, p.WriteMetadata(meta))

--- a/src/internal/provider/hashes.go
+++ b/src/internal/provider/hashes.go
@@ -15,6 +15,9 @@ func (p Provider) CalculateHash1AndSize(releaseDownloadUrl string, shaExpected s
 	if assetErr != nil {
 		return "", 0, fmt.Errorf("failed to download release for calculating hashes: %w", assetErr)
 	}
+	if contents == nil {
+		return "", 0, fmt.Errorf("asset not found: %s", releaseDownloadUrl)
+	}
 
 	size := len(contents)
 

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -95,7 +95,7 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 			if err != nil {
 				// Release is inaccessible, misconfigured, or corrupt
 				// TODO consider if this constitutes a failure, or if we should fall back to pre-h1 logic
-				return nil, err
+				return nil, fmt.Errorf("%s_%s: %w", os, arch, err)
 			}
 
 			v.Targets = append(v.Targets, target)


### PR DESCRIPTION
Also 
- Adds a nil download check to reduce errors reporting that the sha checksum is `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` (the result of checksumming `nil`)
- Adds version and architecture info to the logs of failing provider version backfilling.
- Adds a structured log to get information about how many providers are succeeding/failing etc.