### PR TITLE
fix: Prevent git ls-remote authentication prompts

### DIFF
--- a/src/internal/github/git.go
+++ b/src/internal/github/git.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strings"
 )
@@ -59,6 +60,7 @@ func (c Client) GetTags(repositoryURL string) ([]Tag, error) {
 	var buf bytes.Buffer
 	var bufErr bytes.Buffer
 	cmd := exec.Command("git", "ls-remote", "--tags", "--refs", repositoryURL)
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	cmd.Stdout = &buf
 	cmd.Stderr = &bufErr
 

--- a/src/internal/github/git_test.go
+++ b/src/internal/github/git_test.go
@@ -1,10 +1,38 @@
 package github
 
 import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func installFakeGit(t *testing.T, body string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	script := `#!/bin/sh
+if [ "$GIT_TERMINAL_PROMPT" != "0" ]; then
+	echo "unexpected GIT_TERMINAL_PROMPT=$GIT_TERMINAL_PROMPT" >&2
+	exit 1
+fi
+` + body
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "git"), []byte(script), 0755))
+	t.Setenv("PATH", dir)
+}
+
+func newTestClient() Client {
+	return Client{
+		log: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cliThrottle: func() ThrottleToken {
+			return func() {}
+		},
+	}
+}
 
 func Test_parseTagsFromStdout(t *testing.T) {
 	cases := map[string]struct {
@@ -83,4 +111,42 @@ func Test_parseTagsFromStdout(t *testing.T) {
 
 		})
 	}
+}
+
+func TestClientGetTagsDisablesGitTerminalPrompt(t *testing.T) {
+	t.Setenv("GET_TAGS_ENV_SENTINEL", "inherited")
+	installFakeGit(t, `if [ "$GET_TAGS_ENV_SENTINEL" != "inherited" ]; then
+	echo "parent environment was not inherited" >&2
+	exit 1
+fi
+printf '3141592653589793 refs/tags/v0.0.1\n'
+`)
+
+	tags, err := newTestClient().GetTags("https://example.com/example/repository.git")
+
+	require.NoError(t, err)
+	assert.Equal(t, []Tag{{Commit: "3141592653589793", Ref: "v0.0.1"}}, tags)
+}
+
+func TestClientGetTagsOverridesGitTerminalPrompt(t *testing.T) {
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	installFakeGit(t, "printf '3141592653589793 refs/tags/v0.0.1\\n'\n")
+
+	tags, err := newTestClient().GetTags("https://example.com/example/repository.git")
+
+	require.NoError(t, err)
+	assert.Equal(t, []Tag{{Commit: "3141592653589793", Ref: "v0.0.1"}}, tags)
+}
+
+func TestClientGetTagsReturnsGitError(t *testing.T) {
+	installFakeGit(t, `echo "fake git failure" >&2
+exit 23
+`)
+
+	tags, err := newTestClient().GetTags("https://example.com/example/missing.git")
+
+	assert.Nil(t, tags)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not get tags for https://example.com/example/missing.git")
+	assert.Contains(t, err.Error(), "fake git failure")
 }


### PR DESCRIPTION
Update `Client.GetTags` in `src/internal/github/git.go` so the spawned `git ls-remote` process receives `GIT_TERMINAL_PROMPT=0`, while retaining the rest of the parent process environment needed to locate Git and use configured non-interactive credential helpers. Keep the existing command arguments, throttling, stdout parsing, and stderr-rich error wrapping unchanged; once prompting is disabled, inaccessible repositories should follow the existing error path instead of blocking. Add subprocess-focused coverage in `src/internal/github/git_test.go` using a controlled fake `git` executable to observe the environment passed by `GetTags`, avoiding network access and avoiding a production abstraction created only for testing.

`Client.GetTags` runs `git ls-remote` directly to discover module and provider tags. When a repository has been removed or made private, Git may prompt for credentials on an interactive terminal, causing a local bumper run to wait indefinitely instead of returning an error. The issue is accepted, and maintainers later identified a solution in `opentofu/libregistry` that should be ported back to this repository. The existing module and provider callers already handle `GetTags` errors by skipping the affected repository, so the missing behavior belongs at the Git subprocess boundary.

With a controlled `git` executable that emits a valid tag, `GetTags` passes `GIT_TERMINAL_PROMPT=0` and still parses and returns the tag; When the parent test environment sets `GIT_TERMINAL_PROMPT` to an enabling value, the child process still observes `0`, proving local caller configuration cannot re-enable an interactive prompt.

Fixes #48
