### PR TITLE
Exclude the versions_errors.utc_time from being compared during PR check

### DIFF
--- a/.github/scripts/verify-pr-json.sh
+++ b/.github/scripts/verify-pr-json.sh
@@ -23,8 +23,9 @@ HEADER
 
 # Compare two JSON files semantically (normalized key order and formatting)
 # Stores diff output in $json_diff_output. Sets return code 0 if equal, 1 if different.
+# Do not
 json_diff() {
-	json_diff_output=$(diff -u <(jq --sort-keys '.' "$1") <(jq --sort-keys '.' "$2") || true)
+	json_diff_output=$(diff -u <(jq --sort-keys '. | del(.versions_errors[]?.utc_time)' "$1") <(jq --sort-keys '. | del(.versions_errors[]?.utc_time)' "$2") || true)
 	[[ -z "${json_diff_output}" ]]
 }
 


### PR DESCRIPTION
Added `| del(.versions_errors[]?.utc_time)` to the `jq` instructions used to compare the generated file during PR check vs the one submitted in the PR:
* `del` removes a particular key
* `.versions_errors[]` removes the key from all the objects under the `versions_errors` key
* `?` performs the action only when the `versions_errors` do exist

Fixes #4103