### PR TITLE
Allow provider authors to request re-indexing a version

### DIFF
--- a/.github/ISSUE_TEMPLATE/reindex.yml
+++ b/.github/ISSUE_TEMPLATE/reindex.yml
@@ -1,0 +1,48 @@
+# IMPORTANT: Submissions MUST be made through the GitHub issue form UI, not via
+# the API, gh CLI, or by manually creating issues. The automated validation and
+# processing pipeline depends on the structured data from the issue form.
+name: Request Provider Version Re-index
+description: Ask the registry to re-verify and re-index a specific provider version, e.g. after a release was rebuilt under the same tag
+title: "Re-index: "
+labels: ["reindex", "submission"]
+body:
+  - type: markdown
+    attributes:
+      value: >-
+        This re-downloads and re-verifies the version's current release assets against your
+        provider's on-file GPG key. It does **not** bypass signature verification - if the
+        current release doesn't verify against a key already on file for this provider, the
+        request will be rejected.
+  - type: input
+    id: namespace
+    attributes:
+      label: Provider Namespace
+      description: GitHub Username or Organization that owns the provider. You must be a public member of this organization.
+    validations:
+      required: true
+  - type: input
+    id: providername
+    attributes:
+      label: Provider Name
+      description: Name of the provider (without the terraform-provider- prefix).
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The exact version to re-index, e.g. 4.1.0 (no leading "v").
+    validations:
+      required: true
+  - type: checkboxes
+    id: public_membership
+    attributes:
+      label: Public Membership
+      description: >-
+        **Required:** Your membership in the provider's organization **must** be public.
+        This submission will fail automated validation if your membership is not publicly visible.
+        [How to make your membership public](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership).
+        If you are unable to make your membership public, please [open a different issue](https://github.com/opentofu/registry/issues/new) to contact the OpenTofu team for assistance.
+      options:
+        - label: I have made my membership public
+          required: true

--- a/.github/scripts/submit-reindex-request.sh
+++ b/.github/scripts/submit-reindex-request.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+set -x
+set -euo pipefail
+
+if [[ -z "${BODY}" ]]; then
+  echo "Please run this script from a GitHub Action."
+  exit 1
+fi
+if [[ -z "${TITLE}" ]]; then
+  echo "Please run this script from a GitHub Action."
+  exit 1
+fi
+if [[ -z "${NUMBER}" ]]; then
+  echo "Please run this script from a GitHub Action."
+  exit 1
+fi
+if [[ -z "${GH_USER}" ]]; then
+  echo "Please set GH_USER"
+  exit 1
+fi
+
+namespace=$(echo "${BODY}" | grep "### Provider Namespace" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
+providername=$(echo "${BODY}" | grep "### Provider Name" -A2 | tail -n1 | tr "[:upper:]" "[:lower:]" | sed -e 's/[\r\n]//g')
+version=$(echo "${BODY}" | grep "### Version" -A2 | tail -n1 | sed -e 's/^v//' -e 's/[\r\n]//g')
+
+if [[ ! "${namespace}" =~ ^[a-zA-Z0-9-]+$ ]]; then
+  gh issue comment "${NUMBER}" -b "Failed validation: Invalid namespace: '${namespace}'"
+  exit 1
+fi
+
+if [[ ! "${providername}" =~ ^[a-zA-Z0-9-]+$ ]]; then
+  gh issue comment "${NUMBER}" -b "Failed validation: Invalid provider name: '${providername}'"
+  exit 1
+fi
+
+if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$ ]]; then
+  gh issue comment "${NUMBER}" -b "Failed validation: Invalid version: '${version}'"
+  exit 1
+fi
+
+set +e
+go run ./cmd/verify-reindex-request -namespace "${namespace}" -name "${providername}" -version "${version}" -username "${GH_USER}" -provider-data "../providers" -gpg-data "../keys" -output=./output.json
+verification=$?
+set -euo pipefail
+
+gh issue comment "${NUMBER}" -b "$(jq -r '.' < ./output.json || true)"
+if [[ "${verification}" != 0 ]]; then
+  exit 1
+fi
+
+go run ./cmd/remove-provider-version -namespace "${namespace}" -name "${providername}" -version "${version}" -provider-data "../providers"
+
+# Create Branch
+branch="reindex-request_${namespace}-${providername}-${version}-$(date +%s)"
+set +e
+if ! git checkout -b "${branch}"; then
+  gh issue comment "${NUMBER}" -b "Failed validation: A branch already exists for this re-index request '${branch}'"
+  exit 1
+fi
+set -euo pipefail
+
+# Add result
+providerfile="../providers/${namespace:0:1}/${namespace}/${providername}.json"
+git add "${providerfile}"
+
+# Commit and push result
+git config --global user.email "no-reply@opentofu.org"
+git config --global user.name "OpenTofu Automation"
+git commit -s -m "Fixes #${NUMBER}: removing ${namespace}/${providername} version ${version} for re-index"
+git push -u origin "${branch}"
+
+# Create pull request and update issue
+# GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID are default GitHub Actions env vars
+# shellcheck disable=SC2154
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+pr_body="Removes ${namespace}/${providername} version ${version} so it will be re-indexed on the next run. **This should be merged and then a resync triggered immediately after.**
+
+- **Source Issue:** #${NUMBER}
+- **Requested by:** @${GH_USER}
+- **Created by:** [GitHub Actions Run](${run_url})
+
+Closes #${NUMBER}."
+pr=$(gh pr create --title "${TITLE}" --body "${pr_body}")
+gh issue comment "${NUMBER}" -b "Your submission has been validated and has moved on to the pull request phase (${pr}). This issue has been locked."
+gh issue lock "${NUMBER}" -r resolved

