### PR TITLE
Re-work verify-gpg-key so that we accept expired gpg keys

### DIFF
--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -152,7 +152,7 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 
 	expiredStep := verifyStep.RunStep("Key is not expired", func() error {
 		if key.IsExpired() {
-			return fmt.Errorf("key has expired, whilst this is accepted by the registry, please ensure a renewed key is used for signing new versions of providers.")
+			return fmt.Errorf("key has expired, whilst this is accepted by the registry, please ensure a renewed key is used for signing new versions of providers")
 		}
 		return nil
 	})

--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/opentofu/registry-stable/internal/blacklist"
 	"github.com/opentofu/registry-stable/internal/files"
 	"github.com/opentofu/registry-stable/internal/github"
+	"github.com/opentofu/registry-stable/internal/gpg"
 	"github.com/opentofu/registry-stable/internal/parallel"
 	"github.com/opentofu/registry-stable/internal/provider"
 	"github.com/opentofu/registry-stable/pkg/verification"
@@ -149,12 +150,16 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 		return verifyStep
 	}
 
-	verifyStep.RunStep("Key is not expired", func() error {
+	expiredStep := verifyStep.RunStep("Key is not expired", func() error {
 		if key.IsExpired() {
-			return fmt.Errorf("key is expired")
+			return fmt.Errorf("key has expired, whilst this is accepted by the registry, please ensure a renewed key is used for signing new versions of providers.")
 		}
 		return nil
 	})
+
+	// Expired keys are still accepted. They remain valid for verifying
+	// signatures they produced while valid. This should be a warning and not an error
+	expiredStep.FailureToWarning()
 
 	verifyStep.RunStep("Key is not revoked", func() error {
 		if key.IsRevoked() {
@@ -164,7 +169,9 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 	})
 
 	verifyStep.RunStep("Key can be used for signing", func() error {
-		if !key.CanVerify() {
+		// Use gpg.CanSign rather than key.CanVerify so that an expired key,
+		// is not rejected here purely for being expired.
+		if !gpg.CanSign(key) {
 			return fmt.Errorf("key cannot be used for signing")
 		}
 		return nil
@@ -209,7 +216,6 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 	if !verifyStep.DidFail() {
 		gpgStep := verifyStep.RunStep("Key is used to sign at least one provider", func() error {
 			// Inspired by OpenTofu's getproviders
-
 			keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(string(keyData)))
 			if err != nil {
 				return fmt.Errorf("error decoding signing key: %w", err)

--- a/src/internal/gpg/key.go
+++ b/src/internal/gpg/key.go
@@ -49,3 +49,22 @@ func ParseKey(data string) (*crypto.Key, error) {
 
 	return key, nil
 }
+
+// CanSign reports whether the key has a signing-capable primary key or subkey,
+// ignoring whether the key (or its self-signature) has since expired.
+// The registry currently accepts expired keys, and so this is needed instead of using the
+// key.CanVerify() method which checks expiry dates.
+func CanSign(key *crypto.Key) bool {
+	entity := key.GetEntity()
+	if entity == nil || entity.PrimaryKey == nil {
+		return false
+	}
+
+	identity := entity.PrimaryIdentity()
+	if identity == nil || identity.SelfSignature == nil {
+		return false
+	}
+
+	_, canSign := entity.SigningKey(identity.SelfSignature.CreationTime)
+	return canSign
+}

--- a/src/internal/gpg/key_test.go
+++ b/src/internal/gpg/key_test.go
@@ -7,10 +7,14 @@ import (
 	"encoding/pem"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp/packet"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 	"github.com/ProtonMail/gopenpgp/v2/helper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func generatePrivateKey() (string, error) {
@@ -45,6 +49,23 @@ func generateGPGKey() (string, error) {
 	}
 
 	return publicKey, nil
+}
+
+func generateExpiredGPGKey(t *testing.T) *crypto.Key {
+	t.Helper()
+
+	config := &packet.Config{
+		Time:            func() time.Time { return time.Now().Add(-48 * time.Hour) },
+		KeyLifetimeSecs: 60,
+	}
+
+	entity, err := openpgp.NewEntity("test", "expired test key", "test@test", config)
+	require.NoError(t, err)
+
+	key, err := crypto.NewKeyFromEntity(entity)
+	require.NoError(t, err)
+
+	return key
 }
 
 func TestParseKey(t *testing.T) {
@@ -83,4 +104,27 @@ func TestParseKey(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCanSign(t *testing.T) {
+	t.Run("valid key can sign and verify", func(t *testing.T) {
+		armored, err := generateGPGKey()
+		require.NoError(t, err)
+
+		key, err := ParseKey(armored)
+		require.NoError(t, err)
+
+		assert.False(t, key.IsExpired())
+		assert.True(t, key.CanVerify(), "sanity: non-expired key should also pass CanVerify")
+		assert.True(t, CanSign(key))
+	})
+
+	t.Run("expired key can still sign", func(t *testing.T) {
+		key := generateExpiredGPGKey(t)
+
+		require.True(t, key.IsExpired(), "test fixture should be expired")
+		require.False(t, key.CanVerify(), "CanVerify rejects expired keys, which is what CanSign works around")
+
+		assert.True(t, CanSign(key), "expired keys are still accepted by the registry")
+	})
 }


### PR DESCRIPTION
When rancher tried to upload a key it surfaced two issues (see #4558)

The first issue was that we were failing if the key has expired, when in reality we should accept expired keys if they were used for old versions of providers.

It also highlighted that the "CanVerify" also took into account expiry when that check should only check for the type of the key. 

This PR fixes both of those issues so we should be able to get #4558 in.