### PR TITLE
Track provider bump errors

### DIFF
--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -1,9 +1,12 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"slices"
+	"time"
 
 	"github.com/opentofu/registry-stable/internal"
 	"github.com/opentofu/registry-stable/internal/blacklist"
@@ -21,6 +24,7 @@ func (meta Metadata) filterNewReleases(releases []string, namespace, name string
 
 	var newReleases = make([]string, 0)
 	var blacklistedCount = 0
+	var erroredCount = 0
 	for _, r := range releases {
 		version := internal.TrimTagPrefix(r)
 		if !existingVersions[version] {
@@ -34,12 +38,42 @@ func (meta Metadata) filterNewReleases(releases []string, namespace, name string
 				blacklistedCount++
 				continue
 			}
-			// only append the release if it does not already exist in the metadata and is not blacklisted
+
+			var errorEntries []VersionError
+			var latestError time.Time
+			for _, errored := range meta.VersionErrors {
+				if errored.Version == version {
+					if errored.UTCTime.After(latestError) {
+						latestError = errored.UTCTime
+					}
+					errorEntries = append(errorEntries, errored)
+				}
+			}
+
+			isErrored := false
+			if len(errorEntries) > 0 {
+				// Simple doubling backoff
+				dur := time.Minute * 15 * time.Duration(math.Pow(float64(len(errorEntries)), 2))
+				if latestError.Add(dur).After(time.Now()) {
+					isErrored = true
+				}
+			}
+
+			if isErrored {
+				meta.Logger.Warn("Skipping errored version",
+					slog.String("namespace", namespace),
+					slog.String("name", name),
+					slog.String("version", version))
+				erroredCount++
+				continue
+			}
+
+			// only append the release if it does not already exist in the metadata, is not errored, and is not blacklisted
 			newReleases = append(newReleases, r)
 		}
 	}
 
-	meta.Logger.Info(fmt.Sprintf("Found %d releases that do not already exist in the metadata file (%d blacklisted)", len(newReleases), blacklistedCount))
+	meta.Logger.Info(fmt.Sprintf("Found %d releases that do not already exist in the metadata file (%d blacklisted, %d errored)", len(newReleases), blacklistedCount, erroredCount))
 
 	return newReleases
 }
@@ -93,6 +127,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 	}
 
 	type versionResult struct {
+		r   string
 		v   *Version
 		err error
 	}
@@ -104,15 +139,26 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 		r := r
 		go func() {
 			version, err := p.VersionFromTag(r)
-			verChan <- versionResult{version, err}
+			verChan <- versionResult{r, version, err}
 		}()
 	}
 
 	addedReleases := false
+	var errs []error
 	for range newReleases {
 		result := <-verChan
 		if result.err != nil {
-			return nil, result.err
+			var nonFatal ErrVersionNonFatal
+			if errors.As(result.err, &nonFatal) {
+				meta.VersionErrors = append(meta.VersionErrors, VersionError{
+					Version: internal.TrimTagPrefix(result.r),
+					Message: nonFatal.Error(),
+					UTCTime: time.Now().UTC(),
+				})
+				continue
+			}
+			errs = append(errs, result.err)
+			continue
 		}
 		if result.v == nil {
 			// Not a valid release, skipping
@@ -120,6 +166,11 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 		}
 		// append the new release to the metadata
 		meta.Versions = append(meta.Versions, *result.v)
+
+		// remove any error version records now that we have had a successful result
+		meta.VersionErrors = slices.DeleteFunc(meta.VersionErrors, func(errored VersionError) bool {
+			return errored.Version == result.r
+		})
 
 		addedReleases = true
 	}
@@ -133,5 +184,13 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 	}
 	slices.SortFunc(meta.Versions, semverSortFunc)
 
