### PR TITLE
Add: warn submitter when no GPG key found on provider submission

### DIFF
--- a/.github/scripts/submit-provider.sh
+++ b/.github/scripts/submit-provider.sh
@@ -42,6 +42,17 @@ namespace=$(jq -r '.namespace' < ./output.json)
 name=$(jq -r '.name' < ./output.json)
 jsonfile=$(jq -r '.file' < ./output.json)
 
+# Check if a GPG key exists for this provider or its namespace
+set +e
+if ! go run ./cmd/check-provider-gpg -namespace="${namespace}" -name="${name}" -gpg-data=../keys -output=./gpg_output.json ; then
+  if [[ -f ./gpg_output.json ]]; then
+    gh issue comment "${NUMBER}" -b "$(jq -r '.message' < ./gpg_output.json)"
+  else
+    echo "Warning: GPG check exited with an error and produced no output — skipping GPG warning comment." >&2
+  fi
+fi
+rm -f ./gpg_output.json
+set -euo pipefail
 
 # Create Branch
 branch="provider-submission_${namespace}_${name}"

--- a/src/cmd/check-provider-gpg/main.go
+++ b/src/cmd/check-provider-gpg/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	regaddr "github.com/opentofu/registry-address"
+	"github.com/opentofu/registry-stable/internal/files"
+	"github.com/opentofu/registry-stable/internal/gpg"
+)
+
+type Output struct {
+	HasKeys bool   `json:"has_keys"`
+	Message string `json:"message"`
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+
+	namespace := flag.String("namespace", "", "The provider namespace to check")
+	name := flag.String("name", "", "The provider name to check")
+	outputFile := flag.String("output", "", "Path to write JSON result to")
+	gpgDataDir := flag.String("gpg-data", "", "Directory containing the GPG key data")
+
+	flag.Parse()
+
+	if *namespace == "" || *name == "" || *gpgDataDir == "" {
+		logger.Error("--namespace, --name, and --gpg-data are required")
+		os.Exit(1)
+	}
+
+	collection := gpg.KeyCollection{
+		Namespace:    *namespace,
+		ProviderName: *name,
+		Directory:    *gpgDataDir,
+	}
+
+	keys, err := collection.ListKeys()
+	if err != nil {
+		logger.Error("Failed to list GPG keys", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	output := Output{HasKeys: len(keys) > 0}
+
+	if !output.HasKeys {
+		provider, providerErr := regaddr.ParseProviderSource(fmt.Sprintf("%s/%s", *namespace, *name))
+		if providerErr != nil {
+			logger.Error("Failed to parse provider source", slog.Any("err", providerErr))
+			os.Exit(1)
+		}
+		output.Message = fmt.Sprintf(
+			"No GPG key found for the \"%s\" provider and neither for the \"%s\" organisation. "+
+				"You can submit one by using this [template](https://github.com/opentofu/registry/issues/new?template=provider_key.yml). "+
+				"For more details on how to do it, follow the [official guide](https://search.opentofu.org/docs/providers/adding#adding-the-gpg-key).",
+			provider.String(), *namespace,
+		)
+	}
+
+	if *outputFile != "" {
+		if jsonErr := files.SafeWriteObjectToJSONFile(*outputFile, output); jsonErr != nil {
+			logger.Error("Failed to write output file", slog.Any("err", jsonErr))
+			os.Exit(1)
+		}
+	}
+
+	if !output.HasKeys {
+		os.Exit(1)
+	}
+}

--- a/src/cmd/check-provider-gpg/main.go
+++ b/src/cmd/check-provider-gpg/main.go
@@ -57,16 +57,14 @@ func main() {
 				"For more details on how to do it, follow the [official guide](https://search.opentofu.org/docs/providers/adding#adding-the-gpg-key).",
 			provider.String(), *namespace,
 		)
-	}
 
-	if *outputFile != "" {
-		if jsonErr := files.SafeWriteObjectToJSONFile(*outputFile, output); jsonErr != nil {
-			logger.Error("Failed to write output file", slog.Any("err", jsonErr))
-			os.Exit(1)
+		if *outputFile != "" {
+			if jsonErr := files.SafeWriteObjectToJSONFile(*outputFile, output); jsonErr != nil {
+				logger.Error("Failed to write output file", slog.Any("err", jsonErr))
+				os.Exit(1)
+			}
 		}
-	}
 
-	if !output.HasKeys {
 		os.Exit(1)
 	}
 }

--- a/src/cmd/check-provider-gpg/main.go
+++ b/src/cmd/check-provider-gpg/main.go
@@ -52,7 +52,7 @@ func main() {
 			os.Exit(1)
 		}
 		output.Message = fmt.Sprintf(
-			"No GPG key found for the \"%s\" provider and neither for the \"%s\" organisation. "+
+			"No GPG key found for the \"%s\" provider nor for the \"%s\" namespace. "+
 				"You can submit one by using this [template](https://github.com/opentofu/registry/issues/new?template=provider_key.yml). "+
 				"For more details on how to do it, follow the [official guide](https://search.opentofu.org/docs/providers/adding#adding-the-gpg-key).",
 			provider.String(), *namespace,

--- a/src/internal/gpg/keycollection_test.go
+++ b/src/internal/gpg/keycollection_test.go
@@ -1,0 +1,99 @@
+package gpg
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeKeyFile(t *testing.T, dir string, filename string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0755))
+	key, err := generateGPGKey()
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(dir, filename), []byte(key), 0600))
+}
+
+func TestListKeys(t *testing.T) {
+	tests := []struct {
+		name          string
+		setup         func(t *testing.T, root string)
+		namespace     string
+		providerName  string
+		expectedCount int
+	}{
+		{
+			name:          "no keys directory returns empty",
+			setup:         func(_ *testing.T, _ string) {},
+			namespace:     "acme",
+			providerName:  "widget",
+			expectedCount: 0,
+		},
+		{
+			name: "namespace-level key is found",
+			setup: func(t *testing.T, root string) {
+				writeKeyFile(t, filepath.Join(root, "a", "acme"), "provider.asc")
+			},
+			namespace:     "acme",
+			providerName:  "widget",
+			expectedCount: 1,
+		},
+		{
+			name: "provider-level key is found",
+			setup: func(t *testing.T, root string) {
+				writeKeyFile(t, filepath.Join(root, "a", "acme", "widget"), "provider.asc")
+			},
+			namespace:     "acme",
+			providerName:  "widget",
+			expectedCount: 1,
+		},
+		{
+			name: "namespace and provider keys are both found",
+			setup: func(t *testing.T, root string) {
+				writeKeyFile(t, filepath.Join(root, "a", "acme"), "provider.asc")
+				writeKeyFile(t, filepath.Join(root, "a", "acme", "widget"), "provider.asc")
+			},
+			namespace:     "acme",
+			providerName:  "widget",
+			expectedCount: 2,
+		},
+		{
+			name: "keys for different namespace are not returned",
+			setup: func(t *testing.T, root string) {
+				writeKeyFile(t, filepath.Join(root, "o", "other"), "provider.asc")
+			},
+			namespace:     "acme",
+			providerName:  "widget",
+			expectedCount: 0,
+		},
+		{
+			name: "key for different provider in same namespace is not returned",
+			setup: func(t *testing.T, root string) {
+				writeKeyFile(t, filepath.Join(root, "a", "acme", "gadget"), "provider.asc")
+			},
+			namespace:     "acme",
+			providerName:  "widget",
+			expectedCount: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			tc.setup(t, root)
+
+			collection := KeyCollection{
+				Namespace:    tc.namespace,
+				ProviderName: tc.providerName,
+				Directory:    root,
+			}
+
+			keys, err := collection.ListKeys()
+			require.NoError(t, err)
+			assert.Len(t, keys, tc.expectedCount)
+		})
+	}
+}


### PR DESCRIPTION
Adds a warning comment to provider submission issues when no GPG key is found for the submitted namespace or provider, informing the submitter to follow the 2-step process.

Closes #115 
