### PR TITLE
Added production env to workflow trigger

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -45,6 +45,8 @@ jobs:
     needs: bump-versions
     timeout-minutes: 5
     runs-on: ubuntu-latest
+    environment:
+      name: Production
     permissions:
       actions: write
     steps:


### PR DESCRIPTION
This fixes the broken action triggering as seen here: https://github.com/opentofu/registry/actions/runs/26962351665/job/79556338578