### PR TITLE
Use the old verify and the new sign to check if the key can be used properly

### DIFF
--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -171,7 +171,7 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 	verifyStep.RunStep("Key can be used for signing", func() error {
 		// Use gpg.CanSign rather than key.CanVerify so that an expired key,
 		// is not rejected here purely for being expired.
-		if !gpg.CanSign(key) {
+		if !gpg.CanSign(key) && !key.CanVerify() {
 			return fmt.Errorf("key cannot be used for signing")
 		}
 		return nil


### PR DESCRIPTION
As seen in https://github.com/opentofu/registry/issues/4567, tthe changes from #4560 still fail on some cases.

This PR adds back also the old validation and uses the newly added one too.
This way we ensure that a wider range of keys can be accepted.

Fixes #4568 