### PR TITLE
Record module and provider discover time

### DIFF
--- a/.github/scripts/verify-pr-json.sh
+++ b/.github/scripts/verify-pr-json.sh
@@ -26,7 +26,7 @@ HEADER
 # The comparison is done by ignoring the "utc_time" field from all the "versions_errors" entries (if it exists) since that could have
 # different values between multiple executions.
 json_diff() {
-	json_diff_output=$(diff -u <(jq --sort-keys '. | del(.versions_errors[]?.utc_time)' "$1") <(jq --sort-keys '. | del(.versions_errors[]?.utc_time)' "$2") || true)
+	json_diff_output=$(diff -u <(jq --sort-keys '. | del(.versions_errors[]?.utc_time) | del(.versions[]?.discovered)' "$1") <(jq --sort-keys '. | del(.versions_errors[]?.utc_time) | del(.versions[]?.discovered)' "$2") || true)
 	[[ -z "${json_diff_output}" ]]
 }
 

--- a/src/cmd/bump-versions/main.go
+++ b/src/cmd/bump-versions/main.go
@@ -84,7 +84,7 @@ func main() {
 		return
 	}
 
-	logger.Info("Beginning backfill process for providers", slog.Any("time_allocated", remainingTime))
+	logger.Info("Beginning backfill process", slog.Any("time_allocated", remainingTime))
 
 	// Setup a new github client with the limited context
 	ghClient = github.NewClient(ctx, logger, token)
@@ -117,5 +117,33 @@ func main() {
 		os.Exit(1)
 	}
 
