### PR TITLE
Update the warning messages for deprecated providers

### DIFF
--- a/providers/h/hashicorp/chef.json
+++ b/providers/h/hashicorp/chef.json
@@ -114,6 +114,6 @@
     }
   ],
   "warnings": [
-    "This provider is deprecated. Please use metalsoft-io/metalcloud instead."
+    "This provider is deprecated."
   ]
 }


### PR DESCRIPTION
Checked all the following providers and all have the warning message already configured:
* [hashicorp/opc](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/opc.json)
* [hashicorp/oraclepaas](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/oraclepaas.json)
* [hashicorp/arukas](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/arukas.json)
* [hashicorp/vthunder](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/vthunder.json)
* [hashicorp/ultradns](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/ultradns.json)
* [hashicorp/telefonicaopencloud](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/telefonicaopencloud.json)
* [hashicorp/softlayer](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/softlayer.json)
* [hashicorp/runscope](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/runscope.json)
* [hashicorp/rubrik](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/rubrik.json)
* [hashicorp/rightscale](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/rightscale.json)
* [hashicorp/rancher](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/rancher.json)
* [hashicorp/rabbitmq](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/rabbitmq.json)
* [hashicorp/pureport](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/pureport.json)
* [hashicorp/oneandone](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/oneandone.json)
* [hashicorp/netlify](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/netlify.json)
* [hashicorp/mysql](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/mysql.json)
* [hashicorp/mso](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/mso.json)
* [hashicorp/metalcloud](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/metalcloud.json)
* [hashicorp/mailgun](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/mailgun.json)
* [hashicorp/logentries](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/logentries.json)
* [hashicorp/librato](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/librato.json)
* [hashicorp/lacework](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/lacework.json)
* [hashicorp/ksyun](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/ksyun.json)
* [hashicorp/jdcloud](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/jdcloud.json)
* [hashicorp/incapsula](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/incapsula.json)
* [hashicorp/hedvig](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/hedvig.json)
* [hashicorp/dyn](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/dyn.json)
* [hashicorp/cohesity](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/cohesity.json)
* [hashicorp/cobbler](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/cobbler.json)
* [hashicorp/cloudamqp](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/cloudamqp.json)
* [hashicorp/clc](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/clc.json)
* [hashicorp/bitbucket](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/bitbucket.json)
* [hashicorp/azure](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/azure-classic.json)
* [hashicorp/infoblox](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/infoblox.json)
* [hashicorp/influxdb](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/influxdb.json)

Found only one mistake:
* [hashicorp/chef](https://github.com/opentofu/registry/blob/80fbc76b928c8e74ffc7c65c452a6362b612716f/providers/h/hashicorp/chef.json)

And the following providers are not even in the registry:
* hashicorp/postgresql
* hashicorp/docker
* hashicorp/ignition