--- a/.github/workflows/issue-to-pr.yaml
+++ b/.github/workflows/issue-to-pr.yaml
@@ -90,3 +90,32 @@ jobs:
         working-directory: ./src
         run: |
           ../.github/scripts/submit-provider-key.sh
+  submit-reindex-request:
+    if: contains(github.event.issue.labels.*.name, 'reindex') && contains(github.event.issue.labels.*.name, 'submission')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version-file: './src/go.mod'
+
+      - name: Validate Re-index Request and Create PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          GH_USER: ${{ github.event.issue.user.login }}
+          NUMBER: ${{ github.event.issue.number }}
+          URL: ${{ github.event.issue.url }}
+          TITLE: ${{ github.event.issue.title }}
+          BODY: ${{ github.event.issue.body }}
+        working-directory: ./src
+        run: |
+          ../.github/scripts/submit-reindex-request.sh

--- a/src/cmd/remove-provider-version/main.go
+++ b/src/cmd/remove-provider-version/main.go
@@ -1,0 +1,44 @@
+package main
+ 
+import (
+	"flag"
+	"log/slog"
+	"os"
+ 
+	"github.com/opentofu/registry-stable/internal/provider"
+)
+ 
+// remove-provider-version deletes a single version entry from a provider's
+// metadata file. It is intentionally separate from verify-reindex-request:
+// that command only checks whether a re-index request is *allowed*, this
+// command is the one that actually performs the mutation, and it is only
+// ever invoked after verification has already succeeded.
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+ 
+	namespace := flag.String("namespace", "", "Provider namespace")
+	name := flag.String("name", "", "Provider name")
+	version := flag.String("version", "", "The provider version to remove")
+	providerDataDir := flag.String("provider-data", "../providers", "Directory containing the provider data")
+	flag.Parse()
+ 
+	if *namespace == "" || *name == "" || *version == "" {
+		logger.Error("--namespace, --name, and --version are required")
+		os.Exit(1)
+	}
+ 
+	p := provider.Provider{
+		Namespace:    *namespace,
+		ProviderName: *name,
+		Directory:    *providerDataDir,
+		Logger:       logger,
+	}
+ 
+	if err := p.RemoveVersion(*version); err != nil {
+		logger.Error("Failed to remove version", slog.Any("err", err))
+		os.Exit(1)
+	}
+ 
+	logger.Info("Removed version from metadata", slog.String("namespace", *namespace), slog.String("name", *name), slog.String("version", *version))
+}
+ 

--- a/src/cmd/verify-gpg-key/main.go
+++ b/src/cmd/verify-gpg-key/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -13,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
-	openpgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
 
 	"github.com/opentofu/registry-stable/internal/blacklist"
