### PR TITLE
Bump versions now triggers generate-and-deploy

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -1,8 +1,6 @@
 name: Bump Provider and Module Versions
 
 # Use global lock
-#
-# https://github.com/opentofu/registry/pull/272#discussion_r1511031778
 concurrency:
   group: main
 
@@ -10,13 +8,6 @@ on:
   schedule:
     - cron: '0,15,30,45 * * * *'
   workflow_dispatch:
-    inputs:
-      environment:
-        type: choice
-        description: The environment of the Registry
-        options:
-          - Development
-          - Production
 
 jobs:
   bump-versions:
@@ -24,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     environment:
-      name: ${{ inputs.environment || 'Production' }}
+      name: Production
     permissions:
       contents: write
       actions: write
@@ -46,4 +37,26 @@ jobs:
         run: ./.github/workflows/bump-versions.sh
         env:
           PREFIX: ${{ matrix.prefix }}
-          ENVIRONMENT: ${{ inputs.environment || 'Production' }}
+          ENVIRONMENT: Production
+
+  trigger-deploy:
+    needs: bump-versions
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Trigger Generate and Sync Recent Changes
+        run: |
+          for attempt in 1 2 3 4 5; do
+            if gh workflow run generate-and-deploy-recent.yml; then
+              exit 0
+            fi
+            echo "Attempt $attempt failed; retrying in $((attempt * 10))s" >&2
+            sleep $((attempt * 10))
+          done
+          echo "Failed to dispatch generate-and-deploy-recent after 5 attempts" >&2
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_REPO: ${{ github.repository }}

--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -1,6 +1,8 @@
 name: Bump Provider and Module Versions
 
 # Use global lock
+#
+# https://github.com/opentofu/registry/pull/272#discussion_r1511031778
 concurrency:
   group: main
 

--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -1,24 +1,21 @@
 # Be aware: This workflow should be kept in sync with generate-and-deploy-with-delete.yml and generate-and-deploy.yml
 name: Generate and Sync Recent Changes
 
+# Use global lock
+concurrency:
+  group: main
+
 on:
   schedule:
-    - cron: '5,20,35,50 * * * *'
+    - cron: "5,20,35,50 * * * *"
   workflow_dispatch:
-    inputs:
-      environment:
-        type: choice
-        description: The environment of the Registry
-        options:
-          - Development
-          - Production
 
 jobs:
   generate-and-sync:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     environment:
-      name: ${{ inputs.environment || 'Production' }}
+      name: Production
 
     steps:
       - name: Checkout Repository
@@ -30,8 +27,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
         with:
-          go-version-file: './src/go.mod'
-          cache-dependency-path: './src/go.sum'
+          go-version-file: "./src/go.mod"
+          cache-dependency-path: "./src/go.sum"
 
       - name: Setup dependencies
         run: sudo apt-get update && sudo apt-get install rclone

--- a/.github/workflows/generate-and-deploy-recent.yml
+++ b/.github/workflows/generate-and-deploy-recent.yml
@@ -2,6 +2,8 @@
 name: Generate and Sync Recent Changes
 
 # Use global lock
+#
+# https://github.com/opentofu/registry/pull/272#discussion_r1511031778
 concurrency:
   group: main
 


### PR DESCRIPTION
We've been noticing lately that github scheduling is getting flaky. This is the first step in an attempt to mitigate some of these issues.

After this if its improving, we will attempt the following

- Also trigger the `index` job in github.com/opentofu/registry-ui
- Move cron scheduling to an external mechanism (For now, cloudflare workers)

Then, this means we no longer rely on github action scheduling.

This is based on the investigation I did here: https://github.com/opentofu/registry/issues/4337#issuecomment-4567128219

---

Note, this also removes the concept of the development env for the registry as this has not been used in a LONG time.