### PR TITLE
Limit GHA workflows to specific paths, add bump-versions.sh to shellcheck workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,9 @@
 name: Build
 on:
   push:
+    paths:
+      - 'src/**'
+      - '.github/workflows/build.yaml'
 
 jobs:
   build:

--- a/.github/workflows/bump-versions.sh
+++ b/.github/workflows/bump-versions.sh
@@ -2,35 +2,35 @@
 
 set +x
 
-if [ -z "${PREFIX}" ]; then
+if [[ -z "${PREFIX}" ]]; then
 	echo "Expecting \$PREFIX to be set"
 	exit 1
 fi
-if [ -z "${GITHUB_REF_NAME}" ]; then
+if [[ -z "${GITHUB_REF_NAME}" ]]; then
 	echo "Expecting \$GITHUB_REF_NAME to be set"
 	exit 1
 fi
-if [ -z "${GITHUB_RUN_NUMBER}" ]; then
+if [[ -z "${GITHUB_RUN_NUMBER}" ]]; then
 	echo "Expecting \$GITHUB_RUN_NUMBER to be set"
 	exit 1
 fi
-if [ -z "${ENVIRONMENT}" ]; then
+if [[ -z "${ENVIRONMENT}" ]]; then
 	echo "Expecting \$ENVIRONMENT to be set"
 	exit 1
 fi
 
-cd ./src
+cd ./src || exit 1
 go run ./cmd/bump-versions -module-namespace "${PREFIX}" -provider-namespace "${PREFIX}"
-cd ../
+cd ../ || exit 1
 
 BRANCH="${GITHUB_REF_NAME}-bump-versions-${GITHUB_RUN_NUMBER}"
-if [ "${ENVIRONMENT}" = "Production" ]; then
+if [[ "${ENVIRONMENT}" = "Production" ]]; then
 	export BRANCH="${GITHUB_REF_NAME}"
 fi
 
 # Try to get to the latest HEAD
-git fetch origin $BRANCH
-git checkout -b $BRANCH
+git fetch origin "${BRANCH}"
+git checkout -b "${BRANCH}"
 
 # Commit changes
 git status
@@ -40,17 +40,16 @@ git config user.name "OpenTofu Core Development Team"
 git commit -m "Automated bump of versions for providers and modules (${PREFIX})"
 
 # Racing with other jobs, try a few times to push changes
-for i in {0..30}; do
-	git push -u origin $BRANCH
-	if [ $? = 0 ]; then
+for _ in {0..30}; do
+	if git push -u origin "${BRANCH}"; then
 		echo "Providers and modules changes were pushed to branch: ${BRANCH}"
 		exit 0
 	fi
 	sleep 1
-	git fetch origin $BRANCH
-	git rebase origin/$BRANCH
+	git fetch origin "${BRANCH}"
+	git rebase origin/"${BRANCH}"
 done
 
 echo "Failed to push providers and modules changes to branch: ${BRANCH}"
-exit -1
+exit 1
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,10 @@
 name: Shellcheck
 on:
   push:
+    paths:
+      - '.github/scripts/**/*.sh'
+      - '.github/workflows/*.sh'
+      - '.github/workflows/shellcheck.yml'
 
 jobs:
   shellcheck:
@@ -14,4 +18,4 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
       - name: Run shellcheck
-        run: shellcheck -o all ./.github/scripts/*.sh
+        run: shellcheck -o all ./.github/scripts/*.sh ./.github/workflows/*.sh


### PR DESCRIPTION
This also cleans up the bump-versions.sh script to ensure that it passes the shellcheck warnings.

I raised this because I noticed the build was happening on #4875 and it didnt need to. And doesn't need to for most PRs.