@@ -80,7 +78,7 @@ func main() {
 	s := VerifyKey(*keyFile, filteredProviders, cancelVerifierFn)
 	result.Steps = append(result.Steps, s)
 
-	s = VerifyGithubUser(ghClient, *username, *orgName)
+	s = verification.VerifyGithubUser(ghClient, *username, *orgName)
 	result.Steps = append(result.Steps, s)
 
 	fmt.Println(result.RenderMarkdown())
@@ -96,27 +94,6 @@ func main() {
 	if result.DidFail() {
 		os.Exit(-1)
 	}
-}
-
-func VerifyGithubUser(client github.Client, username string, orgName string) *verification.Step {
-	verifyStep := &verification.Step{
-		Name: "Validate Github user",
-	}
-
-	s := verifyStep.RunStep(fmt.Sprintf("User is a member of the organization %s", orgName), func() error {
-		member, err := client.IsUserInOrganization(username, orgName)
-		if err != nil {
-			return fmt.Errorf("failed to get user: %w", err)
-		}
-		if member {
-			return nil
-		} else {
-			return fmt.Errorf("user is not a member of the organization")
-		}
-	})
-	s.Remarks = []string{"If this is incorrect, please ensure that your organization membership is public. For more information, see [Github Docs - Publicizing or hiding organization membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership)"}
-
-	return verifyStep
 }
 
 var gpgNameEmailRegex = regexp.MustCompile(`.*\<(.*)\>`)
@@ -216,14 +193,13 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 	if !verifyStep.DidFail() {
 		gpgStep := verifyStep.RunStep("Key is used to sign at least one provider", func() error {
 			// Inspired by OpenTofu's getproviders
-			keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(string(keyData)))
-			if err != nil {
+			if _, err := openpgp.ReadArmoredKeyRing(strings.NewReader(string(keyData))); err != nil {
 				return fmt.Errorf("error decoding signing key: %w", err)
 			}
 
 			foundProviderForKey := false
 
-			err = providers.Parallel(20, func(p provider.Provider) error {
+			err := providers.Parallel(20, func(p provider.Provider) error {
 				meta, err := p.ReadMetadata()
 				if err != nil {
 					return err
@@ -232,7 +208,6 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 
 				var versionChecks []parallel.Action
 				for _, version := range meta.Versions {
-					version := version
 					versionChecks = append(versionChecks, func() error {
 						logger := meta.Logger.With(slog.String("version", version.Version))
 						logger.Info("Begin version check")
@@ -248,16 +223,12 @@ func VerifyKey(location string, providers provider.List, cancelVerifierFn contex
 							return err
 						}
 
-						_, err = openpgp.CheckDetachedSignature(keyring, bytes.NewReader(shasumResp), bytes.NewReader(sigResp), nil)
-						if errors.Is(err, openpgpErrors.ErrUnknownIssuer) {
-							return nil
-						}
-
+						verified, err := gpg.VerifyDetachedSignature([]gpg.Key{{ASCIIArmor: string(keyData)}}, shasumResp, sigResp)
 						if err != nil {
-							// If in enforcing mode (or if the error isn’t related to expiry) return immediately.
-							if !errors.Is(err, openpgpErrors.ErrKeyExpired) && !errors.Is(err, openpgpErrors.ErrSignatureExpired) {
-								return fmt.Errorf("error checking signature: %w", err)
-							}
+							return fmt.Errorf("error checking signature: %w", err)
+						}
+						if !verified {
+							return nil
 						}
 
 						// Key might be expired, but that's allowed

--- a/src/cmd/verify-reindex-request/main.go
+++ b/src/cmd/verify-reindex-request/main.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/opentofu/registry-stable/internal/blacklist"
+	"github.com/opentofu/registry-stable/internal/files"
+	"github.com/opentofu/registry-stable/internal/github"
+	"github.com/opentofu/registry-stable/internal/gpg"
+	"github.com/opentofu/registry-stable/internal/provider"
+	"github.com/opentofu/registry-stable/pkg/verification"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	namespace := flag.String("namespace", "", "Provider namespace (also the GitHub org the requester must belong to)")
+	name := flag.String("name", "", "Provider name")
+	version := flag.String("version", "", "The provider version to re-index")
+	username := flag.String("username", "", "GitHub username requesting the re-index")
+
+	providerDataDir := flag.String("provider-data", "../providers", "Directory containing the provider data")
+	gpgDataDir := flag.String("gpg-data", "../keys", "Directory containing the GPG key data")
+	outputFile := flag.String("output", "", "Path to write the result to")
+	flag.Parse()
+	if *namespace == "" || *name == "" || *version == "" || *username == "" {
+		logger.Error("--namespace, --name, --version, and --username are required")
+		os.Exit(1)
+	}
+
+	logger = logger.With(slog.String("namespace", *namespace), slog.String("name", *name), slog.String("version", *version))
+	slog.SetDefault(logger)
+
+	token, err := github.EnvAuthToken()
+	if err != nil {
+		logger.Error("Initialization Error", slog.Any("err", err))
+		os.Exit(1)
+	}
+	ghClient := github.NewClient(context.Background(), logger, token)
+
+	bl, err := blacklist.Load()
+	if err != nil {
+		logger.Error("Failed to load blacklist", slog.Any("err", err))
+		os.Exit(1)
+	}
+
+	p := provider.Provider{
+		Namespace:    *namespace,
+		ProviderName: *name,
+		Directory:    *providerDataDir,
+		Logger:       logger,
+		Github:       ghClient,
+		Blacklist:    bl,
+	}
+	result := &verification.Result{}
+
+	result.Steps = append(result.Steps, verification.VerifyGithubUser(ghClient, *username, *namespace))
+
+	keys, keyStep := loadKeys(*namespace, *name, *gpgDataDir)
+	result.Steps = append(result.Steps, keyStep)
+
+	result.Steps = append(result.Steps, VerifyVersionAgainstKeys(p, *version, keys))
+
+	fmt.Println(result.RenderMarkdown())
+
+	if *outputFile != "" {
+		if jsonErr := files.SafeWriteObjectToJSONFile(*outputFile, result.RenderMarkdown()); jsonErr != nil {
+			panic(jsonErr)
+		}
+	}
+	if result.DidFail() {
+		os.Exit(-1)
+	}
+}
+
+func loadKeys(namespace, name, gpgDataDir string) ([]gpg.Key, *verification.Step) {
+	step := &verification.Step{Name: "Validate GPG key on file"}
+
+	collection := gpg.KeyCollection{
+		Namespace:    namespace,
+		ProviderName: name,
+		Directory:    gpgDataDir,
+	}
+
+	var keys []gpg.Key
+	step.RunStep("A GPG key has been submitted for this provider", func() error {
+		k, err := collection.ListKeys()
+		if err != nil {
+			return fmt.Errorf("failed to list keys: %w", err)
+		}
+		if len(k) == 0 {
+			return fmt.Errorf("no GPG key found for this provider or its namespace")
+		}
+		keys = k
+		return nil
+	})
+
+	return keys, step
+}
+
+func VerifyVersionAgainstKeys(p provider.Provider, requestedVersion string, keys []gpg.Key) *verification.Step {
+	step := &verification.Step{Name: "Validate the requested version against the GPG key"}
+
+	step.RunStep(fmt.Sprintf("Version %s is currently indexed", requestedVersion), func() error {
+		meta, err := p.ReadMetadata()
+		if err != nil {
+			return fmt.Errorf("failed to read provider metadata: %w", err)
+		}
+
+		for _, v := range meta.Versions {
+			if v.Version == requestedVersion {
+				return verifySignature(p, v, keys)
+			}
+		}
+
+		return fmt.Errorf("version %q is not currently indexed for %s/%s", requestedVersion, p.Namespace, p.ProviderName)
+	})
+
+	return step
+}
+
+func verifySignature(p provider.Provider, v provider.Version, keys []gpg.Key) error {
+	if len(keys) == 0 {
+		// The "key on file" step already reported this
+		return fmt.Errorf("no keys available to verify against")
+	}
+
+	shasums, err := p.Github.DownloadAssetContents(v.SHASumsURL)
+	if err != nil {
+		return fmt.Errorf("failed to download current SHASUMS: %w", err)
+	}
+
+	signature, err := p.Github.DownloadAssetContents(v.SHASumsSignatureURL)
+	if err != nil {
+		return fmt.Errorf("failed to download current SHASUMS signature: %w", err)
+	}
+
+	verified, err := gpg.VerifyDetachedSignature(keys, shasums, signature)
+	if err != nil {
+		return fmt.Errorf("signature check failed: %w", err)
+	}
+	if !verified {
+		return fmt.Errorf("current release does not verify against any key on file for this provider")
+	}
+
+	return nil
+}

--- a/src/internal/gpg/verify.go
+++ b/src/internal/gpg/verify.go
@@ -1,0 +1,45 @@
+package gpg
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ProtonMail/go-crypto/openpgp"
+	openpgpErrors "github.com/ProtonMail/go-crypto/openpgp/errors"
+)
+
+func VerifyDetachedSignature(keys []Key, data, signature []byte) (bool, error) {
+	for _, key := range keys {
+		keyring, err := openpgp.ReadArmoredKeyRing(strings.NewReader(key.ASCIIArmor))
+		if err != nil {
+			return false, fmt.Errorf("failed to parse key %s: %w", key.KeyID, err)
+		}
+
+		_, err = openpgp.CheckDetachedSignature(
+			keyring,
+			bytes.NewReader(data),
+			bytes.NewReader(signature),
+			nil,
+		)
+
+		if err == nil {
+			return true, nil
+		}
+
+		// This key didn't produce the signature; try the next one.
+		if errors.Is(err, openpgpErrors.ErrUnknownIssuer) {
+			continue
+		}
+
+		// Expired keys are still accepted by the registry.
+		if errors.Is(err, openpgpErrors.ErrKeyExpired) || errors.Is(err, openpgpErrors.ErrSignatureExpired) {
+			return true, nil
+		}
+
+		return false, fmt.Errorf("error checking signature with key %s: %w", key.KeyID, err)
+	}
+
+	return false, nil
+}

--- a/src/internal/provider/remove.go
+++ b/src/internal/provider/remove.go
@@ -1,0 +1,34 @@
+package provider
+
+import "fmt"
+
+// RemoveVersion removes the given version from the provider's metadata and
+// writes the updated metadata back to disk
+func (p Provider) RemoveVersion(version string) error {
+	meta, err := p.ReadMetadata()
+	if err != nil {
+		return fmt.Errorf("failed to read metadata: %w", err)
+	}
+
+	filtered := make([]Version, 0, len(meta.Versions))
+	found := false
+	for _, v := range meta.Versions {
+		if v.Version == version {
+			found = true
+			continue
+		}
+		filtered = append(filtered, v)
+	}
+
+	if !found {
+		return fmt.Errorf("version %q not found in metadata for %s/%s", version, p.Namespace, p.ProviderName)
+	}
+
+	meta.Versions = filtered
+
+	if err := p.WriteMetadata(meta); err != nil {
+		return fmt.Errorf("failed to write metadata: %w", err)
+	}
+
+	return nil
+}

--- a/src/pkg/verification/steps.go
+++ b/src/pkg/verification/steps.go
@@ -1,0 +1,30 @@
+package verification
+ 
+import (
+	"fmt"
+ 
+	"github.com/opentofu/registry-stable/internal/github"
+)
+ 
+// VerifyGithubUser returns a Step confirming that username is a public
+// member of orgName on GitHub. This is shared by any submission workflow
+// that needs to confirm the requester is affiliated with a provider's
+// organization (e.g. GPG key submission, re-index requests).
+func VerifyGithubUser(client github.Client, username string, orgName string) *Step {
+	step := &Step{Name: "Validate Github user"}
+ 
+	s := step.RunStep(fmt.Sprintf("User is a member of the organization %s", orgName), func() error {
+		member, err := client.IsUserInOrganization(username, orgName)
+		if err != nil {
+			return fmt.Errorf("failed to get user: %w", err)
+		}
+		if !member {
+			return fmt.Errorf("user is not a member of the organization")
+		}
+		return nil
+	})
+	s.Remarks = []string{"If this is incorrect, please ensure that your organization membership is public. For more information, see [Github Docs - Publicizing or hiding organization membership](https://docs.github.com/en/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-your-membership-in-organizations/publicizing-or-hiding-organization-membership)"}
+ 
+	return step
+}
+ 


### PR DESCRIPTION
Closes #642.

Lets a provider author request a re-index of a specific version — e.g. if they
accidentally re-released a binary under an existing tag and the registry's
stored checksums are now stale.

## How it works

1. Author opens an issue using the new "Request Provider Version Re-index" template.
2. The workflow runs `verify-reindex-request`, which checks:
   - they're a public member of the provider's GitHub org
   - a GPG key is already on file for the provider
   - the version's *current* release assets still verify against that key
3. If all three pass, `remove-provider-version` deletes the stale entry and
   opens this PR automatically. The next `bump-versions` run re-fetches and
   re-verifies the version from scratch.

**This still requires a human to merge the PR and trigger a resync
afterward**, same as #634 — nothing here auto-merges