-	return &meta, nil
+	slices.SortFunc(meta.VersionErrors, func(a, b VersionError) int {
+		comp := -semver.Compare(fmt.Sprintf("v%s", a.Version), fmt.Sprintf("v%s", b.Version))
+		if comp == 0 {
+			comp = a.UTCTime.Compare(b.UTCTime)
+		}
+		return comp
+	})
+
+	return &meta, errors.Join(errs...)
 }

--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -162,7 +162,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 
 		// remove any error version records now that we have had a successful result
 		meta.VersionErrors = slices.DeleteFunc(meta.VersionErrors, func(errored VersionError) bool {
-			return errored.Version == result.r
+			return errored.Version == result.v.Version
 		})
 
 		metadataUpdated = true

--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -53,7 +53,7 @@ func (meta Metadata) filterNewReleases(releases []string, namespace, name string
 			isErrored := false
 			if numVersionErrors > 0 {
 				// Simple doubling backoff
-				dur := time.Minute * 15 * time.Duration(math.Pow(float64(numVersionErrors), 2))
+				dur := time.Minute * 15 * time.Duration(math.Pow(2, float64(numVersionErrors)))
 				if latestError.Add(dur).After(time.Now()) {
 					isErrored = true
 				}

--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -39,21 +39,21 @@ func (meta Metadata) filterNewReleases(releases []string, namespace, name string
 				continue
 			}
 
-			var errorEntries []VersionError
+			var numVersionErrors int
 			var latestError time.Time
 			for _, errored := range meta.VersionErrors {
 				if errored.Version == version {
 					if errored.UTCTime.After(latestError) {
 						latestError = errored.UTCTime
 					}
-					errorEntries = append(errorEntries, errored)
+					numVersionErrors += 1
 				}
 			}
 
 			isErrored := false
-			if len(errorEntries) > 0 {
+			if numVersionErrors > 0 {
 				// Simple doubling backoff
-				dur := time.Minute * 15 * time.Duration(math.Pow(float64(len(errorEntries)), 2))
+				dur := time.Minute * 15 * time.Duration(math.Pow(float64(numVersionErrors), 2))
 				if latestError.Add(dur).After(time.Now()) {
 					isErrored = true
 				}
@@ -135,7 +135,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 		}()
 	}
 
-	addedReleases := false
+	metadataUpdated := false
 	var errs []error
 	for range newReleases {
 		result := <-verChan
@@ -147,6 +147,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 					Message: nonFatal.Error(),
 					UTCTime: time.Now().UTC(),
 				})
+				metadataUpdated = true
 				continue
 			}
 			errs = append(errs, result.err)
@@ -164,11 +165,11 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 			return errored.Version == result.r
 		})
 
-		addedReleases = true
+		metadataUpdated = true
 	}