-	logger.Info("Completed backfill process for providers")
+	// Re-list modules with new github client (not ideal)
+	modules, err = module.ListModules(*moduleDataDir, *moduleNamespace, logger, ghClient, bl)
+	if err != nil {
+		logger.Error("Failed to list modules", slog.Any("err", err))
+		os.Exit(1)
+	}
+	err = modules.Parallel(20, func(p module.Module) error {
+		if err := ctx.Err(); err != nil {
+			if errors.Is(err, context.DeadlineExceeded) {
+				// Outta-time
+				return nil
+			}
+			return err
+		}
+		err := p.BackfillVersionData(ctx)
+		if errors.Is(err, context.DeadlineExceeded) {
+			p.Logger.Info("Partial completion of backfill due to time limitation")
+			// Outta-time
+			return nil
+		}
+		return err
+	})
+
+	if err != nil {
+		logger.Error("Failed to backfill modules", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	logger.Info("Completed backfill process")
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,6 @@
 module github.com/opentofu/registry-stable
 
-go 1.21
+go 1.26
 
 require (
 	github.com/ProtonMail/gopenpgp/v2 v2.7.4

--- a/src/internal/github/git.go
+++ b/src/internal/github/git.go
@@ -8,8 +8,13 @@ import (
 	"strings"
 )
 
-func parseTagsFromStdout(lines []string) ([]string, error) {
-	tags := make([]string, 0, len(lines))
+type Tag struct {
+	Ref    string
+	Commit string
+}
+
+func parseTagsFromStdout(lines []string) ([]Tag, error) {
+	tags := make([]Tag, 0, len(lines))
 
 	for _, line := range lines {
 		if !strings.Contains(line, "refs/tags/") {
@@ -31,14 +36,14 @@ func parseTagsFromStdout(lines []string) ([]string, error) {
 			return nil, fmt.Errorf("invalid format for tag '%s', no version provided", line)
 		}
 
-		tags = append(tags, tag)
+		tags = append(tags, Tag{Ref: tag, Commit: fields[0]})
 	}
 
 	return tags, nil
 }
 
 // GetTags lists the tags of the remote repository and returns the refs/tags/ found
-func (c Client) GetTags(repositoryURL string) ([]string, error) {
+func (c Client) GetTags(repositoryURL string) ([]Tag, error) {
 	done := c.cliThrottle()
 	defer done()
 

--- a/src/internal/github/git.go
+++ b/src/internal/github/git.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -17,26 +18,32 @@ func parseTagsFromStdout(lines []string) ([]Tag, error) {
 	tags := make([]Tag, 0, len(lines))
 
 	for _, line := range lines {
-		if !strings.Contains(line, "refs/tags/") {
+		prefix := "refs/tags/"
+		if !strings.Contains(line, prefix) {
 			continue
 		}
 
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
-			return nil, fmt.Errorf("invalid format for tag '%s', expected two fields", line)
+			return nil, fmt.Errorf("invalid format for tag %q, expected two fields", line)
+		}
+
+		commit := fields[0]
+		if _, err := hex.DecodeString(commit); err != nil {
+			return nil, fmt.Errorf("invalid format for commit %q: %w", line, err)
 		}
 
 		ref := fields[1]
-		if !strings.HasPrefix(ref, "refs/tags/") {
-			return nil, fmt.Errorf("invalid format for tag '%s', expected 'refs/tags/' prefix", line)
+		if !strings.HasPrefix(ref, prefix) {
+			return nil, fmt.Errorf("invalid format for tag %q, expected %q prefix", line, prefix)
 		}
 
-		tag := strings.TrimPrefix(ref, "refs/tags/")
+		tag := strings.TrimPrefix(ref, prefix)
 		if tag == "" {
-			return nil, fmt.Errorf("invalid format for tag '%s', no version provided", line)
+			return nil, fmt.Errorf("invalid format for tag %q, no version provided", line)
 		}
 
-		tags = append(tags, Tag{Ref: tag, Commit: fields[0]})
+		tags = append(tags, Tag{Ref: tag, Commit: commit})
 	}
 
 	return tags, nil

--- a/src/internal/github/git_test.go
+++ b/src/internal/github/git_test.go
@@ -1,7 +1,6 @@
 package github
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +10,7 @@ func Test_parseTagsFromStdout(t *testing.T) {
 	cases := map[string]struct {
 		input       []string
 		expected    []Tag
-		expectedErr error
+		expectedErr string
 	}{
 		"Empty input": {
 			input:    []string{""},
@@ -19,17 +18,17 @@ func Test_parseTagsFromStdout(t *testing.T) {
 		},
 		// Successful
 		"Simple Tag": {
-			input: []string{"314159265358979     refs/tags/v0.0.1"},
+			input: []string{"3141592653589793     refs/tags/v0.0.1"},
 			expected: []Tag{
-				{Commit: "314159265358979", Ref: "v0.0.1"},
+				{Commit: "3141592653589793", Ref: "v0.0.1"},
 			},
 		},
 		"Multiple Tags": {
-			input: []string{"314159265358979     refs/tags/v0.0.1", "314159265358979     refs/tags/v0.1.1", "314159265358979     refs/tags/v1.0.1"},
+			input: []string{"3141592653589793     refs/tags/v0.0.1", "3141592653589793     refs/tags/v0.1.1", "3141592653589793     refs/tags/v1.0.1"},
 			expected: []Tag{
-				{Commit: "314159265358979", Ref: "v0.0.1"},
-				{Commit: "314159265358979", Ref: "v0.1.1"},
-				{Commit: "314159265358979", Ref: "v1.0.1"},
+				{Commit: "3141592653589793", Ref: "v0.0.1"},
+				{Commit: "3141592653589793", Ref: "v0.1.1"},
+				{Commit: "3141592653589793", Ref: "v1.0.1"},
 			},
 		},
 		// Invalid entries (ignored)
@@ -42,28 +41,32 @@ func Test_parseTagsFromStdout(t *testing.T) {
 			expected: []Tag{},
 		},
 		"Multiple Tags w/ Invalid": {
-			input: []string{"314159265358979     HEAD", "314159265358979     refs/tags/v0.1.1", "314159265358979     refs/tags/v1.0.1"},
+			input: []string{"3141592653589793     HEAD", "3141592653589793     refs/tags/v0.1.1", "3141592653589793     refs/tags/v1.0.1"},
 			expected: []Tag{
-				{Commit: "314159265358979", Ref: "v0.1.1"},
-				{Commit: "314159265358979", Ref: "v1.0.1"},
+				{Commit: "3141592653589793", Ref: "v0.1.1"},
+				{Commit: "3141592653589793", Ref: "v1.0.1"},
 			},
 		},
 		// Error cases
 		"Missing Field": {
 			input:       []string{"borkborkborkrefs/tags/"},
-			expectedErr: errors.New("invalid format for tag 'borkborkborkrefs/tags/', expected two fields"),
+			expectedErr: "invalid format for tag \"borkborkborkrefs/tags/\", expected two fields",
 		},
 		"Extra Field": {
-			input:       []string{"bork bork refs/tags/"},
-			expectedErr: errors.New("invalid format for tag 'bork bork refs/tags/', expected two fields"),
+			input:       []string{"deadbeef deadbeef refs/tags/"},
+			expectedErr: "invalid format for tag \"deadbeef deadbeef refs/tags/\", expected two fields",
+		},
+		"Bad commit": {
+			input:       []string{"borkbork refs/tags/v0.0.1"},
+			expectedErr: "invalid format for commit \"borkbork refs/tags/v0.0.1\": encoding/hex: invalid byte: U+006F 'o'",
 		},
 		"Missing tags/refs": {
-			input:       []string{"314159265358979refs/tags/   v0.0.1"},
-			expectedErr: errors.New("invalid format for tag '314159265358979refs/tags/   v0.0.1', expected 'refs/tags/' prefix"),
+			input:       []string{"3141592653589793   v0.0.1refs/tags/"},
+			expectedErr: "invalid format for tag \"3141592653589793   v0.0.1refs/tags/\", expected \"refs/tags/\" prefix",
 		},
 		"Missing version": {
-			input:       []string{"314159265358979 refs/tags/"},
-			expectedErr: errors.New("invalid format for tag '314159265358979 refs/tags/', no version provided"),
+			input:       []string{"3141592653589793 refs/tags/"},
+			expectedErr: "invalid format for tag \"3141592653589793 refs/tags/\", no version provided",
 		},
 	}
 
@@ -71,7 +74,11 @@ func Test_parseTagsFromStdout(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			out, err := parseTagsFromStdout(tc.input)
 
-			assert.Equal(t, tc.expectedErr, err)
+			if tc.expectedErr != "" {
+				assert.EqualError(t, err, tc.expectedErr)
+			} else {
+				assert.Nil(t, err)
+			}
 			assert.Equal(t, tc.expected, out)
 
 		})

--- a/src/internal/github/git_test.go
+++ b/src/internal/github/git_test.go
@@ -10,34 +10,43 @@ import (
 func Test_parseTagsFromStdout(t *testing.T) {
 	cases := map[string]struct {
 		input       []string
-		expected    []string
+		expected    []Tag
 		expectedErr error
 	}{
 		"Empty input": {
 			input:    []string{""},
-			expected: []string{},
+			expected: []Tag{},
 		},
 		// Successful
 		"Simple Tag": {
-			input:    []string{"314159265358979     refs/tags/v0.0.1"},
-			expected: []string{"v0.0.1"},
+			input: []string{"314159265358979     refs/tags/v0.0.1"},
+			expected: []Tag{
+				{Commit: "314159265358979", Ref: "v0.0.1"},
+			},
 		},
 		"Multiple Tags": {
-			input:    []string{"314159265358979     refs/tags/v0.0.1", "314159265358979     refs/tags/v0.1.1", "314159265358979     refs/tags/v1.0.1"},
-			expected: []string{"v0.0.1", "v0.1.1", "v1.0.1"},
+			input: []string{"314159265358979     refs/tags/v0.0.1", "314159265358979     refs/tags/v0.1.1", "314159265358979     refs/tags/v1.0.1"},
+			expected: []Tag{
+				{Commit: "314159265358979", Ref: "v0.0.1"},
+				{Commit: "314159265358979", Ref: "v0.1.1"},
+				{Commit: "314159265358979", Ref: "v1.0.1"},
+			},
 		},
 		// Invalid entries (ignored)
 		"No Tags": {
 			input:    []string{},
-			expected: []string{},
+			expected: []Tag{},
 		},
 		"Empty Tags": {
 			input:    []string{""},
-			expected: []string{},
+			expected: []Tag{},
 		},
 		"Multiple Tags w/ Invalid": {
-			input:    []string{"314159265358979     HEAD", "314159265358979     refs/tags/v0.1.1", "314159265358979     refs/tags/v1.0.1"},
-			expected: []string{"v0.1.1", "v1.0.1"},
+			input: []string{"314159265358979     HEAD", "314159265358979     refs/tags/v0.1.1", "314159265358979     refs/tags/v1.0.1"},
+			expected: []Tag{
+				{Commit: "314159265358979", Ref: "v0.1.1"},
+				{Commit: "314159265358979", Ref: "v1.0.1"},
+			},
 		},
 		// Error cases
 		"Missing Field": {

--- a/src/internal/module/backfill.go
+++ b/src/internal/module/backfill.go
@@ -1,0 +1,76 @@
+package module
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+)
+
+func (m *Module) BackfillVersionData(ctx context.Context) error {
+	m.Logger.Info("Beginning version backfill process")
+
+	meta, err := m.ReadMetadata()
+	if err != nil {
+		return err
+	}
+
+	releases, err := m.getSemverTags()
+	if err != nil {
+		return err
+	}
+
+	var errs []error
+	madeChanges := false
+	var backfilled, skipped, errored int
+	for key, version := range meta.Versions {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, err)
+			break
+		}
+
+		if version.Discovered != nil && version.Commit != "" {
+			skipped++
+			continue
+		}
+		madeChanges = true
+
+		if version.Discovered == nil {
+			version.Discovered = new(version.FirstDiscovered())
+			meta.Versions[key] = version
+		}
+
+		if version.Commit == "" {
+			foundRelease := false
+			for _, release := range releases {
+				if release.Ref == version.Version {
+					version.Commit = release.Commit
+					meta.Versions[key] = version
+					foundRelease = true
+					break
+				}
+			}
+			if !foundRelease {
+				err := fmt.Errorf("release not found for version %s", version.Version)
+				m.Logger.Error("Failed to backfill version", slog.String("version", version.Version), slog.Any("err", err))
+				errs = append(errs, err)
+				errored++
+			}
+		}
+
+		backfilled++
+	}
+
+	m.Logger.Info("Completed version backfill process",
+		slog.Int("backfilled", backfilled),
+		slog.Int("skipped", skipped),
+		slog.Int("errored", errored),
+		slog.Int("total", len(meta.Versions)),
+	)
+
+	if madeChanges {
+		errs = append(errs, m.WriteMetadata(meta))
+	}
+
+	return errors.Join(errs...)
+}

--- a/src/internal/module/backfill.go
+++ b/src/internal/module/backfill.go
@@ -55,6 +55,7 @@ func (m *Module) BackfillVersionData(ctx context.Context) error {
 				m.Logger.Error("Failed to backfill version", slog.String("version", version.Version), slog.Any("err", err))
 				errs = append(errs, err)
 				errored++
+				continue
 			}
 		}
 

--- a/src/internal/module/build.go
+++ b/src/internal/module/build.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"time"
 
 	"golang.org/x/mod/semver"
 
 	"github.com/opentofu/registry-stable/internal"
+	"github.com/opentofu/registry-stable/internal/github"
 )
 
 func (m Module) UpdateMetadataFile() error {
@@ -45,14 +47,14 @@ func (m Module) BuildMetadata() (*Metadata, error) {
 	for _, t := range tags {
 		found := false
 		for _, v := range meta.Versions {
-			if v.Version == t {
+			if v.Version == t.Ref {
 				found = true
 				break
 			}
 		}
 		if !found {
 			// Check if this version is blacklisted
-			version := internal.TrimTagPrefix(t)
+			version := internal.TrimTagPrefix(t.Ref)
 			if isBlacklisted, reason := blacklistInstance.IsModuleVersionBlacklisted(m.Namespace, m.Name, m.TargetSystem, version); isBlacklisted {
 				m.Logger.Warn("Skipping blacklisted module version",
 					slog.String("namespace", m.Namespace),
@@ -63,7 +65,11 @@ func (m Module) BuildMetadata() (*Metadata, error) {
 				blacklistedCount++
 				continue
 			}
-			meta.Versions = append(meta.Versions, Version{Version: t})
+			meta.Versions = append(meta.Versions, Version{
+				Version:    t.Ref,
+				Commit:     t.Commit,
+				Discovered: new(time.Now().UTC()),
+			})
 		}
 	}
 
@@ -79,22 +85,22 @@ func (m Module) BuildMetadata() (*Metadata, error) {
 	return &meta, nil
 }
 
-func (m Module) getSemverTags() ([]string, error) {
+func (m Module) getSemverTags() ([]github.Tag, error) {
 	tags, err := m.Github.GetTags(m.RepositoryURL())
 	if err != nil {
 		return nil, err
 	}
 
-	var semverTags = make([]string, 0)
+	var semverTags = make([]github.Tag, 0)
 	for _, tag := range tags {
-		tagWithPrefix := fmt.Sprintf("v%s", internal.TrimTagPrefix(tag))
+		tagWithPrefix := fmt.Sprintf("v%s", internal.TrimTagPrefix(tag.Ref))
 		if semver.IsValid(tagWithPrefix) {
 			semverTags = append(semverTags, tag)
 		}
 	}
 
-	semverSortFunc := func(a, b string) int {
-		return -semver.Compare(a, b)
+	semverSortFunc := func(a, b github.Tag) int {
+		return -semver.Compare(a.Ref, b.Ref)
 	}
 	slices.SortFunc(semverTags, semverSortFunc)
 

--- a/src/internal/module/module.go
+++ b/src/internal/module/module.go
@@ -63,7 +63,7 @@ func (m Module) RSSURL() string {
 
 // VersionDownloadURL returns the location to download the module from.
 // the file should just contain a link to GitHub to download the tarball, ie:
-// git::https://github.com/terraform-aws-modules/terraform-aws-iam?ref=v5.30.0
+// git::https://github.com/terraform-aws-modules/terraform-aws-iam?ref=<commit-hash>
 func (m Module) VersionDownloadURL(version Version) string {
 	ref := version.Commit
 	if ref == "" {

--- a/src/internal/module/module.go
+++ b/src/internal/module/module.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/opentofu/registry-stable/internal/blacklist"
 	"github.com/opentofu/registry-stable/internal/files"
@@ -16,7 +17,20 @@ import (
 
 // Version represents a single version of a module.
 type Version struct {
-	Version string `json:"version"` // The version number of the provider. Correlates to a tag in the module repository
+	Version    string     `json:"version"`              // The version number of the provider. Correlates to a tag in the module repository
+	Commit     string     `json:"commit"`               // The commit hash of the version tag when the module version was first discovered
+	Discovered *time.Time `json:"discovered,omitempty"` // The date the module version was first discovered
+}
+
+// Any module without a discovered date should default to the date we started tracking discovery
+var defaultDiscovery, _ = time.Parse(time.RFC3339, "2026-04-21T00:00:00Z")
+
+func (v *Version) FirstDiscovered() time.Time {
+	if v.Discovered == nil {
+		// This can be removed once the backfill is complete
+		return defaultDiscovery
+	}
+	return *v.Discovered
 }
 
 // Metadata represents all the metadata for a module. This includes the list of
@@ -51,7 +65,12 @@ func (m Module) RSSURL() string {
 // the file should just contain a link to GitHub to download the tarball, ie:
 // git::https://github.com/terraform-aws-modules/terraform-aws-iam?ref=v5.30.0
 func (m Module) VersionDownloadURL(version Version) string {
-	return fmt.Sprintf("git::%s?ref=%s", m.RepositoryURL(), version.Version)
+	ref := version.Commit
+	if ref == "" {
+		// TODO remove this fallback once backfill is complete
+		ref = version.Version
+	}
+	return fmt.Sprintf("git::%s?ref=%s", m.RepositoryURL(), ref)
 }
 
 // MetadataPath returns the path to the metadata file for the module.

--- a/src/internal/module/validate_test.go
+++ b/src/internal/module/validate_test.go
@@ -15,13 +15,13 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid",
 			input: Metadata{
-				Versions: []Version{{"0.0.2"}, {"0.0.1"}},
+				Versions: []Version{{Version: "0.0.2"}, {Version: "0.0.1"}},
 			},
 		},
 		{
 			name: "invalid-version",
 			input: Metadata{
-				Versions: []Version{{"0.0.2"}, {"foo"}},
+				Versions: []Version{{Version: "0.0.2"}, {Version: "foo"}},
 			},
 			wantErrStr: "found semver-incompatible version: foo\n",
 		},

--- a/src/internal/provider/backfill.go
+++ b/src/internal/provider/backfill.go
@@ -4,18 +4,12 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"slices"
 )
 
 func (p *Provider) BackfillVersionData(ctx context.Context) error {
 	p.Logger.Info("Beginning version backfill process")
 
 	meta, err := p.ReadMetadata()
-	if err != nil {
-		return err
-	}
-
-	releases, err := p.getSemverTags()
 	if err != nil {
 		return err
 	}
@@ -29,44 +23,13 @@ func (p *Provider) BackfillVersionData(ctx context.Context) error {
 			break
 		}
 
-		// Check to see if this version has already
-		// been populated
-		hasMeta := false
-		for _, target := range version.Targets {
-			if target.Size != 0 {
-				hasMeta = true
-				break
-			}
-		}
-		if hasMeta {
-			skipped++
-			continue
-		}
-
-		// version.Version *never* starts with "v"
-		// Therefore we need to find the git tag which corresponds
-		// with the recorded provider version.
-		var releaseTag string
-		if slices.Contains(releases, version.Version) {
-			releaseTag = version.Version
-		} else if slices.Contains(releases, "v"+version.Version) {
-			releaseTag = "v" + version.Version
-		} else {
-			p.Logger.Warn("Failed to backfill version, missing release tag", slog.String("version", version.Version))
-			break
-		}
-
-		newVersion, err := p.VersionFromTag(releaseTag)
-		if err != nil {
-			p.Logger.Error("Failed to backfill version", slog.String("version", version.Version), slog.Any("err", err))
-			errs = append(errs, err)
-			errored++
-			continue
-		}
-		if newVersion != nil {
-			meta.Versions[key] = *newVersion
+		if version.Discovered == nil {
+			version.Discovered = new(version.FirstDiscovered())
+			meta.Versions[key] = version
 			madeChanges = true
 			backfilled++
+		} else {
+			skipped++
 		}
 	}
 

--- a/src/internal/provider/build.go
+++ b/src/internal/provider/build.go
@@ -10,23 +10,24 @@ import (
 
 	"github.com/opentofu/registry-stable/internal"
 	"github.com/opentofu/registry-stable/internal/blacklist"
+	"github.com/opentofu/registry-stable/internal/github"
 
 	"golang.org/x/mod/semver"
 )
 
 // filterNewReleases filters the list of releases to only include those that do
 // not already exist in the metadata and are not blacklisted.
-func (meta Metadata) filterNewReleases(releases []string, namespace, name string, blacklistInstance *blacklist.Blacklist) []string {
+func (meta Metadata) filterNewReleases(releases []github.Tag, namespace, name string, blacklistInstance *blacklist.Blacklist) []github.Tag {
 	var existingVersions = make(map[string]bool)
 	for _, v := range meta.Versions {
 		existingVersions[v.Version] = true
 	}
 
-	var newReleases = make([]string, 0)
+	var newReleases = make([]github.Tag, 0)
 	var blacklistedCount = 0
 	var erroredCount = 0
 	for _, r := range releases {
-		version := internal.TrimTagPrefix(r)
+		version := internal.TrimTagPrefix(r.Ref)
 		if !existingVersions[version] {
 			// Check if this version is blacklisted
 			if isBlacklisted, reason := blacklistInstance.IsProviderVersionBlacklisted(namespace, name, version); isBlacklisted {
@@ -79,15 +80,15 @@ func (meta Metadata) filterNewReleases(releases []string, namespace, name string
 }
 
 // getSemverTags returns a list of semver tags for the module fetched from GitHub.
-func (p Provider) getSemverTags() ([]string, error) {
+func (p Provider) getSemverTags() ([]github.Tag, error) {
 	tags, err := p.Github.GetTags(p.RepositoryURL())
 	if err != nil {
 		return nil, err
 	}
 
-	var semverTags = make([]string, 0)
+	var semverTags = make([]github.Tag, 0)
 	for _, tag := range tags {
-		tagWithPrefix := fmt.Sprintf("v%s", internal.TrimTagPrefix(tag))
+		tagWithPrefix := fmt.Sprintf("v%s", internal.TrimTagPrefix(tag.Ref))
 		if semver.IsValid(tagWithPrefix) {
 			semverTags = append(semverTags, tag)
 		}
@@ -119,7 +120,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 	}
 
 	type versionResult struct {
-		r   string
+		r   github.Tag
 		v   *Version
 		err error
 	}
@@ -143,7 +144,7 @@ func (p Provider) buildMetadata() (*Metadata, error) {
 			var nonFatal ErrVersionNonFatal
 			if errors.As(result.err, &nonFatal) {
 				meta.VersionErrors = append(meta.VersionErrors, VersionError{
-					Version: internal.TrimTagPrefix(result.r),
+					Version: internal.TrimTagPrefix(result.r.Ref),
 					Message: nonFatal.Error(),
 					UTCTime: time.Now().UTC(),
 				})

--- a/src/internal/provider/provider.go
+++ b/src/internal/provider/provider.go
@@ -26,11 +26,23 @@ type Metadata struct {
 
 // Version contains information about a specific provider version.
 type Version struct {
-	Version             string   `json:"version"`               // The version number of the provider.
-	Protocols           []string `json:"protocols"`             // The protocol versions the provider supports.
-	SHASumsURL          string   `json:"shasums_url"`           // The URL to the SHA checksums file.
-	SHASumsSignatureURL string   `json:"shasums_signature_url"` // The URL to the GPG signature of the SHA checksums file.
-	Targets             []Target `json:"targets"`               // A list of target platforms for which this provider version is available.
+	Version             string     `json:"version"`               // The version number of the provider.
+	Protocols           []string   `json:"protocols"`             // The protocol versions the provider supports.
+	SHASumsURL          string     `json:"shasums_url"`           // The URL to the SHA checksums file.
+	SHASumsSignatureURL string     `json:"shasums_signature_url"` // The URL to the GPG signature of the SHA checksums file.
+	Targets             []Target   `json:"targets"`               // A list of target platforms for which this provider version is available.
+	Discovered          *time.Time `json:"discovered,omitempty"`  // The date the version was first discovered
+}
+
+// Any provider without a discovered date should default to the date we started tracking discovery
+var defaultDiscovery, _ = time.Parse(time.RFC3339, "2026-04-21T00:00:00Z")
+
+func (v *Version) FirstDiscovered() time.Time {
+	if v.Discovered == nil {
+		// This can be removed once the backfill is complete
+		return defaultDiscovery
+	}
+	return *v.Discovered
 }
 
 // VersionError track versions that can not be populated due to errors.

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -47,7 +47,7 @@ func (p Provider) VersionFromTag(release github.Tag) (*Version, error) {
 		Version:             version,
 		SHASumsURL:          p.ArtifactURL(release, version, "SHA256SUMS"),
 		SHASumsSignatureURL: p.ArtifactURL(release, version, "SHA256SUMS.sig"),
-		Discovered:          new(time.Now()),
+		Discovered:          new(time.Now().UTC()),
 	}
 
 	checksums, err := p.GetSHASums(v.SHASumsURL)

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 
 	"github.com/opentofu/registry-stable/internal"
+	"github.com/opentofu/registry-stable/internal/github"
 )
 
 var (
@@ -31,15 +32,15 @@ func (p Provider) ArtifactName(version string, suffix string) string {
 	return fmt.Sprintf("%s_%s_%s", p.RepositoryName(), version, suffix)
 }
 
-func (p Provider) ArtifactURL(release string, version string, suffix string) string {
-	return fmt.Sprintf("%s/releases/download/%s/%s", p.RepositoryURL(), release, p.ArtifactName(version, suffix))
+func (p Provider) ArtifactURL(release github.Tag, version string, suffix string) string {
+	return fmt.Sprintf("%s/releases/download/%s/%s", p.RepositoryURL(), release.Ref, p.ArtifactName(version, suffix))
 }
 
 // VersionFromTag fetches information about an individual release based on the GitHub release name
-func (p Provider) VersionFromTag(release string) (*Version, error) {
-	version := internal.TrimTagPrefix(release)
+func (p Provider) VersionFromTag(release github.Tag) (*Version, error) {
+	version := internal.TrimTagPrefix(release.Ref)
 
-	logger := p.Logger.With(slog.String("release", release))
+	logger := p.Logger.With(slog.String("release", release.Ref))
 
 	v := Version{
 		Version:             version,

--- a/src/internal/provider/version.go
+++ b/src/internal/provider/version.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/opentofu/registry-stable/internal"
 	"github.com/opentofu/registry-stable/internal/github"
@@ -46,6 +47,7 @@ func (p Provider) VersionFromTag(release github.Tag) (*Version, error) {
 		Version:             version,
 		SHASumsURL:          p.ArtifactURL(release, version, "SHA256SUMS"),
 		SHASumsSignatureURL: p.ArtifactURL(release, version, "SHA256SUMS.sig"),
+		Discovered:          new(time.Now()),
 	}
 
 	checksums, err := p.GetSHASums(v.SHASumsURL)

--- a/src/internal/v1api/modules.go
+++ b/src/internal/v1api/modules.go
@@ -57,7 +57,10 @@ func (m ModuleGenerator) VersionDownloadPath(v module.Version) string {
 func (m ModuleGenerator) VersionListing() ModuleVersionListingResponse {
 	versions := make([]ModuleVersionResponseItem, len(m.Versions))
 	for i, v := range m.Versions {
-		versions[i] = ModuleVersionResponseItem{Version: internal.TrimTagPrefix(v.Version)}
+		versions[i] = ModuleVersionResponseItem{
+			Version:    internal.TrimTagPrefix(v.Version),
+			Discovered: v.FirstDiscovered(),
+		}
 	}
 	return ModuleVersionListingResponse{[]ModuleVersionListingResponseItem{{versions}}}
 }

--- a/src/internal/v1api/providers.go
+++ b/src/internal/v1api/providers.go
@@ -63,9 +63,10 @@ func (p ProviderGenerator) VersionListing() ProviderVersionListingResponse {
 
 	for versionIdx, ver := range p.Versions {
 		verResp := ProviderVersionResponseItem{
-			Version:   ver.Version,
-			Protocols: ver.Protocols,
-			Platforms: make([]ProviderPlatform, len(ver.Targets)),
+			Version:    ver.Version,
+			Protocols:  ver.Protocols,
+			Platforms:  make([]ProviderPlatform, len(ver.Targets)),
+			Discovered: ver.FirstDiscovered(),
 		}
 
 		for targetIdx, target := range ver.Targets {

--- a/src/internal/v1api/providers_test.go
+++ b/src/internal/v1api/providers_test.go
@@ -49,7 +49,7 @@ func Test_ProviderGenerator(t *testing.T) {
 	// Testing if the generated file has version with lower case
 	assert.Equal(t, "gen/v1/providers/zededa/zedcloud/v2.3.1-rc1/download/mac/arm", p.VersionDownloadPath(v, d))
 
-	vt, err := p.VersionFromTag("v2.3.1-RC1")
+	vt, err := p.VersionFromTag(github.Tag{Ref: "v2.3.1-RC1"})
 	require.NoError(t, err)
 
 	// URLs still should have an uppercase version, since we point directly to Github URLs

--- a/src/internal/v1api/responses.go
+++ b/src/internal/v1api/responses.go
@@ -1,7 +1,11 @@
 // Package v1api provides the v1 registry API response generation.
 package v1api
 
-import "github.com/opentofu/registry-stable/internal/gpg"
+import (
+	"time"
+
+	"github.com/opentofu/registry-stable/internal/gpg"
+)
 
 // ModuleVersionDownloadResponse is the item returned by the module version download API.
 type ModuleVersionDownloadResponse struct {
@@ -21,7 +25,8 @@ type ModuleVersionListingResponseItem struct {
 
 // ModuleVersionResponseItem is the item returned by the module version listing API
 type ModuleVersionResponseItem struct {
-	Version string `json:"version"` // The version string
+	Version    string    `json:"version"`    // The version string
+	Discovered time.Time `json:"discovered"` // When the version was first discovered
 
 	// TODO: Discuss if we want to keep or not.
 	// Root is not currently populated in the response, but may be in the future.
@@ -56,9 +61,10 @@ type ProviderVersionListingResponse struct {
 }
 
 type ProviderVersionResponseItem struct {
-	Version   string             `json:"version"`   // The version number of the provider.
-	Protocols []string           `json:"protocols"` // The protocol versions the provider supports.
-	Platforms []ProviderPlatform `json:"platforms"` // A list of platforms for which this provider version is available.
+	Version    string             `json:"version"`    // The version number of the provider.
+	Protocols  []string           `json:"protocols"`  // The protocol versions the provider supports.
+	Platforms  []ProviderPlatform `json:"platforms"`  // A list of platforms for which this provider version is available.
+	Discovered time.Time          `json:"discovered"` // When the version was first discovered
 }
 
 // ProviderPlatform represents a platform that a provider supports.


### PR DESCRIPTION
Also serve module downloads by commit hash

* https://github.com/opentofu/opentofu/issues/3990
* https://github.com/opentofu/opentofu/issues/1545
* https://github.com/opentofu/opentofu/issues/1942

I decided to use today's date as the "we first discovered this module/provider".  By the time we have this supported in a opentofu release, we should have plenty of historical data (months).

One potential alternative is to leave the date field in the metadata blank and choose a sane default (like above) in the v1api generator.

Another alternative is to simply omit dates that are unknown and let opentofu / operators decide how they wish to handle that.  This option would mean that historical releases would never be available for the advanced latest version (by date) selection described in 3990

As currently implemented, this will cause *large* backfill commits and may slow down the sync changes job for the first hour after merge.
