### PR TITLE
Bump the interval that we want to sync the changes for during a partial sync

### DIFF
--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup dependencies
         run: sudo apt-get update && sudo apt-get install rclone
 
-      - name: Prune modules and providers to only modified in the past 100 commits
+      - name: Prune modules and providers to only modified in the past 4 hours
         run: |
           # Copy files changed into pruned directory
           git fetch origin
@@ -44,11 +44,11 @@ jobs:
 
           mkdir ./pruned/
           echo "Copy Changed Providers"
-          git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^providers | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp foo ./pruned/foo; echo foo" | bash
+          git diff --name-only "$(git rev-list -1 --before="$(date -d '-4 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^providers | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp foo ./pruned/foo; echo foo" | bash
           echo "Copy Changed Providers by Keys"
-          git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^keys | sed -e 's,^keys/\([^/]*\)/\([^/]*\).*,providers/\1/\2,' | sort | uniq | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp -r foo ./pruned/foo; echo foo" | bash
+          git diff --name-only "$(git rev-list -1 --before="$(date -d '-4 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^keys | sed -e 's,^keys/\([^/]*\)/\([^/]*\).*,providers/\1/\2,' | sort | uniq | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp -r foo ./pruned/foo; echo foo" | bash
           echo "Copy Changed Modules"
-          git diff --name-only "$(git rev-list -1 --before="$(date -d '-1 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^modules | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp foo ./pruned/foo; echo foo" | bash
+          git diff --name-only "$(git rev-list -1 --before="$(date -d '-4 hours' '+%Y-%m-%d %H:%M:%S')" HEAD)" | grep ^modules | xargs -I foo echo "mkdir -p ./pruned/\$(dirname foo); cp foo ./pruned/foo; echo foo" | bash
 
       - name: Run Generation script
         working-directory: ./src


### PR DESCRIPTION
Sometimes, when GH workflow scheduling is not running as expected, we can have the partial syncing workflow running rarely than once per hour. When it runs, we want to be sure that the latest changes are included.
Maybe changing to include the changes from last 4 hours (compared with 1 hour) is a little bit overkill, but shouldn't affect the performance of the run that much.

If you think that we should set a different interval for that, please block the merge of this PR.