-	if !addedReleases {
+	if !metadataUpdated {
 		// Prevent file modification if not changed
-		return nil, nil
+		return nil, errors.Join(errs...)
 	}
 
 	semverSortFunc := func(a, b Version) int {

--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -118,14 +118,6 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 		return nil, nil
 	}
 
-	shouldUpdate, err := p.shouldUpdateMetadataFile()
-	if err != nil {
-		p.Logger.Warn("Failed to determine update status, forcing update", slog.Any("err", err))
-	} else if !shouldUpdate {
-		p.Logger.Info("No version bump required, latest versions exist")
-		return nil, nil
-	}
-
 	type versionResult struct {
 		r   string
 		v   *Version

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/opentofu/registry-stable/internal/blacklist"
 	"github.com/opentofu/registry-stable/internal/files"
@@ -15,10 +16,11 @@ import (
 
 // Metadata contains information about the provider.
 type Metadata struct {
-	Repository string       `json:"repository,omitempty"` // Optional. Custom repository from which to fetch the provider's metadata.
-	Versions   []Version    `json:"versions"`             // A list of version data, for each supported provider version.
-	Warnings   []string     `json:"warnings,omitempty"`   // Warnings associated with this provider.
-	Logger     *slog.Logger `json:"-"`
+	Repository    string         `json:"repository,omitempty"`      // Optional. Custom repository from which to fetch the provider's metadata.
+	Versions      []Version      `json:"versions"`                  // A list of version data, for each supported provider version.
+	VersionErrors []VersionError `json:"versions_errors,omitempty"` // A list of versions which are not valid due to errors encountered during processing.
+	Warnings      []string       `json:"warnings,omitempty"`        // Warnings associated with this provider.
+	Logger        *slog.Logger   `json:"-"`
 }
 
 // Version contains information about a specific provider version.
@@ -28,6 +30,14 @@ type Version struct {
 	SHASumsURL          string   `json:"shasums_url"`           // The URL to the SHA checksums file.
 	SHASumsSignatureURL string   `json:"shasums_signature_url"` // The URL to the GPG signature of the SHA checksums file.
 	Targets             []Target `json:"targets"`               // A list of target platforms for which this provider version is available.
+}
+
+// VersionError track versions that can not be populated due to errors.
+// This should help prevent constantly querying for data that is invalid.
+type VersionError struct {
+	Version string    `json:"version"` // The version number of the provider.
+	Message string    `json:"message"`
+	UTCTime time.Time `json:"utc_time"`
 }
 
 // Target contains information about a specific provider version for a specific target platform.

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -81,12 +81,6 @@ func (p Provider) RepositoryURL() string {
 	return fmt.Sprintf("https://github.com/%s/%s", p.EffectiveNamespace(), p.RepositoryName())
 }
 
-// RSSURL returns the URL of the RSS feed for the repository's releases.
-func (p Provider) RSSURL() string {
-	repositoryUrl := p.RepositoryURL()
-	return fmt.Sprintf("%s/releases.atom", repositoryUrl)
-}
-
 // EffectiveNamespace will map namespaces for providers in situations
 // where the author (owner of the namespace) does not release artifacts as
 // GitHub Releases.

--- a/src/internal/provider/update.go
+++ b/src/internal/provider/update.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
 
@@ -12,16 +13,13 @@ func (p Provider) UpdateMetadataFile() error {
 	p.Logger.Info("Beginning version bump process")
 
 	meta, err := p.buildMetadata()
-	if err != nil {
-		p.Logger.Error("Failed to version bump provider", slog.Any("err", err))
-		return err
-	}
-	if meta == nil {
-		return nil
+	if meta != nil {
+		err = errors.Join(err, p.WriteMetadata(*meta))
 	}
 
-	p.Logger.Info("Completed provider version bump successfully")
-	return p.WriteMetadata(*meta)
+	p.Logger.Info("Completed provider version bump")
+
+	return err
 }
 
 func (p Provider) shouldUpdateMetadataFile() (bool, error) {

--- a/src/internal/provider/update.go
+++ b/src/internal/provider/update.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"errors"
-	"fmt"
 	"log/slog"
 
 	"golang.org/x/mod/semver"
@@ -20,34 +19,6 @@ func (p Provider) UpdateMetadataFile() error {
 	p.Logger.Info("Completed provider version bump")
 
 	return err
-}
-
-func (p Provider) shouldUpdateMetadataFile() (bool, error) {
-	semVerTag, err := p.getLastSemVerTag()
-	if err != nil {
-		return false, err
-	}
-
-	if semVerTag == "" {
-		// Repo unavailable or tags deleted
-		return false, nil
-	}
-
-	fileContent, err := p.ReadMetadata()
-	if err != nil {
-		return false, err
-	}
-
-	for _, v := range fileContent.Versions {
-		versionWithPrefix := fmt.Sprintf("v%s", v.Version)
-		if versionWithPrefix == semVerTag {
-			p.Logger.Info("Found latest tag, nothing to update...", slog.String("tag", semVerTag))
-			return false, nil
-		}
-	}
-
-	p.Logger.Info("Could not find latest tag, updating...", slog.String("tag", semVerTag))
-	return true, nil
 }
 
 // getSemVerTagsFromRSS returns a list of semver tags from the RSS feed

--- a/src/internal/provider/update.go
+++ b/src/internal/provider/update.go
@@ -2,9 +2,6 @@ package provider
 
 import (
 	"errors"
-	"log/slog"
-
-	"golang.org/x/mod/semver"
 )
 
 // UpdateMetadataFile updates the metadata file with the latest version information
@@ -19,41 +16,4 @@ func (p Provider) UpdateMetadataFile() error {
 	p.Logger.Info("Completed provider version bump")
 
 	return err
-}
-
-// getSemVerTagsFromRSS returns a list of semver tags from the RSS feed
-// ignoring all non-valid semver tags
-func (p Provider) getSemVerTagsFromRSS() ([]string, error) {
-	releasesRssUrl := p.RSSURL()
-	tags, err := p.Github.GetTagsFromRSS(releasesRssUrl)
-	if err != nil {
-		return nil, err
-	}
-
-	var semverTags []string
-	for _, tag := range tags {
-		if semver.IsValid(tag) || semver.IsValid("v"+tag) {
-			semverTags = append(semverTags, tag)
-		}
-	}
-
-	return semverTags, nil
-}
-
-// getLastSemVerTag returns the most recently created semver tag from the RSS feed
-// by sorting the tags by descending creation date
-func (p Provider) getLastSemVerTag() (string, error) {
-	semverTags, err := p.getSemVerTagsFromRSS()
-	if err != nil {
-		p.Logger.Warn("Unable to fetch tags, skipping", slog.Any("err", err))
-		return "", nil
-	}
-
-	if len(semverTags) < 1 {
-		p.Logger.Warn("no semver tags found in repository, skipping", slog.String("url", p.RepositoryURL()))
-		return "", nil
-	}
-
-	// Tags should be sorted by descending creation date. So, return the first tag
-	return semverTags[0], nil
 }

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -65,7 +65,7 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 
 	if checksums == nil {
 		logger.Warn("checksums not found in release, skipping...")
-		return nil, nil
+		return nil, ErrVersionNonFatal{fmt.Errorf("checksums not found in release")}
 	}
 
 	var ok bool
@@ -104,7 +104,7 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 
 	if len(v.Targets) == 0 {
 		logger.Info("No artifacts in release, skipping...", slog.String("release", version))
-		return nil, nil
+		return nil, ErrVersionNonFatal{fmt.Errorf("no artifacts in release")}
 	}
 
 	v.Protocols, err = p.GetProtocols(p.ArtifactURL(release, version, "manifest.json"))
@@ -125,4 +125,16 @@ func (p Provider) VersionFromTag(release string) (*Version, error) {
 	}
 
 	return &v, nil
+}
+
+type ErrVersionNonFatal struct {
+	err error
+}
+
+func (e ErrVersionNonFatal) Unwrap() error {
+	return e.err
+}
+
+func (e ErrVersionNonFatal) Error() string {
+	return e.err.Error()
 }


### PR DESCRIPTION
This resolves issues like those seen in https://github.com/opentofu/registry/pull/3806 where "older" version numbers are not detected.  We originally added the shouldUpdateMetadataFile check to ignore old erroring versions, but it was a workaround that has run it's course.

It uses an exponential backoff approach:
```
delay = 2^NumErrorsRecorded * 15 minutes
nextAttemptSoonest = latestAtteptTime + delay
```
* Delay1 = 2^1 * N = 2N
* Delay2 = 2^2 * N = 4N
* Delay3 = 3^2 * N = 8N
* DelayZ = Z^2 * N = 2^ZN
where N = 15 minutes

The only major issue is that this approach will update a bunch of json meta files in the repo over the first few bumps and cause lots of sync traffic.  Given what we saw with the recent backfill, I'm not terribly worried about that.