### PR TITLE
Provider: blossomstack/terraform-provider-horsie

### DIFF
--- a/providers/b/blossomstack/horsie.json
+++ b/providers/b/blossomstack/horsie.json
@@ -1,0 +1,260 @@
+{
+  "versions": [
+    {
+      "version": "0.2.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.2.0_darwin_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_darwin_amd64.zip",
+          "shasum": "61703cbb6319b6dbc3e37d31004cb3e53f3de0261e17512e46a9a23b671dd55a",
+          "h1": "h1:FtSbDzVga/bmVGggSa05b/nhTEsWzNMGgKXAUaHRgH4=",
+          "size": 6801318
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.2.0_darwin_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_darwin_arm64.zip",
+          "shasum": "3474cc0db37539364a4baf802392b602d95a3a1668b6d5a467c46a25835b0285",
+          "h1": "h1:AFbGyfPDGLbIpC3g0VQkeWvTSC6Sotz6Ns7SSfvwN38=",
+          "size": 6337022
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-horsie_0.2.0_freebsd_386.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_freebsd_386.zip",
+          "shasum": "5bfa5eff9488b82064b049b5f77007bb0cd5f19cfa636346c60da6942f3e4063",
+          "h1": "h1:fB4cJWL8+hyfZiMhKcSTSigBoZpKag5we1souTXapzA=",
+          "size": 6254573
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.2.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_freebsd_amd64.zip",
+          "shasum": "a5224cfebdf41bb03f63a4ef7c7d78712dd42c753a93f9286164d32bd926fbcb",
+          "h1": "h1:XLSxWGX2hVKaRCckvQlaqcTIaB/s1zjGzspeBdiSttI=",
+          "size": 6607314
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-horsie_0.2.0_freebsd_arm.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_freebsd_arm.zip",
+          "shasum": "7a335cd11ad31e4b343ecf1e5e9e6e995c65f0dcb9f9c8e2861ebba2b85f44de",
+          "h1": "h1:/GixgTJNkdQbYQeoXvG769pLA1iz+RUVedEf8zUuUqY=",
+          "size": 6226032
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.2.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_freebsd_arm64.zip",
+          "shasum": "fe448a901b2a22b9cd2cab1d2d6ded796665064e79e96fa174fb420845a64df6",
+          "h1": "h1:Xonm/lpr3diOltacVutL8QvpyFGR5lZFWhSB/1EEzWE=",
+          "size": 6007675
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-horsie_0.2.0_linux_386.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_linux_386.zip",
+          "shasum": "36b98aa9788425681b179acf24bc57fb87a8b0e9e42dd30f381f1467786e9b4b",
+          "h1": "h1:jsbAIK51zmS1gW4ykipmo/ccTUIRjO+u+niBYyMsjG4=",
+          "size": 6285667
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.2.0_linux_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_linux_amd64.zip",
+          "shasum": "008fefba16f3c5fde2f0e7667eb342bab491244318e4e26376c01206190a1478",
+          "h1": "h1:lxgUAIRie460rZjD+jXjw8C1ycTM5uHIHBreaeDW2V4=",
+          "size": 6635361
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-horsie_0.2.0_linux_arm.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_linux_arm.zip",
+          "shasum": "2858247ddeb9765f9d75679be4085d3882a268d68b81954e882d3da1eed38f5e",
+          "h1": "h1:i82MeRZRFbSwzBK4slmIRJzG1Ck+WhbUiVgzifF2abk=",
+          "size": 6250080
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.2.0_linux_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_linux_arm64.zip",
+          "shasum": "b3634b842989c2d426ae982d81a86b3681adc23c2c690d1635d6969e70836afd",
+          "h1": "h1:XoZ4/7ETEOC8c9xso6JxPCo9lObhLwhzhs/01d4KYqQ=",
+          "size": 6031316
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-horsie_0.2.0_windows_386.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_windows_386.zip",
+          "shasum": "f947933cecae4cd0c49e60970b74e34fea996b388df858a699a99101fd8bebc6",
+          "h1": "h1:eKGwzP0rx6BFpC/XaXeHxwCaqpC3udFyrkXPuu40JRw=",
+          "size": 6572786
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.2.0_windows_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_windows_amd64.zip",
+          "shasum": "da0998b3c2707012eee1be14f22622bd38a220ddfc4b29cf43cefa2529463579",
+          "h1": "h1:ACPF8jOGog+TxgHH9Gwks5YRcsl3LWZY6iYRImQkAYI=",
+          "size": 6833585
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.2.0_windows_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.2.0/terraform-provider-horsie_0.2.0_windows_arm64.zip",
+          "shasum": "5f98f6b51484f30e1565fdeafe70c6f3a65ddff4afcc67724303353e3e8a0769",
+          "h1": "h1:M9jkVCCypOlxbeT8d0zM6j8xZ44IdKuFTetSnMiJvGc=",
+          "size": 6115350
+        }
+      ],
+      "discovered": "2026-08-09T16:58:52.862883Z"
+    },
+    {
+      "version": "0.1.0",
+      "protocols": [
+        "6.0"
+      ],
+      "shasums_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_SHA256SUMS",
+      "shasums_signature_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_SHA256SUMS.sig",
+      "targets": [
+        {
+          "os": "darwin",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.1.0_darwin_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_darwin_amd64.zip",
+          "shasum": "3f2f76368b1176ee8631fbdde92a3564c99dd95321630f6a5bc4f2c26205cf1f",
+          "h1": "h1:aa2mBJReEJG5206m88jP3PnQ8MAh9chAT+jtYWOHMbo=",
+          "size": 6765945
+        },
+        {
+          "os": "darwin",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.1.0_darwin_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_darwin_arm64.zip",
+          "shasum": "4d24b701efea14424eaaef34da8b22c619d17f27255446190be5b6bd8eb289a0",
+          "h1": "h1:B+a9yV6ADWaVcPVbimb7PvuC207eDbF4470/94du1h8=",
+          "size": 6302202
+        },
+        {
+          "os": "freebsd",
+          "arch": "386",
+          "filename": "terraform-provider-horsie_0.1.0_freebsd_386.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_freebsd_386.zip",
+          "shasum": "1699a4a6c185bb30a875f09092a344b138ad6ca61b6da0207655bba58eaeecf5",
+          "h1": "h1:cU6ncPgVziNGSazqxVSgvTo/jlqaiinpmkR2RFWOxWo=",
+          "size": 6225370
+        },
+        {
+          "os": "freebsd",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.1.0_freebsd_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_freebsd_amd64.zip",
+          "shasum": "8a042fb9d0a81cd901f0ff1af31a01e898183fbd8da9b6ffe202516e1f86439e",
+          "h1": "h1:2+PvEm1iYLN+lJOLaiugDmYEFzHIxnznCPdQ3jq5DTk=",
+          "size": 6573706
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm",
+          "filename": "terraform-provider-horsie_0.1.0_freebsd_arm.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_freebsd_arm.zip",
+          "shasum": "f534511cae34df436f4741bff29c3a3d8cb8a8b0f7fd2fb6758f1c16f234fcd7",
+          "h1": "h1:8IM5SorkrT190ojIdZyBAs5BUGucoAUzHJu4/Dcs9wA=",
+          "size": 6194748
+        },
+        {
+          "os": "freebsd",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.1.0_freebsd_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_freebsd_arm64.zip",
+          "shasum": "6e605f532795dc2258666e14ce32c4101dcc26b510523ec47acec93d5a08212c",
+          "h1": "h1:Vys4oRUNdAmavmX9XHFq0Em428OmknZ36SIvFydp7i0=",
+          "size": 5976922
+        },
+        {
+          "os": "linux",
+          "arch": "386",
+          "filename": "terraform-provider-horsie_0.1.0_linux_386.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_linux_386.zip",
+          "shasum": "5c69f9a42a33e0e1b3ed4ee2b4bacc53022270265b707504ada3afa683d8f0e0",
+          "h1": "h1:n60XffAay8cQmYY+pVx+7TVddGeMBywQKuppe8j/zAY=",
+          "size": 6254145
+        },
+        {
+          "os": "linux",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.1.0_linux_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_linux_amd64.zip",
+          "shasum": "85cebea482f62d1308993d6d2cb9f3d1e8b9dcae94c79e1fb675b3c0be89c32a",
+          "h1": "h1:SbK1uoUPyQ8d9MbbVWQvsAJuvN0LFS9QyNpcgkoTb0Y=",
+          "size": 6601224
+        },
+        {
+          "os": "linux",
+          "arch": "arm",
+          "filename": "terraform-provider-horsie_0.1.0_linux_arm.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_linux_arm.zip",
+          "shasum": "16edbcb83e07ed765daba0e3f87276e6015f26b505d2e0d66ef332f6441ed859",
+          "h1": "h1:pnh7hci8PFuNFnCyAihc/FcqVxslOhX2vyyJL5d1PjI=",
+          "size": 6218263
+        },
+        {
+          "os": "linux",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.1.0_linux_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_linux_arm64.zip",
+          "shasum": "6c04f3ce1a4e24f95172265ead7dafef986bc1a00cd3af0ce96ff30c58cc3718",
+          "h1": "h1:pu13D+wTzWjGvlaQWlkFdfdW1av8x5oIKM8YMGp4IeE=",
+          "size": 6003707
+        },
+        {
+          "os": "windows",
+          "arch": "386",
+          "filename": "terraform-provider-horsie_0.1.0_windows_386.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_windows_386.zip",
+          "shasum": "b3481f18b006d04306cb73e30174116d3fba34ebd1055961b1aa45fdf4f1f35c",
+          "h1": "h1:LhXASHH5iIhfyP08IFsLgCqcmLAXOTr3S1Ej5pcum30=",
+          "size": 6542233
+        },
+        {
+          "os": "windows",
+          "arch": "amd64",
+          "filename": "terraform-provider-horsie_0.1.0_windows_amd64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_windows_amd64.zip",
+          "shasum": "f47a2d7d07c681924d481d3e1642d19bf6fcfbe81192f2509f2ec24d60f25259",
+          "h1": "h1:t3PNA4izbL0bYh+FCSPngDKPqiAHy/3k1VH+2uHLfmE=",
+          "size": 6797866
+        },
+        {
+          "os": "windows",
+          "arch": "arm64",
+          "filename": "terraform-provider-horsie_0.1.0_windows_arm64.zip",
+          "download_url": "https://github.com/blossomstack/terraform-provider-horsie/releases/download/v0.1.0/terraform-provider-horsie_0.1.0_windows_arm64.zip",
+          "shasum": "305df281bb0d7cf1226448d1937b0038dab342992f0f70926bfdbebf3a03f215",
+          "h1": "h1:MhrGGhhhtRIbw0gvGbW84Fw41+OR8XR/Rgem9nHpAj0=",
+          "size": 6081928
+        }
+      ],
+      "discovered": "2026-08-09T16:58:52.862911Z"
+    }
+  ]
+}


### PR DESCRIPTION
Replaces #4898, which is stuck on the race condition the verify job describes: that PR was generated when the provider only had v0.1.0, and v0.2.0 was released four hours later, so the committed JSON no longer matches regenerated output. The branch lives in this repo and isn't pushable by me, and re-triggering the submission workflow from #4896 would fail on a non-fast-forward push to the existing branch.

This file is the unmodified output of `go run ./cmd/add-provider -repository=blossomstack/terraform-provider-horsie` run against the current releases, so it contains both v0.1.0 and v0.2.0. The v0.1.0 entry is byte-identical to the one in #4898.

The GPG key for the `blossomstack` namespace is already on main at `keys/b/blossomstack/provider-1786234494.asc`.

Please close #4898 and delete its branch when this lands.

Closes #4896.