### PR TITLE
feat(terraform-provider-utils): Add cloudposse/utils provider versions 1.32.0 and 1.33.0

### DIFF
--- a/providers/c/cloudposse/utils.json
+++ b/providers/c/cloudposse/utils.json
@@ -364,6 +364,224 @@
       ]
     },
     {
+      "version": "1.33.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.33.0_darwin_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_darwin_amd64.zip",
+          "shasum": "18c3ca4d718fd87abca0d2e57aa6b007e150eab8fa20ac7585b95c7c3e2a01a9",
+          "h1": "",
+          "size": 47044169
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-utils_1.33.0_darwin_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_darwin_arm64.zip",
+          "shasum": "9d9e1521b7ce365972f7f663c8667972b36ab3b205139722e9753e32c0a3c382",
+          "h1": "",
+          "size": 43603669
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.33.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_freebsd_amd64.zip",
+          "shasum": "5119e0fa2799f33c7e18586e06bc8a573cfc7bdcfc9f5541192da9c07e5c30fd",
+          "h1": "",
+          "size": 45955765
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-utils_1.33.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_freebsd_arm64.zip",
+          "shasum": "c9a727e4129c892d7224f9aaa0eb51c5bf021887bcb2418dc3c6ee698270dc54",
+          "h1": "",
+          "size": 41342725
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-utils_1.33.0_linux_386.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_linux_386.zip",
+          "shasum": "c75a314cecf1911bb45da4a4acbf12e0c72d0adbe297c06912258c33b0e01c7a",
+          "h1": "",
+          "size": 42466374
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.33.0_linux_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_linux_amd64.zip",
+          "shasum": "43717934847a0cad1e74916d1debcca4c9cdd8c6d701fd86fe0907caa150dbcf",
+          "h1": "",
+          "size": 46258949
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-utils_1.33.0_linux_arm.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_linux_arm.zip",
+          "shasum": "52486ae35f9da1944369e887b6683b9eee65090299dd3ff83a70b0232e21a404",
+          "h1": "",
+          "size": 43237771
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-utils_1.33.0_linux_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_linux_arm64.zip",
+          "shasum": "10e9c26297938ccc9956abc8a1a81a1d76019701e6e1b37519ab7d63610917bf",
+          "h1": "",
+          "size": 41620657
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-utils_1.33.0_windows_386.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_windows_386.zip",
+          "shasum": "b49e5f09e18459f927824f98c79f3c632ddacee440f0f77dd7aba2036124d7f2",
+          "h1": "",
+          "size": 44296195
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.33.0_windows_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_windows_amd64.zip",
+          "shasum": "8b95aafc1c00be73d8f119e09fd9cfc123a393042a356f06dc1896dbdbc54227",
+          "h1": "",
+          "size": 47067023
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-utils_1.33.0_windows_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.33.0/terraform-provider-utils_1.33.0_windows_arm64.zip",
+          "shasum": "e7f0de686bb2b6a78d558ff2c6e655e2ed4728c90fea9a10d58c9c2512f0f737",
+          "h1": "",
+          "size": 41601725
+        }
+      ]
+    },
+    {
+      "version": "1.32.0",
+      "protocols": [
+        "5.0"
+      ],
+      "shasums_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.32.0_darwin_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_darwin_amd64.zip",
+          "shasum": "6526cfa7808639f6524e2218e4d25d54bf910b71bcf8155d06c1327b20bca944",
+          "h1": "",
+          "size": 47044165
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-utils_1.32.0_darwin_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_darwin_arm64.zip",
+          "shasum": "3637f7ce1f09fd33501569e23a845848b10d5b7a42c7b723e24b5aef57f869c5",
+          "h1": "",
+          "size": 43603677
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.32.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_freebsd_amd64.zip",
+          "shasum": "9d663677b18fb18410ffd324d37a3d68308d9596aee6839c68fb99fe52bb623b",
+          "h1": "",
+          "size": 45955768
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-utils_1.32.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_freebsd_arm64.zip",
+          "shasum": "35f3bd0c0f7f3cc7cd0fbbff1c01d5f81e2f25db19865d50a19455700b31b305",
+          "h1": "",
+          "size": 41342724
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-utils_1.32.0_linux_386.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_linux_386.zip",
+          "shasum": "effe075c03ca9107500f69a1d2c5f02294a3e3560a0867254fed8d487bf46ddc",
+          "h1": "",
+          "size": 42466362
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.32.0_linux_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_linux_amd64.zip",
+          "shasum": "af0007713b8373bf80856949b9c3ee52dcd5e0d2dc4ca1f0c9f1f1bbdd4d0f15",
+          "h1": "",
+          "size": 46258954
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-utils_1.32.0_linux_arm.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_linux_arm.zip",
+          "shasum": "4b93ed4d7dc0b6c1726e0f81ad08096e4dc6414c03a525a6c3353b9f48003c70",
+          "h1": "",
+          "size": 43237760
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-utils_1.32.0_linux_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_linux_arm64.zip",
+          "shasum": "ef34f7627f0f59f42584e56c5c86437374c6bf5b660199506f450abfb86a5ea4",
+          "h1": "",
+          "size": 41620657
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-utils_1.32.0_windows_386.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_windows_386.zip",
+          "shasum": "1189877c80f8f764a3df463b81d902bf3c4df441b9f91641ef4ac7240cd198ab",
+          "h1": "",
+          "size": 44296197
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-utils_1.32.0_windows_amd64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_windows_amd64.zip",
+          "shasum": "f9cfdc9e1de83b26be2b2dbbc82fcf5a0285e0bb0661376553f32e0d2bbe6023",
+          "h1": "",
+          "size": 47067017
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-utils_1.32.0_windows_arm64.zip",
+          "download_url": "https://github.com/cloudposse/terraform-provider-utils/releases/download/v1.32.0/terraform-provider-utils_1.32.0_windows_arm64.zip",
+          "shasum": "0a773bd649c5ae2cb4038365e82f0aba80630e021ffee84d17a738f01dc024dd",
+          "h1": "",
+          "size": 41601725
+        }
+      ]
+    },
+    {
       "version": "1.31.0",
       "protocols": [
         "5.0"


### PR DESCRIPTION
## Summary

Add missing versions 1.32.0 and 1.33.0 of the `cloudposse/utils` provider to the registry dataset.

These versions were published as GitHub releases but were not picked up by the automated sync, likely because they are new releases on the 1.x branch published after the 2.x line already exists. The [[releases RSS feed](https://github.com/cloudposse/terraform-provider-utils/releases.atom)](https://github.com/cloudposse/terraform-provider-utils/releases.atom) includes both versions, but the sync appears to have skipped them.

## Versions added

- **v1.32.0** — [[GitHub Release](https://github.com/cloudposse/terraform-provider-utils/releases/tag/v1.32.0)](https://github.com/cloudposse/terraform-provider-utils/releases/tag/v1.32.0) (published 2026-03-11)
- **v1.33.0** — [[GitHub Release](https://github.com/cloudposse/terraform-provider-utils/releases/tag/v1.33.0)](https://github.com/cloudposse/terraform-provider-utils/releases/tag/v1.33.0) (published 2026-03-12)

Both releases have signed SHA256SUMS and binary artifacts for 11 platform targets (darwin, freebsd, linux, windows across amd64/arm64/386/arm).

## Why the sync may have missed these

The provider maintains parallel 1.x and 2.x release lines. The registry already has v2.1.0 (released the same day as v1.32.0), suggesting the sync logic may not expect new releases on an older major version after a newer major version exists. Additionally, the releases RSS feed contains floating tags (`v1`, `v2`) alongside proper semver tags, which could interfere with version parsing.

## Changes

- Updated `providers/c/cloudposse/utils.json` to include v1.32.0 and v1.33.0 entries with shasums, download URLs, and file sizes sourced from the GitHub releases.
- `h1` hashes are left empty, consistent with the majority of existing entries in this file.