### PR TITLE
Fix backfill version matching bug and re-enable backfill

### DIFF
--- a/src/cmd/bump-versions/main.go
+++ b/src/cmd/bump-versions/main.go
@@ -24,7 +24,7 @@ func main() {
 	moduleNamespace := flag.String("module-namespace", "", "Which module namespace to limit the command to")
 	providerDataDir := flag.String("provider-data", "../providers", "Directory containing the provider data")
 	providerNamespace := flag.String("provider-namespace", "", "Which provider namespace to limit the command to")
-	targetDuration := flag.Duration("target-duration", time.Minute*0, "Used to limit how much of a backfill this command can perform") // Disabled by default
+	targetDuration := flag.Duration("target-duration", time.Minute*5, "Used to limit how much of a backfill this command can perform")
 
 	flag.Parse()
 

--- a/src/internal/provider/backfill.go
+++ b/src/internal/provider/backfill.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 )
 
 func (p *Provider) BackfillVersionData(ctx context.Context) error {
 	p.Logger.Info("Beginning version backfill process")
 
 	meta, err := p.ReadMetadata()
+	if err != nil {
+		return err
+	}
+
+	releases, err := p.getSemverTags()
 	if err != nil {
 		return err
 	}
@@ -37,7 +43,20 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 			continue
 		}
 
-		newVersion, err := p.VersionFromTag("v" + version.Version)
+		// version.Version *never* starts with "v"
+		// Therefore we need to find the git tag which corresponds
+		// with the recorded provider version.
+		var releaseTag string
+		if slices.Contains(releases, version.Version) {
+			releaseTag = version.Version
+		} else if slices.Contains(releases, "v"+version.Version) {
+			releaseTag = "v" + version.Version
+		} else {
+			p.Logger.Warn("Failed to backfill version, missing release tag", slog.String("version", version.Version))
+			break
+		}
+
+		newVersion, err := p.VersionFromTag(releaseTag)
 		if err != nil {
 			p.Logger.Error("Failed to backfill version", slog.String("version", version.Version), slog.Any("err", err))
 			errs = append(errs, err)


### PR DESCRIPTION
The original backfill missed the scenario where older providers may have had release without a "v" in the version tag. We now scan the list of tags the provider reports and find the matching to "v" or not to "v", as that is the question.